### PR TITLE
Phase 2 source breakpoints and indexes

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,13 @@
                 "description": "Run asm80 before launch when asm is provided",
                 "default": true
               },
+              "sourceRoots": {
+                "type": "array",
+                "description": "Additional directories to resolve source file paths from LST anchors",
+                "items": {
+                  "type": "string"
+                }
+              },
               "terminal": {
                 "type": "object",
                 "description": "Optional terminal device port mapping",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -6,7 +6,8 @@ import * as path from 'path';
 import * as cp from 'child_process';
 import { Event as DapEvent } from '@vscode/debugadapter';
 import { parseIntelHex, parseListing, ListingInfo } from './z80-loaders';
-import { parseMapping, MappingParseResult, SourceMapAnchor, SourceMapSegment } from './mapping-parser';
+import { parseMapping, MappingParseResult } from './mapping-parser';
+import { buildSourceMapIndex, findAnchorLine, findSegmentForAddress, resolveLocation, SourceMapIndex } from './source-map';
 import {
   createZ80Runtime,
   Z80Runtime,
@@ -25,6 +26,7 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
   projectConfig?: string;
   target?: string;
   assemble?: boolean;
+  sourceRoots?: string[];
   terminal?: TerminalConfig;
 }
 
@@ -55,15 +57,16 @@ export class Z80DebugSession extends DebugSession {
   private listing: ListingInfo | undefined;
   private listingPath: string | undefined;
   private mapping: MappingParseResult | undefined;
-  private mappingSegmentsByAddress: SourceMapSegment[] | undefined;
-  private mappingAnchorsByFile: Map<string, SourceMapAnchor[]> | undefined;
+  private mappingIndex: SourceMapIndex | undefined;
+  private pendingBreakpointsBySource: Map<string, DebugProtocol.SourceBreakpoint[]> = new Map();
+  private sourceRoots: string[] = [];
+  private baseDir = process.cwd();
   private sourceFile = '';
   private stopOnEntry = false;
   private haltNotified = false;
   private variableHandles = new Handles<'registers'>();
   private breakpoints: Set<number> = new Set();
   private terminalState: TerminalState | undefined;
-  private pendingBreakpoints: DebugProtocol.SourceBreakpoint[] = [];
 
   public constructor() {
     super();
@@ -100,8 +103,9 @@ export class Z80DebugSession extends DebugSession {
     this.listing = undefined;
     this.listingPath = undefined;
     this.mapping = undefined;
-    this.mappingSegmentsByAddress = undefined;
-    this.mappingAnchorsByFile = undefined;
+    this.mappingIndex = undefined;
+    this.sourceRoots = [];
+    this.baseDir = process.cwd();
     this.terminalState = undefined;
 
     try {
@@ -131,6 +135,7 @@ export class Z80DebugSession extends DebugSession {
       }
 
       const baseDir = this.resolveBaseDir(merged);
+      this.baseDir = baseDir;
       const { hexPath, listingPath, asmPath } = this.resolveArtifacts(merged, baseDir);
 
       this.assembleIfRequested(merged, asmPath, hexPath, listingPath);
@@ -158,15 +163,16 @@ export class Z80DebugSession extends DebugSession {
 
       const listingContent = fs.readFileSync(listingPath, 'utf-8');
       this.listing = parseListing(listingContent);
-      this.mapping = parseMapping(listingContent);
-      this.buildMappingIndexes(this.mapping);
       this.listingPath = listingPath;
       this.sourceFile = listingPath;
+      this.sourceRoots = this.resolveSourceRoots(merged, baseDir);
+      this.mapping = parseMapping(listingContent);
+      this.mappingIndex = buildSourceMapIndex(this.mapping, (file) => this.resolveMappedPath(file));
 
       const ioHandlers = this.buildIoHandlers(merged);
       this.runtime = createZ80Runtime(program, merged.entry, ioHandlers);
       if (this.listing !== undefined) {
-        const applied = this.applyBreakpoints(this.pendingBreakpoints);
+        const applied = this.applyAllBreakpoints();
         for (const bp of applied) {
           this.sendEvent(new BreakpointEvent('changed', bp));
         }
@@ -192,10 +198,23 @@ export class Z80DebugSession extends DebugSession {
     response: DebugProtocol.SetBreakpointsResponse,
     args: DebugProtocol.SetBreakpointsArguments
   ): void {
-    this.pendingBreakpoints = args.breakpoints ?? [];
+    const sourcePath = args.source?.path;
+    const breakpoints = args.breakpoints ?? [];
+    const normalized = sourcePath ? this.normalizeSourcePath(sourcePath) : undefined;
+
+    if (normalized) {
+      this.pendingBreakpointsBySource.set(normalized, breakpoints);
+    }
 
     const verified =
-      this.listing !== undefined ? this.applyBreakpoints(this.pendingBreakpoints) : this.pendingBreakpoints.map((bp) => ({ line: bp.line, verified: false }));
+      this.listing !== undefined && normalized
+        ? this.applyBreakpointsForSource(normalized, breakpoints)
+        : breakpoints.map((bp) => ({ line: bp.line, verified: false }));
+
+    if (this.listing !== undefined) {
+      this.rebuildBreakpoints();
+    }
+
     response.body = { breakpoints: verified };
     this.sendResponse(response);
   }
@@ -287,32 +306,16 @@ export class Z80DebugSession extends DebugSession {
     this.sendResponse(response);
   }
 
-  private buildMappingIndexes(mapping: MappingParseResult): void {
-    this.mappingSegmentsByAddress = [...mapping.segments].sort(
-      (a, b) => a.start - b.start || a.lst.line - b.lst.line
-    );
-
-    const anchorsByFile = new Map<string, SourceMapAnchor[]>();
-    for (const anchor of mapping.anchors) {
-      const list = anchorsByFile.get(anchor.file);
-      if (list) {
-        list.push(anchor);
-      } else {
-        anchorsByFile.set(anchor.file, [anchor]);
-      }
-    }
-    for (const list of anchorsByFile.values()) {
-      list.sort((a, b) => a.address - b.address || a.line - b.line);
-    }
-    this.mappingAnchorsByFile = anchorsByFile;
-  }
-
   private resolveSourceForAddress(address: number): { path: string; line: number } {
     const listingPath = this.listingPath ?? this.sourceFile;
     const listingLine = this.listing?.addressToLine.get(address) ?? 1;
     const fallback = { path: listingPath, line: listingLine };
 
-    const segment = this.findSegmentForAddress(address);
+    const index = this.mappingIndex;
+    if (!index) {
+      return fallback;
+    }
+    const segment = findSegmentForAddress(index, address);
     if (!segment || segment.loc.file === null) {
       return fallback;
     }
@@ -326,7 +329,7 @@ export class Z80DebugSession extends DebugSession {
       return { path: resolvedPath, line: segment.loc.line };
     }
 
-    const anchorLine = this.findAnchorLine(segment.loc.file, address);
+    const anchorLine = findAnchorLine(index, resolvedPath, address);
     if (anchorLine !== null) {
       return { path: resolvedPath, line: anchorLine };
     }
@@ -334,48 +337,24 @@ export class Z80DebugSession extends DebugSession {
     return fallback;
   }
 
-  private findSegmentForAddress(address: number): SourceMapSegment | undefined {
-    const segments = this.mappingSegmentsByAddress;
-    if (!segments) {
-      return undefined;
-    }
-    for (const segment of segments) {
-      if (address < segment.start) {
-        break;
-      }
-      if (address >= segment.start && address < segment.end) {
-        return segment;
-      }
-    }
-    return undefined;
-  }
-
   private resolveMappedPath(file: string): string | undefined {
     if (path.isAbsolute(file)) {
       return file;
     }
+    const roots: string[] = [];
     if (this.listingPath) {
-      const candidate = path.resolve(path.dirname(this.listingPath), file);
+      roots.push(path.dirname(this.listingPath));
+    }
+    roots.push(...this.sourceRoots);
+
+    for (const root of roots) {
+      const candidate = path.resolve(root, file);
       if (fs.existsSync(candidate)) {
         return candidate;
       }
     }
-    return undefined;
-  }
 
-  private findAnchorLine(file: string, address: number): number | null {
-    const anchors = this.mappingAnchorsByFile?.get(file);
-    if (!anchors || anchors.length === 0) {
-      return null;
-    }
-    let candidate: SourceMapAnchor | undefined;
-    for (const anchor of anchors) {
-      if (anchor.address > address) {
-        break;
-      }
-      candidate = anchor;
-    }
-    return candidate?.line ?? null;
+    return undefined;
   }
 
   protected scopesRequest(
@@ -713,6 +692,11 @@ export class Z80DebugSession extends DebugSession {
         merged.assemble = assembleResolved;
       }
 
+      const sourceRootsResolved = args.sourceRoots ?? targetCfg?.sourceRoots ?? cfg.sourceRoots;
+      if (sourceRootsResolved !== undefined) {
+        merged.sourceRoots = sourceRootsResolved;
+      }
+
       const targetResolved = targetName ?? args.target;
       if (targetResolved !== undefined) {
         merged.target = targetResolved;
@@ -914,7 +898,19 @@ export class Z80DebugSession extends DebugSession {
     }
   }
 
-  private applyBreakpoints(bps: DebugProtocol.SourceBreakpoint[]): DebugProtocol.Breakpoint[] {
+  private applyAllBreakpoints(): DebugProtocol.Breakpoint[] {
+    const applied: DebugProtocol.Breakpoint[] = [];
+    for (const [source, breakpoints] of this.pendingBreakpointsBySource.entries()) {
+      applied.push(...this.applyBreakpointsForSource(source, breakpoints));
+    }
+    this.rebuildBreakpoints();
+    return applied;
+  }
+
+  private applyBreakpointsForSource(
+    sourcePath: string,
+    bps: DebugProtocol.SourceBreakpoint[]
+  ): DebugProtocol.Breakpoint[] {
     const listing = this.listing;
     const listingPath = this.listingPath;
     const verified: DebugProtocol.Breakpoint[] = [];
@@ -926,23 +922,83 @@ export class Z80DebugSession extends DebugSession {
       return verified;
     }
 
-    this.breakpoints.clear();
+    if (this.isListingSource(sourcePath)) {
+      for (const bp of bps) {
+        const line = bp.line ?? 0;
+        const address =
+          listing.lineToAddress.get(line) ??
+          listing.lineToAddress.get(line + 1); // tolerate 0-based incoming lines
+        const ok = address !== undefined;
+        verified.push({ line: bp.line, verified: ok });
+      }
+      return verified;
+    }
+
     for (const bp of bps) {
       const line = bp.line ?? 0;
-      const address =
-        listing.lineToAddress.get(line) ??
-        listing.lineToAddress.get(line + 1); // tolerate 0-based incoming lines
-      const ok = address !== undefined;
-      if (ok && address !== undefined) {
-        this.breakpoints.add(address);
-      }
-      verified.push({
-        line: bp.line,
-        verified: ok,
-      });
+      const addresses = this.resolveSourceBreakpoint(sourcePath, line);
+      const ok = addresses.length > 0;
+      verified.push({ line: bp.line, verified: ok });
     }
 
     return verified;
+  }
+
+  private rebuildBreakpoints(): void {
+    this.breakpoints.clear();
+    if (this.listing === undefined || this.listingPath === undefined) {
+      return;
+    }
+
+    for (const [source, bps] of this.pendingBreakpointsBySource.entries()) {
+      if (this.isListingSource(source)) {
+        for (const bp of bps) {
+          const line = bp.line ?? 0;
+          const address =
+            this.listing.lineToAddress.get(line) ??
+            this.listing.lineToAddress.get(line + 1);
+          if (address !== undefined) {
+            this.breakpoints.add(address);
+          }
+        }
+        continue;
+      }
+
+      for (const bp of bps) {
+        const line = bp.line ?? 0;
+        const addresses = this.resolveSourceBreakpoint(source, line);
+        if (addresses.length > 0) {
+          this.breakpoints.add(addresses[0]);
+        }
+      }
+    }
+  }
+
+  private resolveSourceBreakpoint(sourcePath: string, line: number): number[] {
+    const index = this.mappingIndex;
+    if (!index) {
+      return [];
+    }
+    return resolveLocation(index, sourcePath, line);
+  }
+
+  private isListingSource(sourcePath: string): boolean {
+    if (this.listingPath === undefined) {
+      return path.extname(sourcePath).toLowerCase() === '.lst';
+    }
+    return path.resolve(sourcePath) === path.resolve(this.listingPath);
+  }
+
+  private normalizeSourcePath(sourcePath: string): string {
+    if (path.isAbsolute(sourcePath)) {
+      return path.resolve(sourcePath);
+    }
+    return path.resolve(this.baseDir, sourcePath);
+  }
+
+  private resolveSourceRoots(args: LaunchRequestArguments, baseDir: string): string[] {
+    const roots = args.sourceRoots ?? [];
+    return roots.map((root) => this.resolveRelative(root, baseDir));
   }
 
   private resolveBundledAsm80(): string | undefined {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -967,8 +967,9 @@ export class Z80DebugSession extends DebugSession {
       for (const bp of bps) {
         const line = bp.line ?? 0;
         const addresses = this.resolveSourceBreakpoint(source, line);
-        if (addresses.length > 0) {
-          this.breakpoints.add(addresses[0]);
+        const [first] = addresses;
+        if (first !== undefined) {
+          this.breakpoints.add(first);
         }
       }
     }

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -1,0 +1,117 @@
+import { MappingParseResult, SourceMapAnchor, SourceMapSegment } from './mapping-parser';
+
+export interface SourceMapIndex {
+  segmentsByAddress: SourceMapSegment[];
+  segmentsByFileLine: Map<string, Map<number, SourceMapSegment[]>>;
+  anchorsByFile: Map<string, SourceMapAnchor[]>;
+}
+
+export type ResolvePathFn = (file: string) => string | undefined;
+
+export function buildSourceMapIndex(
+  mapping: MappingParseResult,
+  resolvePath: ResolvePathFn
+): SourceMapIndex {
+  const segmentsByAddress = [...mapping.segments].sort(
+    (a, b) => a.start - b.start || a.lst.line - b.lst.line
+  );
+
+  const segmentsByFileLine = new Map<string, Map<number, SourceMapSegment[]>>();
+  for (const segment of mapping.segments) {
+    if (segment.loc.file === null || segment.loc.line === null) {
+      continue;
+    }
+    const resolved = resolvePath(segment.loc.file);
+    if (!resolved) {
+      continue;
+    }
+    const fileMap = segmentsByFileLine.get(resolved) ?? new Map<number, SourceMapSegment[]>();
+    const list = fileMap.get(segment.loc.line) ?? [];
+    list.push(segment);
+    fileMap.set(segment.loc.line, list);
+    segmentsByFileLine.set(resolved, fileMap);
+  }
+
+  for (const fileMap of segmentsByFileLine.values()) {
+    for (const list of fileMap.values()) {
+      list.sort((a, b) => a.start - b.start || a.lst.line - b.lst.line);
+    }
+  }
+
+  const anchorsByFile = new Map<string, SourceMapAnchor[]>();
+  for (const anchor of mapping.anchors) {
+    const resolved = resolvePath(anchor.file);
+    if (!resolved) {
+      continue;
+    }
+    const list = anchorsByFile.get(resolved) ?? [];
+    list.push(anchor);
+    anchorsByFile.set(resolved, list);
+  }
+  for (const list of anchorsByFile.values()) {
+    list.sort((a, b) => a.line - b.line || a.address - b.address);
+  }
+
+  return { segmentsByAddress, segmentsByFileLine, anchorsByFile };
+}
+
+export function findSegmentForAddress(
+  index: SourceMapIndex,
+  address: number
+): SourceMapSegment | undefined {
+  for (const segment of index.segmentsByAddress) {
+    if (address < segment.start) {
+      break;
+    }
+    if (address >= segment.start && address < segment.end) {
+      return segment;
+    }
+  }
+  return undefined;
+}
+
+export function resolveLocation(
+  index: SourceMapIndex,
+  filePath: string,
+  line: number
+): number[] {
+  const fileMap = index.segmentsByFileLine.get(filePath);
+  if (fileMap) {
+    const segments = fileMap.get(line);
+    if (segments && segments.length > 0) {
+      return segments.map((seg) => seg.start);
+    }
+  }
+
+  const anchors = index.anchorsByFile.get(filePath);
+  if (!anchors || anchors.length === 0) {
+    return [];
+  }
+  let candidate: SourceMapAnchor | undefined;
+  for (const anchor of anchors) {
+    if (anchor.line > line) {
+      break;
+    }
+    candidate = anchor;
+  }
+  return candidate ? [candidate.address] : [];
+}
+
+export function findAnchorLine(
+  index: SourceMapIndex,
+  filePath: string,
+  address: number
+): number | null {
+  const anchors = index.anchorsByFile.get(filePath);
+  if (!anchors || anchors.length === 0) {
+    return null;
+  }
+  let candidate: SourceMapAnchor | undefined;
+  for (const anchor of anchors) {
+    if (anchor.address > address) {
+      break;
+    }
+    candidate = anchor;
+  }
+  return candidate?.line ?? null;
+}

--- a/src/test/source-map.test.ts
+++ b/src/test/source-map.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseMapping } from '../mapping-parser';
+import { buildSourceMapIndex, findSegmentForAddress, resolveLocation } from '../source-map';
+
+const fixtureDir = path.join(process.cwd(), 'src', 'test', 'fixtures');
+const lstPath = path.join(fixtureDir, 'simple.lst');
+const asmPath = path.join(fixtureDir, 'simple.asm');
+
+const listingContent = fs.readFileSync(lstPath, 'utf-8');
+const mapping = parseMapping(listingContent);
+const resolvePath = (file: string): string | undefined =>
+  file === 'simple.asm' ? asmPath : undefined;
+const index = buildSourceMapIndex(mapping, resolvePath);
+
+describe('source-map', () => {
+  it('resolves locations to addresses', () => {
+    assert.deepEqual(resolveLocation(index, asmPath, 1), [0x0000]);
+    assert.deepEqual(resolveLocation(index, asmPath, 4), [0x0003]);
+    assert.deepEqual(resolveLocation(index, asmPath, 5), [0x0003]);
+  });
+
+  it('returns empty for unknown files', () => {
+    assert.deepEqual(resolveLocation(index, path.join(fixtureDir, 'missing.asm'), 1), []);
+  });
+
+  it('finds a segment by address', () => {
+    const segment = findSegmentForAddress(index, 0x0001);
+    assert.ok(segment);
+    assert.equal(segment?.lst.line, 3);
+  });
+});


### PR DESCRIPTION
## Overview
Implements Phase 2 of the mapping plan: source breakpoint resolution using indexes, plus optional `sourceRoots` support for resolving `.asm` paths. Listing fallback remains intact.

## Key Changes
- new `src/source-map.ts` with index builders and resolve helpers
- adapter now stores breakpoints per source and resolves `.asm` breakpoints via mapping
- adds `sourceRoots` debug config property
- new unit tests for source map resolution

## Behavior Notes
- `.asm` breakpoints resolve to the lowest address for the line; if none, fall back to nearest anchor
- if a source file cannot be resolved, the breakpoint stays unverified

## Testing
- not run (suggest: `yarn build`, `yarn test`)
