### PR TITLE
Fix D8 map options and HelloWorld echo

### DIFF
--- a/examples/HelloWorld/README.md
+++ b/examples/HelloWorld/README.md
@@ -6,7 +6,7 @@ Z80 sample wired for the debug80 extension. The adapter runs asm80 for you and d
 - `src/constants.asm`, `macros.asm`, `system.asm` — tiny ROM layer and RST 10H service macros.
 - `src/lib/readline.asm`, `src/lib/ui.asm` — reusable routines pulled in via `.include`.
 - `src/data/messages.asm` — shared strings/constants referenced by multiple files.
-- `src/main.asm` — prints a greeting, then echoes input lines until you press Enter on an empty line.
+- `src/main.asm` — prints a greeting, then reads input lines until you press Enter on an empty line.
 - `.vscode/debug80.json` — target config (`src/main.asm` → `build/main`).
 - `.vscode/launch.json` — “Debug (debug80)” launch config.
 

--- a/examples/HelloWorld/src/lib/readline.asm
+++ b/examples/HelloWorld/src/lib/readline.asm
@@ -1,5 +1,6 @@
 ; readLn: HL buffer, B = buffer length (including terminator)
-; Reads until newline (0x0A) or buffer full-1, echoes as it reads,
+; Reads until newline (0x0A) or buffer full-1. Input echo is handled by
+; the host terminal.
 ; zero-terminates. Returns with A holding last read (newline).
 readLn:
         DEC     B               ; reserve space for terminator

--- a/examples/HelloWorld/src/main.asm
+++ b/examples/HelloWorld/src/main.asm
@@ -19,8 +19,6 @@ READLOOP:
         CP      0x20
         JR      C,DONE         ; empty or control -> exit
 
-        LD      HL,BUF
-        CALL    printLine
         JR      READLOOP
 
 DONE:   LD      HL,DONE_MSG

--- a/src/mapping/d8-map.ts
+++ b/src/mapping/d8-map.ts
@@ -76,18 +76,19 @@ export interface BuildD8MapOptions {
   diagnostics?: D8Diagnostics;
 }
 
-const CONFIDENCE_MAP: Record<SourceMapSegment['confidence'], D8Segment['confidence']> = {
+const CONFIDENCE_MAP: Record<SourceMapSegment['confidence'], NonNullable<D8Segment['confidence']>> =
+  {
   HIGH: 'high',
   MEDIUM: 'medium',
   LOW: 'low',
-};
+  };
 
 export function buildD8DebugMap(
   mapping: MappingParseResult,
   options: BuildD8MapOptions
 ): D8DebugMap {
   const files = collectFiles(mapping);
-  const segments = mapping.segments.map((segment) => ({
+  const segments: D8Segment[] = mapping.segments.map((segment): D8Segment => ({
     start: segment.start,
     end: segment.end,
     file: segment.loc.file,
@@ -107,8 +108,8 @@ export function buildD8DebugMap(
     files,
     segments,
     symbols,
-    generator: options.generator,
-    diagnostics: options.diagnostics,
+    ...(options.generator ? { generator: options.generator } : {}),
+    ...(options.diagnostics ? { diagnostics: options.diagnostics } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- Only include optional D8 map fields when defined to satisfy exactOptionalPropertyTypes.
- Stop HelloWorld from re-printing input (terminal echo handles it).
- Update HelloWorld docs and readLn comment to match behavior.

## Testing
- yarn build