### PR TITLE
Make D8 map the default mapping artifact

### DIFF
--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -106,9 +106,9 @@ Common fields:
 - hex / listing (override)
 - sourceRoots (list of extra source folders)
 - stepOverMaxInstructions / stepOutMaxInstructions
-- emitDebugMap (writes a .d8dbg.json mapping artifact)
-- debugMapPath (explicit output path for the D8 map)
 - terminal (I/O bridge config)
+
+Debug80 always writes a D8 debug map to `<artifactBase>.d8dbg.json` in outputDir.
 
 ### 6.3 Scaffold command
 
@@ -185,12 +185,12 @@ Indexes built at launch:
 
 ### 9.4 D8 Debug Map (D8M) format
 
-Debug80 currently builds the mapping in memory from the .lst. The proposed
-on-disk standard is documented in `docs/D8_DEBUG_MAP.md` and is designed to be
+Debug80 builds the mapping from the .lst, serializes it as a D8 debug map, then
+uses the D8 map as the canonical representation for debugging. The on-disk
+standard is documented in `docs/D8_DEBUG_MAP.md` and is designed to be
 assembler-agnostic while preserving the existing LST-derived confidence data.
 
-When `emitDebugMap` is true (or `debugMapPath` is set), Debug80 writes a
-`*.d8dbg.json` file alongside the build artifacts.
+Debug80 always writes a `*.d8dbg.json` file alongside the build artifacts.
 
 ## 10. Breakpoints and stack frames
 

--- a/examples/HelloWorld/.vscode/debug80.json
+++ b/examples/HelloWorld/.vscode/debug80.json
@@ -7,7 +7,6 @@
       "outputDir": "build",
       "artifactBase": "main",
       "entry": 0,
-      "emitDebugMap": true,
       "terminal": {
         "txPort": 0,
         "rxPort": 1,

--- a/examples/HelloWorld/README.md
+++ b/examples/HelloWorld/README.md
@@ -13,5 +13,5 @@ Z80 sample wired for the debug80 extension. The adapter runs asm80 for you and d
 ## Usage
 1) Open `examples/HelloWorld` in VS Code with debug80 installed.
 2) Press F5 and pick “Debug (debug80)”. The adapter assembles to `build/main.hex` + `build/main.lst`.
-3) The example enables D8 map output, so `build/main.d8dbg.json` is also written.
+3) Debug80 writes `build/main.d8dbg.json` alongside the build artifacts.
 4) Set breakpoints in the `.asm` files and run. Use the Debug80 Terminal panel for input/output.

--- a/package.json
+++ b/package.json
@@ -125,15 +125,6 @@
                 "type": "number",
                 "description": "Maximum instructions to execute during Step Out before stopping (0 disables the cap)."
               },
-              "emitDebugMap": {
-                "type": "boolean",
-                "description": "Write a D8 debug map (.d8dbg.json) alongside the build artifacts.",
-                "default": false
-              },
-              "debugMapPath": {
-                "type": "string",
-                "description": "Explicit path for the D8 debug map output (overrides emitDebugMap path)."
-              },
               "terminal": {
                 "type": "object",
                 "description": "Optional terminal device port mapping",


### PR DESCRIPTION
## Summary\n- Remove emitDebugMap/debugMapPath flags and always write a .d8dbg.json artifact.\n- Treat the D8 map as the canonical mapping source for debugging.\n- Update docs and HelloWorld config to match the new default behavior.\n\n## Testing\n- yarn build