### PR TITLE
Introduce D8 map v2 columnar format

### DIFF
--- a/docs/D8_DEBUG_MAP.md
+++ b/docs/D8_DEBUG_MAP.md
@@ -1,8 +1,12 @@
-# D8 Debug Map (D8M) v1
+# D8 Debug Map (D8M) v2
 
 This document defines a JSON mapping format for Z80 debugging. The intent is to
 support deterministic address-to-source mapping across assemblers, while still
 allowing best-effort maps derived from listings.
+
+Version 2 stores segment data in columnar arrays to reduce file size. Version 1
+(row-wise segments) is considered legacy but is still accepted for backwards
+compatibility.
 
 ## Naming
 
@@ -11,15 +15,11 @@ Format name: D8 Debug Map (D8M)
 Canonical file name:
 `<artifactBase>.d8dbg.json`
 
-Rationale: the name is explicit and namespaced to avoid collisions with other
-formats.
-
 ## Goals
 
 - Map instruction address ranges to source locations.
 - Capture symbol definitions for labels, constants, and data.
 - Represent data regions distinctly from executable code.
-- Support macro expansions and include chains where available.
 - Allow confidence flags when mappings are inferred.
 - Remain assembler-agnostic and stable across projects.
 
@@ -29,14 +29,15 @@ Top-level JSON object:
 
 Required:
 - `format`: string, must be `d8-debug-map`
-- `version`: number, must be `1`
+- `version`: number, must be `2`
 - `arch`: string (e.g. `z80`, `6502`, `6809`)
 - `addressWidth`: number of address bits (e.g. `16`, `24`)
 - `endianness`: `little` or `big`
 - `files`: array of source file entries
-- `segments`: array of mapping segments
+- `segments`: columnar segment data
 
 Optional:
+- `lstText`: array of listing text strings (string table)
 - `symbols`: array of symbol entries
 - `memory`: memory layout information
 - `generator`: toolchain metadata
@@ -53,37 +54,23 @@ Optional fields:
 - `sha256`: string (hex), hash of file contents
 - `lineCount`: number, total lines in the file
 
-Example:
-```json
-{
-  "path": "src/main.asm",
-  "sha256": "b6d81b360a5672d80c27430f39153e2c",
-  "lineCount": 120
-}
-```
+### 2) `segments` (columnar)
 
-### 2) `segments`
+`segments` is an object of parallel arrays. All arrays must be the same length.
+Each index maps one segment across all arrays.
 
-Each segment maps a byte range to a source location.
+Required arrays:
+- `start`: number[] start address (0..65535)
+- `end`: number[] end address (exclusive)
+- `file`: (number|null)[] index into `files[]` or null
+- `line`: (number|null)[] 1-based line number or null
 
-Required fields:
-- `start`: number, start address (0..65535)
-- `end`: number, end address (exclusive)
-
-Optional fields:
-- `file`: string (or null when unknown), should match a `files[].path` when present
-- `line`: number (or null when unknown), 1-based line number
-
-- `column`: number, 1-based column number
-- `kind`: string enum: `code`, `data`, `directive`, `label`, `macro`, `unknown`
-- `confidence`: string enum: `high`, `medium`, `low`
-- `lst`: object with listing provenance:
-  - `line`: number, listing line number
-  - `text`: string, listing asm text
-- `includeChain`: array of strings, include path stack
-- `macro`: object with expansion details:
-  - `name`: string
-  - `callsite`: `{ file, line, column }`
+Optional arrays:
+- `column`: (number|null)[] 1-based column number
+- `kind`: (string|null)[] enum: `code`, `data`, `directive`, `label`, `macro`, `unknown`
+- `confidence`: (string|null)[] enum: `high`, `medium`, `low`
+- `lstLine`: (number|null)[] listing line number
+- `lstText`: (number|null)[] index into `lstText[]`
 
 Notes:
 - `end` is exclusive. Length is `end - start`.
@@ -92,13 +79,20 @@ Notes:
 Example:
 ```json
 {
-  "start": 2304,
-  "end": 2307,
-  "file": "src/main.asm",
-  "line": 12,
-  "kind": "code",
-  "confidence": "high",
-  "lst": { "line": 87, "text": "JP      APPSTART" }
+  "segments": {
+    "start": [2304, 2307],
+    "end": [2307, 2310],
+    "file": [0, 0],
+    "line": [12, 13],
+    "kind": ["code", "code"],
+    "confidence": ["high", "high"],
+    "lstLine": [87, 88],
+    "lstText": [0, 1]
+  },
+  "lstText": [
+    "JP      APPSTART",
+    "LD      A,0"
+  ]
 }
 ```
 
@@ -146,18 +140,7 @@ Fields:
 - `warnings`: array of strings
 - `errors`: array of strings
 
-## Integration with Debug80 (current)
+## Legacy v1 (row-wise)
 
-- Debug80 currently parses `.lst` directly into in-memory segments and anchors.
-- No map file is emitted yet.
-- The in-memory structures correspond to this format and can be serialized.
-
-## Proposed workflow
-
-1) Assemble with asm80 to produce `build/main.hex` and `build/main.lst`.
-2) Generate a map file (future):
-   - `build/main.d8dbg.json`
-3) Debug80 loads the map file if provided; otherwise it parses `.lst`.
-
-The map file can be treated as a build artifact in `build/` and is not
-expected to be committed by default.
+Version 1 stores `segments` as an array of objects with repeated fields. Debug80
+accepts v1 maps for compatibility, but writes v2 by default.

--- a/src/debug/adapter.ts
+++ b/src/debug/adapter.ts
@@ -9,7 +9,12 @@ import { parseIntelHex, parseListing, ListingInfo } from '../z80/loaders';
 import { parseMapping, MappingParseResult } from '../mapping/parser';
 import { applyLayer2 } from '../mapping/layer2';
 import { buildSourceMapIndex, findAnchorLine, findSegmentForAddress, resolveLocation, SourceMapIndex } from '../mapping/source-map';
-import { buildD8DebugMap, buildMappingFromD8DebugMap, parseD8DebugMap } from '../mapping/d8-map';
+import {
+  buildD8DebugMap,
+  buildMappingFromD8DebugMap,
+  parseD8DebugMap,
+  D8DebugMap,
+} from '../mapping/d8-map';
 import {
   createZ80Runtime,
   Z80Runtime,
@@ -1301,7 +1306,7 @@ export class Z80DebugSession extends DebugSession {
     return roots.map((root) => this.resolveRelative(root, baseDir));
   }
 
-  private loadDebugMap(mapPath: string): ReturnType<typeof buildD8DebugMap> | undefined {
+  private loadDebugMap(mapPath: string): D8DebugMap | undefined {
     if (!fs.existsSync(mapPath)) {
       return undefined;
     }

--- a/src/mapping/d8-map.ts
+++ b/src/mapping/d8-map.ts
@@ -1,20 +1,39 @@
 import { MappingParseResult, SourceMapAnchor, SourceMapSegment } from './parser';
 
 export type D8Endianness = 'little' | 'big';
+export type D8SegmentKind = 'code' | 'data' | 'directive' | 'label' | 'macro' | 'unknown';
+export type D8Confidence = 'high' | 'medium' | 'low';
 
-export interface D8DebugMap {
+export interface D8DebugMapV1 {
   format: 'd8-debug-map';
   version: 1;
   arch: string;
   addressWidth: number;
   endianness: D8Endianness;
   files: D8SourceFile[];
-  segments: D8Segment[];
+  segments: D8SegmentRow[];
   symbols?: D8Symbol[];
   memory?: D8MemoryLayout;
   generator?: D8Generator;
   diagnostics?: D8Diagnostics;
 }
+
+export interface D8DebugMapV2 {
+  format: 'd8-debug-map';
+  version: 2;
+  arch: string;
+  addressWidth: number;
+  endianness: D8Endianness;
+  files: D8SourceFile[];
+  lstText?: string[];
+  segments: D8SegmentColumns;
+  symbols?: D8Symbol[];
+  memory?: D8MemoryLayout;
+  generator?: D8Generator;
+  diagnostics?: D8Diagnostics;
+}
+
+export type D8DebugMap = D8DebugMapV1 | D8DebugMapV2;
 
 export interface D8SourceFile {
   path: string;
@@ -22,17 +41,29 @@ export interface D8SourceFile {
   lineCount?: number;
 }
 
-export interface D8Segment {
+export interface D8SegmentRow {
   start: number;
   end: number;
   file: string | null;
   line: number | null;
   column?: number;
-  kind?: 'code' | 'data' | 'directive' | 'label' | 'macro' | 'unknown';
-  confidence?: 'high' | 'medium' | 'low';
+  kind?: D8SegmentKind;
+  confidence?: D8Confidence;
   lst?: { line: number; text: string };
   includeChain?: string[];
   macro?: { name: string; callsite: { file: string; line: number; column?: number } };
+}
+
+export interface D8SegmentColumns {
+  start: number[];
+  end: number[];
+  file: Array<number | null>;
+  line: Array<number | null>;
+  column?: Array<number | null>;
+  kind?: Array<D8SegmentKind | null>;
+  confidence?: Array<D8Confidence | null>;
+  lstLine?: Array<number | null>;
+  lstText?: Array<number | null>;
 }
 
 export interface D8Symbol {
@@ -76,44 +107,77 @@ export interface BuildD8MapOptions {
   diagnostics?: D8Diagnostics;
 }
 
-const CONFIDENCE_MAP: Record<SourceMapSegment['confidence'], NonNullable<D8Segment['confidence']>> =
-  {
-    HIGH: 'high',
-    MEDIUM: 'medium',
-    LOW: 'low',
-  };
-const CONFIDENCE_FROM_D8: Record<NonNullable<D8Segment['confidence']>, SourceMapSegment['confidence']> =
-  {
-    high: 'HIGH',
-    medium: 'MEDIUM',
-    low: 'LOW',
-  };
-const KIND_SET = new Set<D8Segment['kind']>(['code', 'data', 'directive', 'label', 'macro', 'unknown']);
-const CONFIDENCE_SET = new Set<D8Segment['confidence']>(['high', 'medium', 'low']);
+const CONFIDENCE_MAP: Record<SourceMapSegment['confidence'], NonNullable<D8Confidence>> = {
+  HIGH: 'high',
+  MEDIUM: 'medium',
+  LOW: 'low',
+};
+const CONFIDENCE_FROM_D8: Record<NonNullable<D8Confidence>, SourceMapSegment['confidence']> = {
+  high: 'HIGH',
+  medium: 'MEDIUM',
+  low: 'LOW',
+};
+const KIND_SET = new Set<D8SegmentKind>(['code', 'data', 'directive', 'label', 'macro', 'unknown']);
+const CONFIDENCE_SET = new Set<D8Confidence>(['high', 'medium', 'low']);
 
 export function buildD8DebugMap(
   mapping: MappingParseResult,
   options: BuildD8MapOptions
-): D8DebugMap {
+): D8DebugMapV2 {
   const files = collectFiles(mapping);
-  const segments: D8Segment[] = mapping.segments.map((segment): D8Segment => ({
-    start: segment.start,
-    end: segment.end,
-    file: segment.loc.file,
-    line: segment.loc.line,
-    kind: 'unknown',
-    confidence: CONFIDENCE_MAP[segment.confidence],
-    lst: { line: segment.lst.line, text: segment.lst.text },
-  }));
+  const fileIndex = new Map<string, number>();
+  files.forEach((file, index) => {
+    fileIndex.set(file.path, index);
+  });
+
+  const lstText: string[] = [];
+  const lstIndex = new Map<string, number>();
+
+  const segments: D8SegmentColumns = {
+    start: [],
+    end: [],
+    file: [],
+    line: [],
+    kind: [],
+    confidence: [],
+    lstLine: [],
+    lstText: [],
+  };
+
+  for (const segment of mapping.segments) {
+    segments.start.push(segment.start);
+    segments.end.push(segment.end);
+
+    if (segment.loc.file) {
+      const idx = fileIndex.get(segment.loc.file);
+      segments.file.push(idx ?? null);
+    } else {
+      segments.file.push(null);
+    }
+    segments.line.push(segment.loc.line ?? null);
+    segments.kind?.push('unknown');
+    segments.confidence?.push(CONFIDENCE_MAP[segment.confidence]);
+    segments.lstLine?.push(segment.lst.line);
+
+    const text = segment.lst.text;
+    let textIndex = lstIndex.get(text);
+    if (textIndex === undefined) {
+      textIndex = lstText.length;
+      lstText.push(text);
+      lstIndex.set(text, textIndex);
+    }
+    segments.lstText?.push(textIndex);
+  }
   const symbols = mapping.anchors.map(toSymbol);
 
   return {
     format: 'd8-debug-map',
-    version: 1,
+    version: 2,
     arch: options.arch,
     addressWidth: options.addressWidth,
     endianness: options.endianness,
     files,
+    lstText,
     segments,
     symbols,
     ...(options.generator ? { generator: options.generator } : {}),
@@ -122,30 +186,10 @@ export function buildD8DebugMap(
 }
 
 export function buildMappingFromD8DebugMap(map: D8DebugMap): MappingParseResult {
-  const segments: SourceMapSegment[] = map.segments.map((segment) => ({
-    start: segment.start,
-    end: segment.end,
-    loc: {
-      file: segment.file ?? null,
-      line: segment.line ?? null,
-    },
-    lst: {
-      line: segment.lst?.line ?? 0,
-      text: segment.lst?.text ?? '',
-    },
-    confidence: CONFIDENCE_FROM_D8[segment.confidence ?? 'low'],
-  }));
-
-  const anchors: SourceMapAnchor[] = (map.symbols ?? [])
-    .filter((symbol) => symbol.file !== undefined && symbol.line !== undefined)
-    .map((symbol) => ({
-      address: symbol.address,
-      symbol: symbol.name,
-      file: symbol.file as string,
-      line: symbol.line as number,
-    }));
-
-  return { segments, anchors };
+  if (map.version === 2) {
+    return buildMappingFromV2(map);
+  }
+  return buildMappingFromV1(map);
 }
 
 export function parseD8DebugMap(content: string): { map?: D8DebugMap; error?: string } {
@@ -171,9 +215,16 @@ function validateD8DebugMap(value: unknown): string | undefined {
   if (value.format !== 'd8-debug-map') {
     return 'Missing or invalid format field.';
   }
-  if (value.version !== 1) {
+  if (value.version !== 1 && value.version !== 2) {
     return 'Unsupported D8 map version.';
   }
+  if (value.version === 1) {
+    return validateD8DebugMapV1(value);
+  }
+  return validateD8DebugMapV2(value);
+}
+
+function validateD8DebugMapV1(value: Record<string, unknown>): string | undefined {
   if (typeof value.arch !== 'string' || value.arch.length === 0) {
     return 'Missing arch.';
   }
@@ -202,12 +253,12 @@ function validateD8DebugMap(value: unknown): string | undefined {
     if (segment.line !== null && segment.line !== undefined && !Number.isFinite(segment.line)) {
       return 'Segment line must be a number or null.';
     }
-    if (segment.kind !== undefined && !KIND_SET.has(segment.kind as D8Segment['kind'])) {
+    if (segment.kind !== undefined && !KIND_SET.has(segment.kind as D8SegmentKind)) {
       return 'Segment kind is invalid.';
     }
     if (
       segment.confidence !== undefined &&
-      !CONFIDENCE_SET.has(segment.confidence as D8Segment['confidence'])
+      !CONFIDENCE_SET.has(segment.confidence as D8Confidence)
     ) {
       return 'Segment confidence is invalid.';
     }
@@ -215,8 +266,172 @@ function validateD8DebugMap(value: unknown): string | undefined {
   return undefined;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+function validateD8DebugMapV2(value: Record<string, unknown>): string | undefined {
+  if (typeof value.arch !== 'string' || value.arch.length === 0) {
+    return 'Missing arch.';
+  }
+  if (!Number.isFinite(value.addressWidth)) {
+    return 'Missing addressWidth.';
+  }
+  if (value.endianness !== 'little' && value.endianness !== 'big') {
+    return 'Missing endianness.';
+  }
+  if (!Array.isArray(value.files)) {
+    return 'Missing files array.';
+  }
+  if (value.lstText !== undefined && !Array.isArray(value.lstText)) {
+    return 'lstText must be an array when present.';
+  }
+  if (!isRecord(value.segments)) {
+    return 'Missing segments object.';
+  }
+
+  const segments = value.segments as unknown as D8SegmentColumns;
+  if (!Array.isArray(segments.start) || !Array.isArray(segments.end)) {
+    return 'segments.start/end must be arrays.';
+  }
+  if (!Array.isArray(segments.file) || !Array.isArray(segments.line)) {
+    return 'segments.file/line must be arrays.';
+  }
+
+  const count = segments.start.length;
+  if (segments.end.length !== count || segments.file.length !== count || segments.line.length !== count) {
+    return 'segments arrays must be the same length.';
+  }
+
+  const optionalArrays: Array<[string, unknown]> = [
+    ['column', segments.column],
+    ['kind', segments.kind],
+    ['confidence', segments.confidence],
+    ['lstLine', segments.lstLine],
+    ['lstText', segments.lstText],
+  ];
+
+  for (const [name, valueArr] of optionalArrays) {
+    if (valueArr === undefined) {
+      continue;
+    }
+    if (!Array.isArray(valueArr)) {
+      return `segments.${name} must be an array.`;
+    }
+    if (valueArr.length !== count) {
+      return `segments.${name} length must match segments.start.`;
+    }
+  }
+
+  const filesCount = value.files.length;
+  for (let i = 0; i < count; i += 1) {
+    const start = segments.start[i];
+    const end = segments.end[i];
+    if (!Number.isFinite(start) || !Number.isFinite(end)) {
+      return 'segments.start/end entries must be numbers.';
+    }
+    const fileIdx = segments.file[i];
+    if (fileIdx !== null && fileIdx !== undefined) {
+      if (!Number.isFinite(fileIdx) || fileIdx < 0 || fileIdx >= filesCount) {
+        return 'segments.file contains invalid file index.';
+      }
+    }
+    const line = segments.line[i];
+    if (line !== null && line !== undefined && !Number.isFinite(line)) {
+      return 'segments.line entries must be numbers or null.';
+    }
+    if (segments.kind) {
+      const kind = segments.kind[i];
+      if (kind !== null && kind !== undefined && !KIND_SET.has(kind as D8SegmentKind)) {
+        return 'segments.kind contains invalid entry.';
+      }
+    }
+    if (segments.confidence) {
+      const conf = segments.confidence[i];
+      if (conf !== null && conf !== undefined && !CONFIDENCE_SET.has(conf as D8Confidence)) {
+        return 'segments.confidence contains invalid entry.';
+      }
+    }
+  }
+
+  if (segments.lstText && value.lstText) {
+    const textCount = value.lstText.length;
+    for (const entry of segments.lstText as Array<number | null>) {
+      if (entry === null || entry === undefined) {
+        continue;
+      }
+      if (!Number.isFinite(entry) || entry < 0 || entry >= textCount) {
+        return 'segments.lstText contains invalid index.';
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function buildMappingFromV1(map: D8DebugMapV1): MappingParseResult {
+  const segments: SourceMapSegment[] = map.segments.map((segment) => ({
+    start: segment.start,
+    end: segment.end,
+    loc: {
+      file: segment.file ?? null,
+      line: segment.line ?? null,
+    },
+    lst: {
+      line: segment.lst?.line ?? 0,
+      text: segment.lst?.text ?? '',
+    },
+    confidence: CONFIDENCE_FROM_D8[segment.confidence ?? 'low'],
+  }));
+
+  const anchors: SourceMapAnchor[] = (map.symbols ?? [])
+    .filter((symbol) => symbol.file !== undefined && symbol.line !== undefined)
+    .map((symbol) => ({
+      address: symbol.address,
+      symbol: symbol.name,
+      file: symbol.file as string,
+      line: symbol.line as number,
+    }));
+
+  return { segments, anchors };
+}
+
+function buildMappingFromV2(map: D8DebugMapV2): MappingParseResult {
+  const filePaths = map.files.map((file) => file.path);
+  const segments: SourceMapSegment[] = [];
+  const count = map.segments.start.length;
+  for (let i = 0; i < count; i += 1) {
+    const start = map.segments.start[i];
+    const end = map.segments.end[i];
+    if (start === undefined || end === undefined) {
+      continue;
+    }
+    const fileIdx = map.segments.file[i];
+    const file = fileIdx !== null && fileIdx !== undefined ? filePaths[fileIdx] ?? null : null;
+    const line = map.segments.line[i] ?? null;
+    const lstLine = map.segments.lstLine?.[i] ?? 0;
+    const textIdx = map.segments.lstText?.[i];
+    const lstText =
+      textIdx !== null && textIdx !== undefined
+        ? map.lstText?.[textIdx] ?? ''
+        : '';
+    const confidence = map.segments.confidence?.[i] ?? 'low';
+
+    segments.push({
+      start,
+      end,
+      loc: { file, line },
+      lst: { line: lstLine, text: lstText },
+      confidence: CONFIDENCE_FROM_D8[confidence ?? 'low'],
+    });
+  }
+
+  const anchors: SourceMapAnchor[] = (map.symbols ?? [])
+    .filter((symbol) => symbol.file !== undefined && symbol.line !== undefined)
+    .map((symbol) => ({
+      address: symbol.address,
+      symbol: symbol.name,
+      file: symbol.file as string,
+      line: symbol.line as number,
+    }));
+
+  return { segments, anchors };
 }
 
 function collectFiles(mapping: MappingParseResult): D8SourceFile[] {
@@ -250,4 +465,8 @@ function toSymbol(anchor: SourceMapAnchor): D8Symbol {
     kind: 'label',
     scope: 'global',
   };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }


### PR DESCRIPTION
## Summary\n- Emit D8 debug maps in v2 columnar format with string tables to reduce size.\n- Keep v1 reader compatibility while validating v2 column arrays.\n- Update D8 spec to describe v2 and note v1 legacy support.\n\n## Testing\n- yarn build