### PR TITLE
Regenerate v1 maps and add D8 v2 test

### DIFF
--- a/docs/D8_DEBUG_MAP.md
+++ b/docs/D8_DEBUG_MAP.md
@@ -143,4 +143,5 @@ Fields:
 ## Legacy v1 (row-wise)
 
 Version 1 stores `segments` as an array of objects with repeated fields. Debug80
-accepts v1 maps for compatibility, but writes v2 by default.
+accepts v1 maps for compatibility, but writes v2 by default. When Debug80 finds
+a v1 map on disk, it regenerates a v2 map from the listing on the next launch.

--- a/src/debug/adapter.ts
+++ b/src/debug/adapter.ts
@@ -1322,6 +1322,15 @@ export class Z80DebugSession extends DebugSession {
         );
         return undefined;
       }
+      if (map.version === 1) {
+        this.sendEvent(
+          new OutputEvent(
+            `Debug80: D8 map v1 detected at "${mapPath}". Regenerating v2 map from LST.\n`,
+            'console'
+          )
+        );
+        return undefined;
+      }
       return map;
     } catch (err) {
       this.sendEvent(

--- a/src/mapping/d8-map.test.ts
+++ b/src/mapping/d8-map.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildD8DebugMap, buildMappingFromD8DebugMap, parseD8DebugMap } from './d8-map';
+import { MappingParseResult } from './parser';
+
+test('D8 map v2 round-trip preserves mapping', () => {
+  const mapping: MappingParseResult = {
+    segments: [
+      {
+        start: 0x1000,
+        end: 0x1003,
+        loc: { file: 'src/main.asm', line: 12 },
+        lst: { line: 200, text: 'JP START' },
+        confidence: 'HIGH',
+      },
+      {
+        start: 0x1003,
+        end: 0x1004,
+        loc: { file: 'src/main.asm', line: 13 },
+        lst: { line: 201, text: 'NOP' },
+        confidence: 'MEDIUM',
+      },
+    ],
+    anchors: [
+      {
+        address: 0x1000,
+        symbol: 'START',
+        file: 'src/main.asm',
+        line: 12,
+      },
+    ],
+  };
+
+  const map = buildD8DebugMap(mapping, {
+    arch: 'z80',
+    addressWidth: 16,
+    endianness: 'little',
+  });
+
+  assert.equal(map.version, 2);
+  assert.equal(map.format, 'd8-debug-map');
+  assert.equal(map.segments.start.length, mapping.segments.length);
+
+  const { map: parsed, error } = parseD8DebugMap(JSON.stringify(map));
+  assert.equal(error, undefined);
+  assert.ok(parsed);
+
+  const roundTrip = buildMappingFromD8DebugMap(parsed!);
+  assert.deepEqual(roundTrip, mapping);
+});


### PR DESCRIPTION
## Summary
- Treat v1 D8 maps as legacy and regenerate v2 from the LST.
- Add a D8 v2 round-trip test to lock down columnar behavior.
- Document v1 regeneration in the spec.

## Testing
- yarn test