### PR TITLE
Add TEC-1 RAM init hex support

### DIFF
--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -287,6 +287,11 @@ and extract the embedded HEX string.
 Optional tuning fields:
 - `updateMs` (default 16): min milliseconds between TEC-1 panel updates.
 - `yieldMs` (default 0): extra yield delay when the emulator is ahead of real time.
+- `ramInitHex`: optional Intel HEX file to preload RAM (e.g. a starter program).
+
+ROM-specific RAM usage:
+- MON-1 user programs start at 0x0800.
+- MON-2 user programs start at 0x0900 (0x0800–0x08ff reserved for variables).
 
 I/O map:
 - IN 0x00: keycode (0x00–0x0f hex digits, 0x13 ADDRESS, 0x10 UP (+), 0x12 GO, 0x11 DOWN (-))
@@ -328,6 +333,23 @@ loop:   LD  A, 0x01       ; select rightmost digit (bit 0)
 Build it with asm80 (or let Debug80 assemble it), then run the ROM monitor and
 press ADDRESS to 0800 followed by GO. The ROM keeps scanning once your program
 takes over, so your code should refresh the display as needed.
+
+Mon-2 example (RAM reserved 0x0800–0x08ff, user programs at 0x0900):
+
+```json
+{
+  "platform": "tec1",
+  "tec1": {
+    "romHex": "roms/tec1/mon-2.hex",
+    "regions": [
+      { "start": 0, "end": 2047, "kind": "rom" },
+      { "start": 2048, "end": 4095, "kind": "ram" }
+    ],
+    "appStart": 2304,
+    "entry": 0
+  }
+}
+```
 
 ## Build and launch flow
 

--- a/src/debug/adapter.ts
+++ b/src/debug/adapter.ts
@@ -220,6 +220,23 @@ export class Z80DebugSession extends DebugSession {
           const romHex = this.extractRomHex(romContent, romPath);
           this.applyIntelHexToMemory(romHex, program.memory);
         }
+        const ramInitPath = tec1Config?.ramInitHex
+          ? this.resolveRelative(tec1Config.ramInitHex, baseDir)
+          : undefined;
+        if (ramInitPath) {
+          if (!fs.existsSync(ramInitPath)) {
+            this.sendEvent(
+              new OutputEvent(
+                `Debug80: TEC-1 RAM init not found at "${ramInitPath}".\n`,
+                'console'
+              )
+            );
+          } else {
+            const ramInitContent = fs.readFileSync(ramInitPath, 'utf-8');
+            const ramInitHex = this.extractRomHex(ramInitContent, ramInitPath);
+            this.applyIntelHexToMemory(ramInitHex, program.memory);
+          }
+        }
       }
 
       const listingContent = fs.readFileSync(listingPath, 'utf-8');

--- a/src/platforms/tec1/README.md
+++ b/src/platforms/tec1/README.md
@@ -114,7 +114,8 @@ Not every ROM uses RAM the same way:
 - MINT: uses RAM as data only and does not require an initial program in RAM.
 
 In Debug80, set `appStart` per ROM so that assembled programs do not overwrite
-reserved RAM.
+reserved RAM. You can also preload RAM with an Intel HEX file via `ramInitHex`
+(useful for shipping a small starter program at the correct address).
 
 ## ROMs
 
@@ -136,6 +137,7 @@ You can override with `romHex` in the platform config.
     "appStart": 2048,
     "entry": 0,
     "romHex": "roms/tec1/mon-1b.hex",
+    "ramInitHex": "build/main.hex",
     "updateMs": 16,
     "yieldMs": 0
   }

--- a/src/platforms/tec1/runtime.ts
+++ b/src/platforms/tec1/runtime.ts
@@ -60,6 +60,10 @@ export function normalizeTec1Config(cfg?: Tec1PlatformConfig): Tec1PlatformConfi
       : romRanges[0]?.start ?? 0x0000;
   const romHex =
     typeof config.romHex === 'string' && config.romHex !== '' ? config.romHex : undefined;
+  const ramInitHex =
+    typeof config.ramInitHex === 'string' && config.ramInitHex !== ''
+      ? config.ramInitHex
+      : undefined;
   const updateMs =
     Number.isFinite(config.updateMs) && config.updateMs !== undefined ? config.updateMs : 16;
   const yieldMs =
@@ -70,6 +74,7 @@ export function normalizeTec1Config(cfg?: Tec1PlatformConfig): Tec1PlatformConfi
     appStart: Math.max(0, Math.min(0xffff, appStart)),
     entry: Math.max(0, Math.min(0xffff, entry)),
     ...(romHex ? { romHex } : {}),
+    ...(ramInitHex ? { ramInitHex } : {}),
     updateMs: Math.max(0, updateMs),
     yieldMs: Math.max(0, yieldMs),
   };

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -27,6 +27,7 @@ export interface Tec1PlatformConfig {
   appStart?: number;
   entry?: number;
   romHex?: string;
+  ramInitHex?: string;
   updateMs?: number;
   yieldMs?: number;
 }
@@ -37,6 +38,7 @@ export interface Tec1PlatformConfigNormalized {
   appStart: number;
   entry: number;
   romHex?: string;
+  ramInitHex?: string;
   updateMs: number;
   yieldMs: number;
 }


### PR DESCRIPTION
## Summary\n- allow TEC-1 platforms to preload RAM from a HEX file via config\n- document ROM-specific RAM usage (MON-1 vs MON-2)\n- add examples for MON-1 and MON-2 configs\n\n## Testing\n- not run (docs/config change only)