### PR TITLE
Fix TEC-1 example ROM paths

### DIFF
--- a/examples/Tec1/.vscode/debug80.json
+++ b/examples/Tec1/.vscode/debug80.json
@@ -15,7 +15,7 @@
         ],
         "appStart": 2048,
         "entry": 0,
-        "romHex": "roms/tec1/mon-1b.hex"
+        "romHex": "../../roms/tec1/mon-1b.hex"
       }
     },
     "mon2-serial": {
@@ -32,7 +32,7 @@
         ],
         "appStart": 2304,
         "entry": 0,
-        "romHex": "roms/tec1/mon-2.hex"
+        "romHex": "../../roms/tec1/mon-2.hex"
       }
     }
   }


### PR DESCRIPTION
## Summary\n- update TEC-1 example romHex paths to work when opening examples/Tec1 as the workspace\n\n## Testing\n- not run