### PR TITLE
Fix leftover merge marker

### DIFF
--- a/src/debug/adapter.ts
+++ b/src/debug/adapter.ts
@@ -227,7 +227,6 @@ export class Z80DebugSession extends DebugSession {
             this.applyIntelHexToMemory(romHex, memory);
           }
         }
-<<<<<<< HEAD
         const ramInitPath = tec1Config?.ramInitHex
           ? this.resolveRelative(tec1Config.ramInitHex, baseDir)
           : undefined;


### PR DESCRIPTION
## Summary\n- remove a stray merge conflict marker from adapter.ts that breaks build\n\n## Testing\n- not run (fixes compile error)