### PR TITLE
Align TEC-1 LCD with LED display

### DIFF
--- a/src/platforms/tec1/panel.ts
+++ b/src/platforms/tec1/panel.ts
@@ -289,7 +289,7 @@ function getTec1Html(): string {
       padding: 10px 12px;
     }
     .lcd {
-      margin-top: 16px;
+      margin-top: 0;
       background: #0f1f13;
       border-radius: 8px;
       padding: 10px 12px;


### PR DESCRIPTION
## Summary\n- remove extra top margin on the LCD panel so it aligns with the 7-seg display\n\n## Testing\n- not run (UI layout tweak only)\n