### PR TITLE
Add TEC-1 program loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ coverage/
 # Temporary files
 *.tmp
 *.temp
+.debug80/

--- a/programs/tec1/README.md
+++ b/programs/tec1/README.md
@@ -1,0 +1,41 @@
+# TEC-1 Programs
+
+Bundled and user programs for the TEC-1 program loader.
+
+## Folder layout
+
+```
+programs/tec1/
+  bundled/
+    <program>/
+      main.asm
+      program.json
+      README.md (optional)
+  user/
+    <program>/
+      main.asm
+      program.json (optional)
+      README.md (optional)
+```
+
+## program.json (optional)
+
+```json
+{
+  "name": "Serial Demo (MON-1)",
+  "rom": "mon-1b",
+  "org": 2048,
+  "entry": 0,
+  "description": "Bit-bang serial TX demo"
+}
+```
+
+Fields:
+- `name`: display name (defaults to folder name).
+- `rom`: bundled ROM id (`mon-1b`, `mon-2`, `jmon`).
+- `romHex`: explicit ROM path (absolute or relative to the program folder).
+- `org`: load address (decimal or 0x-prefixed string).
+- `entry`: override entry (defaults to 0).
+- `description`: optional detail shown in the loader.
+
+If `org` is omitted, Debug80 uses 0x0800 for MON-1B and 0x0900 for MON-2/JMON.

--- a/programs/tec1/bundled/serial-mon1/main.asm
+++ b/programs/tec1/bundled/serial-mon1/main.asm
@@ -1,0 +1,148 @@
+; TEC-1 example program (RAM @ 0x0800, MON-1 layout).
+; - Target platform: TEC-1 (debug80 "tec1")
+; - Demonstrates bit-banged 8N2 serial on PORTSCAN bit 6 at 9600 baud
+;   when fast mode is 4 MHz (MINT-compatible timing).
+; - Reads a CR-terminated line into a 64-byte buffer and echoes CR/LF.
+; - Intended to be preloaded via platform ramInitHex.
+; - For MON-2 (RAM @ 0x0900), change ORG accordingly.
+        ORG     0x0800
+
+KEYBUF:     EQU     0x00
+PORTSCAN:   EQU     0x01
+SERIALMASK: EQU     0x40     ; bit 6 on PORTSCAN
+BAUD:       EQU     0x000B   ; 9600 baud at 4 MHz (from MINT bitbang constants)
+BUF_LEN:    EQU     64
+
+START:  LD      A,SERIALMASK ; idle high
+        OUT     (PORTSCAN),A
+
+        LD      HL,MSG
+SEND:   LD      A,(HL)
+        OR      A
+        JR      Z,ECHO
+        CALL    SEND_BYTE
+        INC     HL
+        JR      SEND
+
+        LD      HL,BUF
+        LD      C,0
+ECHO:   CALL    RXCHAR
+        CP      0x0D
+        JR      Z,FLUSH
+        LD      D,A
+        LD      A,C
+        CP      BUF_LEN
+        JR      NC,ECHO
+        LD      A,D
+        LD      (HL),A
+        INC     HL
+        INC     C
+        JR      ECHO
+
+FLUSH:  LD      B,C
+        LD      HL,BUF
+SEND_BUF:
+        LD      A,B
+        OR      A
+        JR      Z,SEND_CRLF
+        LD      A,(HL)
+        CALL    SEND_BYTE
+        INC     HL
+        DEC     B
+        JR      SEND_BUF
+SEND_CRLF:
+        LD      A,0x0D
+        CALL    SEND_BYTE
+        LD      A,0x0A
+        CALL    SEND_BYTE
+        LD      HL,BUF
+        LD      C,0
+        JR      ECHO
+
+; Bit-banged 8N2 TX/RX at 9600 baud when TEC-1 fast mode is 4 MHz.
+; Timing matches the MINT bitbang routine.
+SEND_BYTE:
+        PUSH    AF
+        PUSH    BC
+        PUSH    DE
+        PUSH    HL
+        LD      D,A
+        LD      HL,BAUD
+        XOR     A
+        OUT     (PORTSCAN),A ; start bit (low)
+        CALL    BITTIME
+        LD      B,8
+BIT_LOOP:
+        RRC     D
+        LD      A,0x00
+        JR      NC,BIT_ZERO
+        LD      A,SERIALMASK
+BIT_ZERO:
+        OUT     (PORTSCAN),A
+        CALL    BITTIME
+        DJNZ    BIT_LOOP
+
+        LD      A,SERIALMASK ; stop bit 1
+        OUT     (PORTSCAN),A
+        CALL    BITTIME
+        OUT     (PORTSCAN),A ; stop bit 2
+        CALL    BITTIME
+        POP     HL
+        POP     DE
+        POP     BC
+        POP     AF
+        RET
+
+; Receive one byte from serial input on bit 7 of KEYBUF.
+; Returns byte in A. Preserves BC/HL.
+RXCHAR:
+        PUSH    BC
+        PUSH    HL
+RXIDLE:
+        IN      A,(KEYBUF)
+        BIT     7,A
+        JR      Z,RXIDLE
+
+RXWAIT:
+        IN      A,(KEYBUF)
+        BIT     7,A
+        JR      NZ,RXWAIT
+
+        LD      HL,BAUD
+        SRL     H
+        RR      L
+        CALL    BITTIME
+        IN      A,(KEYBUF)
+        BIT     7,A
+        JR      NZ,RXIDLE
+
+        LD      B,8
+        LD      C,0
+RXLOOP:
+        LD      HL,BAUD
+        CALL    BITTIME
+        IN      A,(KEYBUF)
+        RL      A
+        RR      C
+        DJNZ    RXLOOP
+        LD      A,C
+        OR      A
+        POP     HL
+        POP     BC
+        RET
+
+; Delay for one bit time, HL holds the baud constant.
+; Preserves all registers (MINT-compatible).
+BITTIME:
+        PUSH    HL
+        PUSH    DE
+        LD      DE,0x0001
+BITIME1:
+        SBC     HL,DE
+        JP      NC,BITIME1
+        POP     DE
+        POP     HL
+        RET
+
+MSG:    DB      "TEC1 SERIAL OK",0x0D,0x0A,0
+BUF:    DS      64,0

--- a/programs/tec1/bundled/serial-mon1/program.json
+++ b/programs/tec1/bundled/serial-mon1/program.json
@@ -1,0 +1,5 @@
+{
+  "name": "Serial Demo (MON-1)",
+  "rom": "mon-1b",
+  "org": 2048
+}

--- a/programs/tec1/bundled/serial-mon2/main.asm
+++ b/programs/tec1/bundled/serial-mon2/main.asm
@@ -1,0 +1,147 @@
+; TEC-1 example program (RAM @ 0x0900, MON-2 layout).
+; - Target platform: TEC-1 (debug80 "tec1")
+; - Demonstrates bit-banged 8N2 serial on PORTSCAN bit 6 at 9600 baud
+;   when fast mode is 4 MHz (MINT-compatible timing).
+; - Reads a CR-terminated line into a 64-byte buffer and echoes CR/LF.
+; - Intended for MON-2 where 0x0800–0x08ff is reserved.
+        ORG     0x0900
+
+KEYBUF:     EQU     0x00
+PORTSCAN:   EQU     0x01
+SERIALMASK: EQU     0x40     ; bit 6 on PORTSCAN
+BAUD:       EQU     0x000B   ; 9600 baud at 4 MHz (from MINT bitbang constants)
+BUF_LEN:    EQU     64
+
+START:  LD      A,SERIALMASK ; idle high
+        OUT     (PORTSCAN),A
+
+        LD      HL,MSG
+SEND:   LD      A,(HL)
+        OR      A
+        JR      Z,ECHO
+        CALL    SEND_BYTE
+        INC     HL
+        JR      SEND
+
+        LD      HL,BUF
+        LD      C,0
+ECHO:   CALL    RXCHAR
+        CP      0x0D
+        JR      Z,FLUSH
+        LD      D,A
+        LD      A,C
+        CP      BUF_LEN
+        JR      NC,ECHO
+        LD      A,D
+        LD      (HL),A
+        INC     HL
+        INC     C
+        JR      ECHO
+
+FLUSH:  LD      B,C
+        LD      HL,BUF
+SEND_BUF:
+        LD      A,B
+        OR      A
+        JR      Z,SEND_CRLF
+        LD      A,(HL)
+        CALL    SEND_BYTE
+        INC     HL
+        DEC     B
+        JR      SEND_BUF
+SEND_CRLF:
+        LD      A,0x0D
+        CALL    SEND_BYTE
+        LD      A,0x0A
+        CALL    SEND_BYTE
+        LD      HL,BUF
+        LD      C,0
+        JR      ECHO
+
+; Bit-banged 8N2 TX/RX at 9600 baud when TEC-1 fast mode is 4 MHz.
+; Timing matches the MINT bitbang routine.
+SEND_BYTE:
+        PUSH    AF
+        PUSH    BC
+        PUSH    DE
+        PUSH    HL
+        LD      D,A
+        LD      HL,BAUD
+        XOR     A
+        OUT     (PORTSCAN),A ; start bit (low)
+        CALL    BITTIME
+        LD      B,8
+BIT_LOOP:
+        RRC     D
+        LD      A,0x00
+        JR      NC,BIT_ZERO
+        LD      A,SERIALMASK
+BIT_ZERO:
+        OUT     (PORTSCAN),A
+        CALL    BITTIME
+        DJNZ    BIT_LOOP
+
+        LD      A,SERIALMASK ; stop bit 1
+        OUT     (PORTSCAN),A
+        CALL    BITTIME
+        OUT     (PORTSCAN),A ; stop bit 2
+        CALL    BITTIME
+        POP     HL
+        POP     DE
+        POP     BC
+        POP     AF
+        RET
+
+; Receive one byte from serial input on bit 7 of KEYBUF.
+; Returns byte in A. Preserves BC/HL.
+RXCHAR:
+        PUSH    BC
+        PUSH    HL
+RXIDLE:
+        IN      A,(KEYBUF)
+        BIT     7,A
+        JR      Z,RXIDLE
+
+RXWAIT:
+        IN      A,(KEYBUF)
+        BIT     7,A
+        JR      NZ,RXWAIT
+
+        LD      HL,BAUD
+        SRL     H
+        RR      L
+        CALL    BITTIME
+        IN      A,(KEYBUF)
+        BIT     7,A
+        JR      NZ,RXIDLE
+
+        LD      B,8
+        LD      C,0
+RXLOOP:
+        LD      HL,BAUD
+        CALL    BITTIME
+        IN      A,(KEYBUF)
+        RL      A
+        RR      C
+        DJNZ    RXLOOP
+        LD      A,C
+        OR      A
+        POP     HL
+        POP     BC
+        RET
+
+; Delay for one bit time, HL holds the baud constant.
+; Preserves all registers (MINT-compatible).
+BITTIME:
+        PUSH    HL
+        PUSH    DE
+        LD      DE,0x0001
+BITIME1:
+        SBC     HL,DE
+        JP      NC,BITIME1
+        POP     DE
+        POP     HL
+        RET
+
+MSG:    DB      "TEC1 SERIAL OK",0x0D,0x0A,0
+BUF:    DS      64,0

--- a/programs/tec1/bundled/serial-mon2/program.json
+++ b/programs/tec1/bundled/serial-mon2/program.json
@@ -1,0 +1,5 @@
+{
+  "name": "Serial Demo (MON-2/JMON)",
+  "rom": "mon-2",
+  "org": 2304
+}

--- a/src/debug/adapter.ts
+++ b/src/debug/adapter.ts
@@ -765,6 +765,135 @@ export class Z80DebugSession extends DebugSession {
       this.sendResponse(response);
       return;
     }
+    if (command === 'debug80/tec1LoadProgram') {
+      if (this.runtime === undefined || this.tec1Runtime === undefined) {
+        this.sendErrorResponse(response, 1, 'Debug80: TEC-1 platform not active.');
+        return;
+      }
+      const payload = args as {
+        asmPath?: unknown;
+        outputDir?: unknown;
+        artifactBase?: unknown;
+        sourceRoots?: unknown;
+      };
+      const asmPath = typeof payload.asmPath === 'string' ? payload.asmPath : undefined;
+      if (!asmPath) {
+        this.sendErrorResponse(response, 1, 'Debug80: Missing program asm path.');
+        return;
+      }
+      const outputDir =
+        typeof payload.outputDir === 'string' && payload.outputDir !== ''
+          ? payload.outputDir
+          : path.dirname(asmPath);
+      const artifactBase =
+        typeof payload.artifactBase === 'string' && payload.artifactBase !== ''
+          ? payload.artifactBase
+          : path.basename(asmPath, path.extname(asmPath));
+      const listingPath = path.join(outputDir, `${artifactBase}.lst`);
+      const hexPath = path.join(outputDir, `${artifactBase}.hex`);
+      try {
+        this.assembleIfRequested(
+          { assemble: true, outputDir, artifactBase },
+          asmPath,
+          hexPath,
+          listingPath,
+          'tec1'
+        );
+      } catch (err) {
+        this.sendErrorResponse(
+          response,
+          1,
+          `Debug80: Failed to assemble program. ${String(err)}`
+        );
+        return;
+      }
+      if (!fs.existsSync(hexPath)) {
+        this.sendErrorResponse(response, 1, `Debug80: Program hex not found at "${hexPath}".`);
+        return;
+      }
+      const hexContent = fs.readFileSync(hexPath, 'utf-8');
+      const writes = this.parseIntelHexWrites(hexContent);
+      const romRanges = this.tec1Config?.romRanges ?? [];
+      const isRomAddress = (addr: number): boolean =>
+        romRanges.some((range) => addr >= range.start && addr <= range.end);
+      for (const write of writes) {
+        const addr = write.addr & 0xffff;
+        const value = write.value & 0xff;
+        if (this.runtime?.hardware.memWrite) {
+          this.runtime.hardware.memWrite(addr, value);
+        } else if (this.runtime) {
+          this.runtime.hardware.memory[addr] = value;
+        }
+        if (this.loadedProgram && !isRomAddress(addr)) {
+          this.loadedProgram.memory[addr] = value;
+        }
+      }
+
+      if (!fs.existsSync(listingPath)) {
+        this.sendErrorResponse(
+          response,
+          1,
+          `Debug80: Program listing not found at "${listingPath}".`
+        );
+        return;
+      }
+      const listingContent = fs.readFileSync(listingPath, 'utf-8');
+      this.listing = parseListing(listingContent);
+      this.listingPath = listingPath;
+      this.sourceFile = asmPath;
+      const baseDir = path.dirname(asmPath);
+      const roots = Array.isArray(payload.sourceRoots)
+        ? payload.sourceRoots.filter(
+            (root): root is string => typeof root === 'string' && root.trim() !== ''
+          )
+        : [];
+      if (roots.length === 0) {
+        roots.push(baseDir);
+      }
+      this.sourceRoots = this.resolveSourceRoots({ sourceRoots: roots }, baseDir);
+
+      const baseMapping = parseMapping(listingContent);
+      this.applySourceFallback(baseMapping, asmPath, baseDir);
+      const layer2 = applyLayer2(baseMapping, {
+        resolvePath: (file) => this.resolveMappedPath(file),
+      });
+      if (layer2.missingSources.length > 0) {
+        const unique = Array.from(new Set(layer2.missingSources));
+        this.sendEvent(
+          new OutputEvent(
+            `Debug80: Missing source files for Layer 2 mapping: ${unique.join(', ')}\n`,
+            'console'
+          )
+        );
+      }
+      const debugMap = buildD8DebugMap(baseMapping, {
+        arch: 'z80',
+        addressWidth: 16,
+        endianness: 'little',
+        generator: {
+          name: 'debug80',
+        },
+      });
+      const mapPath = this.resolveDebugMapPath(
+        { outputDir, artifactBase },
+        baseDir,
+        asmPath,
+        listingPath
+      );
+      this.writeDebugMap(debugMap, mapPath, baseDir, listingPath);
+      this.mapping = buildMappingFromD8DebugMap(debugMap);
+      this.mappingIndex = buildSourceMapIndex(this.mapping, (file) => this.resolveMappedPath(file));
+
+      if (this.listing !== undefined) {
+        const applied = this.applyAllBreakpoints();
+        for (const bp of applied) {
+          this.sendEvent(new BreakpointEvent('changed', bp));
+        }
+      }
+
+      this.sendResponse(response);
+      return;
+    }
 
     super.customRequest(command, response, args);
   }
@@ -1413,6 +1542,37 @@ export class Z80DebugSession extends DebugSession {
       return 0;
     }
     return Math.floor(value);
+  }
+
+  private parseIntelHexWrites(content: string): Array<{ addr: number; value: number }> {
+    const lines = content
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    const writes: Array<{ addr: number; value: number }> = [];
+
+    for (const line of lines) {
+      if (!line.startsWith(':') || line.length < 11) {
+        continue;
+      }
+      const byteCount = parseInt(line.slice(1, 3), 16);
+      const address = parseInt(line.slice(3, 7), 16);
+      const recordType = parseInt(line.slice(7, 9), 16);
+      const dataString = line.slice(9, 9 + byteCount * 2);
+
+      if (recordType === 1) {
+        break;
+      }
+      if (recordType !== 0) {
+        continue;
+      }
+      for (let i = 0; i < byteCount; i += 1) {
+        const byteHex = dataString.slice(i * 2, i * 2 + 2);
+        const value = parseInt(byteHex, 16);
+        writes.push({ addr: address + i, value: value & 0xff });
+      }
+    }
+    return writes;
   }
 
   private applyIntelHexToMemory(content: string, memory: Uint8Array): void {


### PR DESCRIPTION
## Summary
- load TEC-1 demo programs into the running session without restarting
- move the program selector into a single top bar
- add bundled program folders and docs for TEC-1
- ignore local .debug80 artifacts

## Testing
- not run (user to run yarn run v1.22.21
$ tsc
Done in 1.73s.)
