### PR TITLE
Add TEC-1 8x8 matrix test program

### DIFF
--- a/programs/tec1/bundled/matrix-test/main.asm
+++ b/programs/tec1/bundled/matrix-test/main.asm
@@ -1,0 +1,39 @@
+; TEC-1 8x8 LED Matrix Test
+; Target: TEC-1 platform (ports 0x05 row select, 0x06 data latch)
+; Loads at 0x0900 so it is safe for MON-2/JMON RAM layout.
+; Run by setting the address to 0x0900 and pressing GO.
+
+        .org 0x0900
+
+PORT_ROW        EQU   0x05
+PORT_DATA       EQU   0x06
+
+START:  LD   HL,PATTERN
+        LD   DE,ROWMASKS
+
+FRAME:  LD   B,8
+ROWLP:  LD   A,(HL)
+        OUT  (PORT_DATA),A
+        LD   A,(DE)
+        OUT  (PORT_ROW),A
+        CALL DELAY
+        INC  HL
+        INC  DE
+        DJNZ ROWLP
+        LD   HL,PATTERN
+        LD   DE,ROWMASKS
+        JR   FRAME
+
+DELAY:  LD   B,0x10
+D1:     LD   C,0xFF
+D2:     DEC  C
+        JR   NZ,D2
+        DJNZ D1
+        RET
+
+; Simple X pattern.
+PATTERN:
+        DB   0x81,0x42,0x24,0x18,0x18,0x24,0x42,0x81
+
+ROWMASKS:
+        DB   0x01,0x02,0x04,0x08,0x10,0x20,0x40,0x80

--- a/programs/tec1/bundled/matrix-test/program.json
+++ b/programs/tec1/bundled/matrix-test/program.json
@@ -1,0 +1,6 @@
+{
+  "name": "8x8 Matrix Test",
+  "rom": "mon-2",
+  "org": 2304,
+  "description": "Simple X pattern scan on the 8x8 LED matrix (ports 0x05/0x06)."
+}


### PR DESCRIPTION
## Summary
- add a bundled TEC-1 program that scans an X pattern on the 8x8 LED matrix

## Testing
- not run (user to run yarn run v1.22.21
$ tsc
Done in 1.99s. if desired)
