### PR TITLE
Reset TEC-1 after program load

### DIFF
--- a/examples/Tec1/.vscode/debug80.json
+++ b/examples/Tec1/.vscode/debug80.json
@@ -15,6 +15,7 @@
         ],
         "appStart": 2048,
         "entry": 0,
+        "romId": "mon-1b",
         "romHex": "../../roms/tec1/mon-1b/mon-1b.hex"
       }
     },
@@ -32,6 +33,7 @@
         ],
         "appStart": 2304,
         "entry": 0,
+        "romId": "mon-2",
         "romHex": "../../roms/tec1/mon-2/mon-2.hex"
       }
     },
@@ -49,6 +51,7 @@
         ],
         "appStart": 2304,
         "entry": 0,
+        "romId": "jmon",
         "romHex": "../../roms/tec1/jmon/jmon.hex"
       }
     }

--- a/programs/tec1/README.md
+++ b/programs/tec1/README.md
@@ -39,3 +39,9 @@ Fields:
 - `description`: optional detail shown in the loader.
 
 If `org` is omitted, Debug80 uses 0x0800 for MON-1B and 0x0900 for MON-2/JMON.
+
+## ROM filtering
+
+The program loader filters the list when the active TEC-1 debug session declares a ROM id.
+Add `romId` under `tec1` in your `debug80.json` target to enable filtering (for example,
+`"romId": "mon-1b"` or `"romId": "mon-2"`). Programs without a `rom` entry are always shown.


### PR DESCRIPTION
## Summary
- auto-reset the TEC-1 after loading a program so the monitor resumes cleanly
- filter program list based on active ROM id when provided
- document ROM filtering in 

## Testing
- not run (user to run yarn run v1.22.21
$ tsc
Done in 2.04s.)
