### PR TITLE
feat(ui): responsive memory tab

### DIFF
--- a/src/platforms/tec1g/ui-panel-html-script.ts
+++ b/src/platforms/tec1g/ui-panel-html-script.ts
@@ -119,6 +119,51 @@ export function getTec1gScript(activeTab: 'ui' | 'memory'): string {
     }
 
     let activeTab = DEFAULT_TAB === 'memory' ? 'memory' : 'ui';
+    let memoryRowSize = 16;
+    let resizeTimer = null;
+    const MEMORY_NARROW_MAX = 480;
+    const MEMORY_WIDE_MIN = 520;
+
+    function resolveMemoryRowSize(width) {
+      if (!Number.isFinite(width)) {
+        return memoryRowSize;
+      }
+      if (width <= MEMORY_NARROW_MAX) {
+        return 8;
+      }
+      if (width >= MEMORY_WIDE_MIN) {
+        return 16;
+      }
+      return memoryRowSize;
+    }
+
+    function updateMemoryLayout(forceRefresh) {
+      if (activeTab !== 'memory') {
+        return;
+      }
+      if (!memoryPanel) {
+        return;
+      }
+      const next = resolveMemoryRowSize(memoryPanel.clientWidth);
+      if (next !== memoryRowSize) {
+        memoryRowSize = next;
+        requestSnapshot();
+        return;
+      }
+      if (forceRefresh) {
+        requestSnapshot();
+      }
+    }
+
+    function scheduleMemoryResize() {
+      if (resizeTimer !== null) {
+        clearTimeout(resizeTimer);
+      }
+      resizeTimer = setTimeout(() => {
+        resizeTimer = null;
+        updateMemoryLayout(false);
+      }, 150);
+    }
 
     function setTab(tab, notify) {
       activeTab = tab === 'memory' ? 'memory' : 'ui';
@@ -136,7 +181,7 @@ export function getTec1gScript(activeTab: 'ui' | 'memory'): string {
         vscode.postMessage({ type: 'tab', tab: activeTab });
       }
       if (activeTab === 'memory') {
-        requestSnapshot();
+        updateMemoryLayout(true);
       }
     }
 
@@ -927,7 +972,7 @@ export function getTec1gScript(activeTab: 'ui' | 'memory'): string {
       if (activeTab !== 'memory') {
         return;
       }
-      const rowSize = 16;
+      const rowSize = memoryRowSize;
       const payloadViews = views.map((entry) => {
         const viewValue = entry.view.value;
         let viewMode = viewValue;
@@ -1020,7 +1065,7 @@ export function getTec1gScript(activeTab: 'ui' | 'memory'): string {
               : target.view.value.toUpperCase();
             target.label.textContent = labelValue;
             target.addr.textContent = formatHex(entry.address ?? 0, 4);
-            renderDump(target.dump, entry.start, entry.bytes, entry.focus ?? 0, 16);
+            renderDump(target.dump, entry.start, entry.bytes, entry.focus ?? 0, memoryRowSize);
             if (entry.symbol) {
               if (entry.symbolOffset) {
                 const offset = entry.symbolOffset.toString(16).toUpperCase();
@@ -1052,6 +1097,8 @@ export function getTec1gScript(activeTab: 'ui' | 'memory'): string {
     drawMatrix();
     drawGlcd();
     setTab(DEFAULT_TAB, false);
+    window.addEventListener('resize', scheduleMemoryResize);
+    updateMemoryLayout(false);
     if (document.activeElement !== serialInputEl) {
       document.getElementById('app').focus();
     }


### PR DESCRIPTION
## Summary

- Make TEC-1/TEC-1G memory tabs responsive in the sidebar
- Switch to 8-byte rows under narrow widths with hysteresis
- Debounce resize handling and re-request snapshots on layout change

## Test plan

- [x] yarn lint
- [x] yarn build
- [x] yarn test
