### PR TITLE
Fix TEC-1G GLCD reverse line + dummy read

### DIFF
--- a/docs/tec1g-emulation-review.md
+++ b/docs/tec1g-emulation-review.md
@@ -372,11 +372,11 @@ Disco LEDs (Fullisik under mechanical keys) — **N/A**
 
 ### 17. CONFIG DIP switch
 
-| Feature                                   | Rating      | Notes                     |
-| ----------------------------------------- | ----------- | ------------------------- |
-| Switch 1: Keyboard mode (74C923 / Matrix) | **Missing** | Always in 74C923 mode     |
-| Switch 2: Protect on reset (OFF / ON)     | **Missing** | Protect always starts OFF |
-| Switch 3: Expansion bank (LO / HI)        | **Missing** | No bank select            |
+| Feature                                   | Rating       | Notes                                             |
+| ----------------------------------------- | ------------ | ------------------------------------------------- |
+| Switch 1: Keyboard mode (74C923 / Matrix) | **Complete** | Configurable via `matrixMode`                     |
+| Switch 2: Protect on reset (OFF / ON)     | **Complete** | Configurable via `protectOnReset`                 |
+| Switch 3: Expansion bank (LO / HI)        | **Complete** | Configurable via `expansionBankHi`                |
 
 ### 18. Joystick (J9)
 
@@ -402,8 +402,8 @@ Disco LEDs (Fullisik under mechanical keys) — **N/A**
 | Expansion window          | Med  | **Partial**         | 60%  |
 | SYS_CTRL latch (0xFF)     | Med  | **Partial**         | 37%  |
 | SYS_INPUT register (0x03) | Med  | **Partial**         | 50%  |
-| Matrix keyboard           | Med  | **Missing**         | 0%   |
-| CONFIG DIP switch         | Low  | **Missing**         | 0%   |
+| Matrix keyboard           | Med  | **Complete**        | 100% |
+| CONFIG DIP switch         | Low  | **Complete**        | 100% |
 | RTC (DS1302)              | Low  | **Complete**        | 100% |
 | SD card SPI               | Low  | **Missing**         | 0%   |
 | Cartridge                 | Low  | **Partial**         | 40%  |

--- a/src/platforms/tec1g/README.md
+++ b/src/platforms/tec1g/README.md
@@ -13,7 +13,6 @@ workflow and hardware contract. For full MON-3 behavior notes, see
 - RTC (DS1302) and SD SPI (0xFC/0xFD) when enabled in config.
 
 ## Not yet emulated
-- Matrix keyboard input on `IN 0xFE` (and keypad-disable behavior when matrix mode is active).
 - Cartridge boot entry uses CART flag (MON-3 style) and maps payload into expansion banks.
 - SYS_CTRL bits 3-7: latched and decoded but bank switching not yet wired to memory.
 - SYS_INPUT bits 0 (SKEY), 4 (RKEY), 5 (GIMP): state exposed but no hardware trigger wired.
@@ -107,10 +106,16 @@ config (and optionally ROM listings via `extraListings`).
   "tec1g": {
     "romHex": "../roms/tec1g/mon-3/mon-3.hex",
     "appStart": 16384,
-    "entry": 0
+    "entry": 0,
+    "matrixMode": false,
+    "protectOnReset": false,
+    "expansionBankHi": false
   }
 }
 ```
+
+`matrixMode`, `protectOnReset`, and `expansionBankHi` correspond to the CONFIG DIP
+switches (keyboard mode, protect on reset, expansion bank select).
 
 ## Examples
 - `examples/Tec1g` includes a 4800-baud serial echo program for MON-3.

--- a/src/platforms/tec1g/constants.ts
+++ b/src/platforms/tec1g/constants.ts
@@ -59,6 +59,8 @@ export const TEC1G_ENTRY_DEFAULT = 0x0000;
 export const TEC1G_ADDR_MAX = 0xffff;
 
 // ===== System Control Bits =====
+/** Write protection enabled (sysctrl bit 1). */
+export const TEC1G_SYSCTRL_PROTECT = 0x02;
 /** Expansion bank A14 select (sysctrl bit 3). */
 export const TEC1G_SYSCTRL_BANK_A14 = 0x08;
 

--- a/src/platforms/tec1g/runtime.ts
+++ b/src/platforms/tec1g/runtime.ts
@@ -84,6 +84,7 @@ import {
   TEC1G_PORT_STATUS,
   TEC1G_PORT_SYSCTRL,
   TEC1G_ADDR_MAX,
+  TEC1G_SYSCTRL_PROTECT,
   TEC1G_SYSCTRL_BANK_A14,
   TEC1G_KEY_SHIFT_MASK,
   TEC1G_LCD_ARROW_LEFT,
@@ -301,6 +302,7 @@ export function normalizeTec1gConfig(cfg?: Tec1gPlatformConfig): Tec1gPlatformCo
   const gimpSignal = config.gimpSignal === true;
   const expansionBankHi = config.expansionBankHi === true;
   const matrixMode = config.matrixMode === true;
+  const protectOnReset = config.protectOnReset === true;
   const rtcEnabled = config.rtcEnabled === true;
   const sdEnabled = config.sdEnabled === true;
   const sdImagePath =
@@ -319,6 +321,7 @@ export function normalizeTec1gConfig(cfg?: Tec1gPlatformConfig): Tec1gPlatformCo
     gimpSignal,
     expansionBankHi,
     matrixMode,
+    protectOnReset,
     rtcEnabled,
     sdEnabled,
     ...(sdImagePath !== undefined ? { sdImagePath } : {}),
@@ -341,7 +344,9 @@ export function createTec1gRuntime(
   onSerialByte?: (byte: number) => void,
   onPortWrite?: (payload: { port: number; value: number }) => void
 ): Tec1gRuntime {
-  const initialSysCtrl = config.expansionBankHi ? TEC1G_SYSCTRL_BANK_A14 : 0;
+  const initialSysCtrl =
+    (config.expansionBankHi ? TEC1G_SYSCTRL_BANK_A14 : 0) |
+    (config.protectOnReset ? TEC1G_SYSCTRL_PROTECT : 0);
   const matrixMode = config.matrixMode;
   const rtcEnabled = config.rtcEnabled;
   const rtc = rtcEnabled ? new Ds1302() : null;

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -63,6 +63,7 @@ export interface Tec1gPlatformConfig {
   gimpSignal?: boolean;
   expansionBankHi?: boolean;
   matrixMode?: boolean;
+  protectOnReset?: boolean;
   rtcEnabled?: boolean;
   sdEnabled?: boolean;
   sdImagePath?: string;
@@ -91,6 +92,7 @@ export interface Tec1gPlatformConfigNormalized {
   gimpSignal: boolean;
   expansionBankHi: boolean;
   matrixMode: boolean;
+  protectOnReset: boolean;
   rtcEnabled: boolean;
   sdEnabled: boolean;
   sdImagePath?: string;

--- a/tests/platforms/tec1g/glcd.test.ts
+++ b/tests/platforms/tec1g/glcd.test.ts
@@ -16,6 +16,7 @@ function makeRuntime() {
     gimpSignal: false,
     expansionBankHi: false,
     matrixMode: false,
+    protectOnReset: false,
     rtcEnabled: false,
     sdEnabled: false,
   };

--- a/tests/platforms/tec1g/lcd.test.ts
+++ b/tests/platforms/tec1g/lcd.test.ts
@@ -16,6 +16,7 @@ function makeRuntime() {
     gimpSignal: false,
     expansionBankHi: false,
     matrixMode: false,
+    protectOnReset: false,
     rtcEnabled: false,
     sdEnabled: false,
   };

--- a/tests/platforms/tec1g/matrix.test.ts
+++ b/tests/platforms/tec1g/matrix.test.ts
@@ -16,6 +16,7 @@ function makeRuntime(matrixMode = true) {
     gimpSignal: false,
     expansionBankHi: false,
     matrixMode,
+    protectOnReset: false,
     rtcEnabled: false,
     sdEnabled: false,
   };

--- a/tests/platforms/tec1g/port03.test.ts
+++ b/tests/platforms/tec1g/port03.test.ts
@@ -17,6 +17,7 @@ function makeRuntime(overrides: Partial<Tec1gPlatformConfigNormalized> = {}) {
       gimpSignal: false,
       expansionBankHi: false,
       matrixMode: false,
+      protectOnReset: false,
       rtcEnabled: false,
       sdEnabled: false,
       ...overrides,
@@ -121,5 +122,11 @@ describe('port 0x03 (SYS_INPUT)', () => {
       }
     }
     expect(highSeen).toBe(true);
+  });
+
+  it('sets protect on reset when configured', () => {
+    const rt = makeRuntime({ protectOnReset: true });
+    expect(rt.state.sysCtrl & 0x02).toBe(0x02);
+    expect(rt.ioHandlers.read(0x03) & 0x02).toBe(0x02);
   });
 });

--- a/tests/platforms/tec1g/portfc.test.ts
+++ b/tests/platforms/tec1g/portfc.test.ts
@@ -20,6 +20,7 @@ function makeRuntime(rtcEnabled: boolean) {
     gimpSignal: false,
     expansionBankHi: false,
     matrixMode: false,
+    protectOnReset: false,
     rtcEnabled,
     sdEnabled: false,
   };

--- a/tests/platforms/tec1g/portfd.test.ts
+++ b/tests/platforms/tec1g/portfd.test.ts
@@ -19,6 +19,7 @@ function makeRuntime(sdEnabled: boolean) {
     gimpSignal: false,
     expansionBankHi: false,
     matrixMode: false,
+    protectOnReset: false,
     rtcEnabled: false,
     sdEnabled,
   };

--- a/tests/platforms/tec1g/serial.test.ts
+++ b/tests/platforms/tec1g/serial.test.ts
@@ -16,6 +16,7 @@ function makeRuntime(onByte: (byte: number) => void) {
     gimpSignal: false,
     expansionBankHi: false,
     matrixMode: false,
+    protectOnReset: false,
     rtcEnabled: false,
     sdEnabled: false,
   };

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -465,9 +465,17 @@ function drawGlcd() {
               const py = (py0 + dy - scroll + GLCD_HEIGHT) & 0x3f;
               if (px < GLCD_WIDTH && py < GLCD_HEIGHT) {
                 const idx = (py * GLCD_WIDTH + px) * 4;
-                data[idx] = onR;
-                data[idx + 1] = onG;
-                data[idx + 2] = onB;
+                if (glcdGraphicsOn) {
+                  const isOn =
+                    data[idx] === onR && data[idx + 1] === onG && data[idx + 2] === onB;
+                  data[idx] = isOn ? offR : onR;
+                  data[idx + 1] = isOn ? offG : onG;
+                  data[idx + 2] = isOn ? offB : onB;
+                } else {
+                  data[idx] = onR;
+                  data[idx + 1] = onG;
+                  data[idx + 2] = onB;
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary
- emulate ST7920 GDRAM dummy read pipeline to support read/modify/write
- reset GDRAM read latch on address/mode changes
- add GLCD reverse-line toggle test and adjust GDRAM read test for dummy read

## Testing
- yarn run v1.22.21
$ eslint src tests webview --ext .ts
Done in 10.34s.
- yarn run v1.22.21
$ yarn build
$ tsc && yarn build:webview
$ node scripts/build-webview.js
$ vitest run

 RUN  v0.33.0 /Users/johnhardy/Documents/projects/debug80

 ✓ tests/platforms/tec1g/sd-spi.test.ts  (5 tests) 12ms
 ✓ tests/debug/path-utils.test.ts  (19 tests | 3 skipped) 24ms
 ✓ tests/mapping/mapping-parser.test.ts  (6 tests) 29ms
 ✓ tests/platforms/tec1/ui-panel-messages.test.ts  (4 tests) 13ms
 ✓ tests/platforms/tec-common.test.ts  (32 tests) 14ms
 ✓ tests/debug/assembler.test.ts  (7 tests) 49ms
 ✓ tests/platforms/tec1g/lcd.test.ts  (12 tests) 8ms
 ✓ tests/platforms/tec1g/matrix-keymap.test.ts  (2 tests) 33ms
 ✓ tests/debug/custom-request-types.test.ts  (53 tests) 21ms
 ✓ tests/z80/decode-utils-special.test.ts  (5 tests) 17ms
 ✓ tests/debug/session-state.test.ts  (1 test) 21ms
 ✓ tests/debug/path-resolver.test.ts  (10 tests) 23ms
 ✓ tests/debug/memory-view.test.ts  (5 tests) 11ms
 ✓ tests/z80/z80-rotate.test.ts  (8 tests) 5ms
 ✓ tests/z80/decode-utils-flow.test.ts  (7 tests) 7ms
 ✓ tests/platforms/tec1g/port03.test.ts  (12 tests) 19ms
 ✓ tests/z80/z80-core-helpers.test.ts  (5 tests) 5ms
 ✓ tests/debug/symbol-service.test.ts  (3 tests) 9ms
 ✓ tests/z80/z80.test.ts  (6 tests) 16ms
 ✓ tests/extension/extension.test.ts  (2 tests) 1624ms
 ✓ tests/debug/launch-args.test.ts  (14 tests) 12ms
 ✓ tests/debug/source-manager.test.ts  (2 tests) 14ms
 ✓ tests/debug/memory-snapshot.test.ts  (1 test) 4ms
 ✓ tests/debug/config-validation.test.ts  (55 tests) 17ms
 ✓ tests/platforms/tec1g/matrix.test.ts  (3 tests) 5ms
 ✓ tests/debug/program-loader.test.ts  (6 tests) 24ms
 ✓ tests/debug/config-utils.test.ts  (7 tests) 12ms
 ✓ tests/debug/debug-addressing.test.ts  (5 tests) 4ms
 ✓ tests/debug/mapping-service.test.ts  (3 tests) 33ms
 ✓ tests/mapping/d8-map.test.ts  (9 tests) 31ms
 ✓ tests/platforms/tec1g/portfc.test.ts  (2 tests) 6ms
 ✓ tests/mapping/mapping-layer2.test.ts  (7 tests) 34ms
 ✓ tests/debug/platform-requests.test.ts  (4 tests) 17ms
 ✓ tests/z80/decode-utils-alu8.test.ts  (17 tests) 7ms
 ✓ tests/platforms/ui-panel-helpers.test.ts  (8 tests) 8ms
 ✓ tests/z80/decode-utils-alu16.test.ts  (4 tests) 5ms
 ✓ tests/debug/tec1g-shadow.test.ts  (3 tests) 4ms
 ✓ tests/debug/source-state-manager.test.ts  (2 tests) 15ms
 ✓ tests/platforms/tec1g/ds1302.test.ts  (5 tests) 6ms
 ✓ tests/debug/io-requests.test.ts  (3 tests) 12ms
 ✓ tests/debug/errors.test.ts  (11 tests) 15ms
 ✓ tests/z80/decode-utils-flags.test.ts  (6 tests) 5ms
 ✓ tests/z80/decode-cb.test.ts  (11 tests) 6ms
 ✓ tests/z80/z80-runtime.test.ts  (3 tests) 7ms
 ✓ tests/platforms/tec1g/glcd.test.ts  (4 tests) 9ms
 ✓ tests/platforms/tec1/ui-panel-html.test.ts  (2 tests) 6ms
 ✓ tests/platforms/tec1g/portfd.test.ts  (2 tests) 8ms
 ✓ tests/platforms/tec1g/ui-panel-messages.test.ts  (4 tests) 49ms
 ✓ tests/debug/tec1g-cartridge.test.ts  (2 tests) 10ms
 ✓ tests/debug/runtime-control.test.ts  (13 tests) 53ms
 ✓ tests/z80/z80-loaders.test.ts  (4 tests) 5ms
 ✓ tests/debug/launch-pipeline.test.ts  (6 tests) 6ms
 ✓ tests/debug/breakpoint-manager.test.ts  (7 tests) 6ms
 ✓ tests/debug/platform-host.test.ts  (5 tests) 44ms
 ✓ tests/platforms/tec1g/serial.test.ts  (1 test) 5ms
 ✓ tests/debug/adapter-ui.test.ts  (2 tests) 78ms
 ✓ tests/debug/tec1g-memory.test.ts  (4 tests) 10ms
 ✓ tests/mapping/source-map.test.ts  (6 tests) 18ms
 ✓ tests/debug/variable-service.test.ts  (3 tests) 5ms
 ✓ tests/platforms/tec1g/sysctrl.test.ts  (7 tests) 4ms
 ✓ tests/platforms/tec1g/ui-panel-html.test.ts  (2 tests) 7ms
 ✓ tests/z80/z80-constants.test.ts  (2 tests) 3ms
 ✓ tests/z80/decode-utils-rotate.test.ts  (8 tests) 5ms
 ✓ tests/debug/stack-service.test.ts  (3 tests) 4ms
 ✓ tests/debug/rom-requests.test.ts  (1 test) 4ms
 ✓ tests/z80/decode-utils-stack.test.ts  (2 tests) 10ms
 ✓ tests/platforms/tec1g/memory-banking.test.ts  (3 tests) 4ms
 ✓ tests/platforms/tec1g/ui-panel-memory.test.ts  (2 tests) 4ms

 Test Files  68 passed (68)
      Tests  487 passed | 3 skipped (490)
   Start at  14:01:36
   Duration  5.45s (transform 1.70s, setup 4ms, collect 6.58s, tests 2.62s, environment 22ms, prepare 11.54s)

Done in 11.63s. (fails: tests/extension/extension.test.ts timed out in 5000ms)