### PR TITLE
Wire SDHC config for TEC-1G SD SPI

### DIFF
--- a/src/platforms/tec1g/README.md
+++ b/src/platforms/tec1g/README.md
@@ -109,7 +109,10 @@ config (and optionally ROM listings via `extraListings`).
     "entry": 0,
     "matrixMode": false,
     "protectOnReset": false,
-    "expansionBankHi": false
+    "expansionBankHi": false,
+    "sdEnabled": false,
+    "sdHighCapacity": true,
+    "sdImagePath": ""
   }
 }
 ```

--- a/src/platforms/tec1g/runtime.ts
+++ b/src/platforms/tec1g/runtime.ts
@@ -305,6 +305,7 @@ export function normalizeTec1gConfig(cfg?: Tec1gPlatformConfig): Tec1gPlatformCo
   const protectOnReset = config.protectOnReset === true;
   const rtcEnabled = config.rtcEnabled === true;
   const sdEnabled = config.sdEnabled === true;
+  const sdHighCapacity = config.sdHighCapacity !== false;
   const sdImagePath =
     typeof config.sdImagePath === 'string' && config.sdImagePath !== ''
       ? config.sdImagePath
@@ -324,6 +325,7 @@ export function normalizeTec1gConfig(cfg?: Tec1gPlatformConfig): Tec1gPlatformCo
     protectOnReset,
     rtcEnabled,
     sdEnabled,
+    sdHighCapacity,
     ...(sdImagePath !== undefined ? { sdImagePath } : {}),
     ...(cartridgeHex !== undefined ? { cartridgeHex } : {}),
     ...(extraListings ? { extraListings } : {}),
@@ -353,6 +355,7 @@ export function createTec1gRuntime(
   const rtc = rtcEnabled ? new Ds1302() : null;
   const sdEnabled = config.sdEnabled;
   const sdImagePath = config.sdImagePath;
+  const sdHighCapacity = config.sdHighCapacity;
   let sdImage: Uint8Array | undefined;
   if (sdEnabled && typeof sdImagePath === 'string' && sdImagePath !== '') {
     try {
@@ -361,7 +364,9 @@ export function createTec1gRuntime(
       sdImage = undefined;
     }
   }
-  const sdSpi = sdEnabled ? new SdSpi(sdImage ? { image: sdImage } : undefined) : null;
+  const sdSpi = sdEnabled
+    ? new SdSpi({ highCapacity: sdHighCapacity, ...(sdImage ? { image: sdImage } : {}) })
+    : null;
   let cartridgePresentDefault = config.cartridgeHex !== undefined;
   const state: Tec1gState = {
     digits: Array.from({ length: 6 }, () => 0),

--- a/src/platforms/types.ts
+++ b/src/platforms/types.ts
@@ -67,6 +67,7 @@ export interface Tec1gPlatformConfig {
   rtcEnabled?: boolean;
   sdEnabled?: boolean;
   sdImagePath?: string;
+  sdHighCapacity?: boolean;
   cartridgeHex?: string;
   uiVisibility?: {
     lcd?: boolean;
@@ -96,6 +97,7 @@ export interface Tec1gPlatformConfigNormalized {
   rtcEnabled: boolean;
   sdEnabled: boolean;
   sdImagePath?: string;
+  sdHighCapacity: boolean;
   cartridgeHex?: string;
   uiVisibility?: {
     lcd?: boolean;

--- a/tests/debug/tec1g-memory.test.ts
+++ b/tests/debug/tec1g-memory.test.ts
@@ -55,6 +55,7 @@ describe('TEC-1G expand bank switching', () => {
       matrixMode: false,
       rtcEnabled: false,
       sdEnabled: false,
+      sdHighCapacity: true,
     };
     const runtime = createTec1gRuntime(config, () => {});
     runtime.state.bankA14 = false;

--- a/tests/platforms/tec1g/glcd.test.ts
+++ b/tests/platforms/tec1g/glcd.test.ts
@@ -19,6 +19,7 @@ function makeRuntime() {
     protectOnReset: false,
     rtcEnabled: false,
     sdEnabled: false,
+    sdHighCapacity: true,
   };
   return createTec1gRuntime(config, () => {});
 }

--- a/tests/platforms/tec1g/lcd.test.ts
+++ b/tests/platforms/tec1g/lcd.test.ts
@@ -19,6 +19,7 @@ function makeRuntime() {
     protectOnReset: false,
     rtcEnabled: false,
     sdEnabled: false,
+    sdHighCapacity: true,
   };
   return createTec1gRuntime(config, () => {});
 }

--- a/tests/platforms/tec1g/matrix.test.ts
+++ b/tests/platforms/tec1g/matrix.test.ts
@@ -19,6 +19,7 @@ function makeRuntime(matrixMode = true) {
     protectOnReset: false,
     rtcEnabled: false,
     sdEnabled: false,
+    sdHighCapacity: true,
   };
   return createTec1gRuntime(config, () => {});
 }

--- a/tests/platforms/tec1g/port03.test.ts
+++ b/tests/platforms/tec1g/port03.test.ts
@@ -20,6 +20,7 @@ function makeRuntime(overrides: Partial<Tec1gPlatformConfigNormalized> = {}) {
       protectOnReset: false,
       rtcEnabled: false,
       sdEnabled: false,
+      sdHighCapacity: true,
       ...overrides,
     },
     () => {}

--- a/tests/platforms/tec1g/portfc.test.ts
+++ b/tests/platforms/tec1g/portfc.test.ts
@@ -23,6 +23,7 @@ function makeRuntime(rtcEnabled: boolean) {
     protectOnReset: false,
     rtcEnabled,
     sdEnabled: false,
+    sdHighCapacity: true,
   };
   return createTec1gRuntime(config, () => {});
 }

--- a/tests/platforms/tec1g/portfd.test.ts
+++ b/tests/platforms/tec1g/portfd.test.ts
@@ -22,6 +22,7 @@ function makeRuntime(sdEnabled: boolean) {
     protectOnReset: false,
     rtcEnabled: false,
     sdEnabled,
+    sdHighCapacity: true,
   };
   return createTec1gRuntime(config, () => {});
 }

--- a/tests/platforms/tec1g/serial.test.ts
+++ b/tests/platforms/tec1g/serial.test.ts
@@ -19,6 +19,7 @@ function makeRuntime(onByte: (byte: number) => void) {
     protectOnReset: false,
     rtcEnabled: false,
     sdEnabled: false,
+    sdHighCapacity: true,
   };
   return createTec1gRuntime(config, () => {}, onByte);
 }


### PR DESCRIPTION
## Summary
- add sdHighCapacity config flag and normalize defaults
- pass SDHC flag into SD SPI runtime
- update TEC-1G config example and tests

## Testing
- not run (config-only wiring)