### PR TITLE
ci: add macOS runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-latest
           - windows-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- add macos-latest to the CI OS matrix
- keep the existing linux and windows jobs intact
- let the standard test workflow validate the extension on all three desktop platforms

## Testing
- GitHub Actions