### PR TITLE
Prefer native D8 debug maps

### DIFF
--- a/docs/d8-debug-map.md
+++ b/docs/d8-debug-map.md
@@ -194,14 +194,16 @@ Fields:
 
 ## Integration with Debug80
 
-- Debug80 writes `build/main.d8.json` alongside the build artifacts.
-- On launch, Debug80 loads the map if present; if missing or invalid, it
-  regenerates the map from the `.lst`.
+- Debug80 loads `build/main.d8.json` if present.
+- If the map is missing or invalid, Debug80 regenerates a map from the `.lst`
+  and writes that cache alongside the build artifacts.
+- For native producer-generated maps such as ZAX output, Debug80 preserves the
+  existing `.d8.json` even when it is older than the `.lst`.
 
 ## Workflow
 
 1) Assemble with asm80 to produce `build/main.hex` and `build/main.lst`.
-2) Debug80 writes `build/main.d8.json`.
+2) The assembler or Debug80 may provide `build/main.d8.json`.
 3) Debug80 loads the map for debugging, with `.lst` as the fallback source.
 
 The map file can be treated as a build artifact in `build/` and is not

--- a/src/debug/mapping-service.ts
+++ b/src/debug/mapping-service.ts
@@ -105,7 +105,8 @@ export function buildMappingFromListing(options: {
     writeDebugMap(debugMap, mapPath, service, listingPath);
   }
 
-  let mapping = buildMappingFromD8DebugMap(debugMap);
+  const normalizedDebugMap = hasNativeMap ? normalizeNativeDebugMapForDebug80(debugMap) : debugMap;
+  let mapping = buildMappingFromD8DebugMap(normalizedDebugMap);
   const extraMapping = loadExtraListingMapping(extraListingPaths, service);
   if (extraMapping) {
     mapping = mergeMappings(mapping, extraMapping);
@@ -210,6 +211,35 @@ function getDebugMapGeneratorLabel(map: D8DebugMap): string {
     : 'unknown generator';
 }
 
+function normalizeNativeDebugMapForDebug80(map: D8DebugMap): D8DebugMap {
+  const files = map.files;
+  if (files === undefined || Array.isArray(files)) {
+    return map;
+  }
+
+  const normalizedFiles: D8DebugMap['files'] = {};
+  for (const [fileKey, entry] of Object.entries(files)) {
+    normalizedFiles[fileKey] = {
+      ...entry,
+      ...(entry.segments
+        ? {
+            segments: entry.segments.map((segment) => ({
+              ...segment,
+              ...(segment.line === undefined || segment.line === null
+                ? { line: segment.lstLine }
+                : {}),
+            })),
+          }
+        : {}),
+    };
+  }
+
+  return {
+    ...map,
+    files: normalizedFiles,
+  };
+}
+
 function writeDebugMap(
   map: ReturnType<typeof buildD8DebugMap>,
   mapPath: string,
@@ -262,7 +292,10 @@ function loadExtraListingMapping(
 
       let debugMap = hasNativeMap ? loadedMap : !mapStale && fs.existsSync(mapPath) ? loadedMap : undefined;
       if (debugMap) {
-        const mapping = buildMappingFromD8DebugMap(debugMap);
+        const normalizedDebugMap = hasNativeMap
+          ? normalizeNativeDebugMapForDebug80(debugMap)
+          : debugMap;
+        const mapping = buildMappingFromD8DebugMap(normalizedDebugMap);
         combined.segments.push(...mapping.segments);
         combined.anchors.push(...mapping.anchors);
         continue;

--- a/src/mapping/d8-map.ts
+++ b/src/mapping/d8-map.ts
@@ -315,7 +315,7 @@ function buildMappingFromGroupedDebugMap(map: D8DebugMap): MappingParseResult {
   for (const [fileKey, entry] of Object.entries(files)) {
     const file = fromFileKey(fileKey);
     for (const segment of entry.segments ?? []) {
-      const line = segment.line ?? segment.lstLine ?? null;
+      const line = segment.line ?? null;
       const confidence = segment.confidence ?? defaultConfidence;
 
       const lstLine = segment.lstLine;

--- a/tests/debug/mapping-service.test.ts
+++ b/tests/debug/mapping-service.test.ts
@@ -185,6 +185,56 @@ describe('mapping-service', () => {
     expect(fs.readFileSync(mapPath, 'utf-8')).toBe(originalContent);
   });
 
+  it('fills missing source lines from lstLine only for native debug maps', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-map-'));
+    const listingPath = path.join(dir, 'simple.lst');
+    const asmPath = path.join(dir, 'simple.asm');
+    const mapPath = path.join(dir, 'simple.d8.json');
+
+    writeFile(listingPath, listingContent);
+    writeFile(asmPath, asmContent);
+
+    const nativeMap = {
+      format: 'd8-debug-map',
+      version: 1,
+      arch: 'z80',
+      addressWidth: 16,
+      endianness: 'little',
+      generator: { name: 'zax' },
+      files: {
+        [asmPath]: {
+          segments: [{ start: 0x2000, end: 0x2001, lstLine: 42, lstText: 'NOP' }],
+        },
+      },
+    };
+    writeFile(mapPath, JSON.stringify(nativeMap, null, 2));
+
+    const result = buildMappingFromListing({
+      listingContent,
+      listingPath,
+      asmPath,
+      sourceFile: asmPath,
+      extraListingPaths: [],
+      mapArgs: {},
+      service: {
+        platform: 'simple',
+        baseDir: dir,
+        resolveMappedPath: (file) => {
+          const candidate = path.resolve(dir, file);
+          return fs.existsSync(candidate) ? candidate : undefined;
+        },
+        relativeIfPossible: (filePath, baseDir) =>
+          path.relative(baseDir, filePath) || filePath,
+        resolveExtraDebugMapPath: (p) => path.join(dir, `${path.basename(p)}.extra.json`),
+        resolveDebugMapPath: () => mapPath,
+        log: () => undefined,
+      },
+    });
+
+    expect(result.mapping.segments[0]?.loc.line).toBe(42);
+    expect(result.mapping.segments[0]?.lst.line).toBe(42);
+  });
+
   it('regenerates when the debug map is stale and merges extra listings', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-map-'));
     const listingPath = path.join(dir, 'simple.lst');

--- a/tests/mapping/d8-map.test.ts
+++ b/tests/mapping/d8-map.test.ts
@@ -152,7 +152,7 @@ describe('d8-map', () => {
     expect(rebuilt.segments[0]?.confidence).toBe('LOW');
   });
 
-  it('falls back to lstLine when source line is omitted', () => {
+  it('keeps source line unknown when line is omitted', () => {
     const map = {
       format: 'd8-debug-map',
       version: 1,
@@ -167,7 +167,7 @@ describe('d8-map', () => {
     };
 
     const rebuilt = buildMappingFromD8DebugMap(map as never);
-    expect(rebuilt.segments[0]?.loc.line).toBe(99);
+    expect(rebuilt.segments[0]?.loc.line).toBeNull();
     expect(rebuilt.segments[0]?.lst.line).toBe(99);
   });
 


### PR DESCRIPTION
## Summary
- prefer native producer-generated D8 maps over regenerating from LST files
- fall back to lstLine when a D8 segment omits source line information
- add regression coverage for stale native primary and extra-listing maps

Closes #80

## Testing
- npm run build
- npm test