### PR TITLE
Move TEC-1G helpers into platform ownership

### DIFF
--- a/src/platforms/tec1g/provider.ts
+++ b/src/platforms/tec1g/provider.ts
@@ -7,11 +7,11 @@ import type { DebugProtocol } from '@vscode/debugprotocol';
 import {
   applyCartridgeMemory,
   createTec1gMemoryHooks,
-} from '../../debug/tec1g-memory';
+} from './tec1g-memory';
 import {
   loadTec1gCartridgeImage,
   type Tec1gCartridgeImage,
-} from '../../debug/tec1g-cartridge';
+} from './tec1g-cartridge';
 import {
   buildPlatformIoHandlers,
   type PlatformIoBuildResult,

--- a/src/platforms/tec1g/tec1g-cartridge.ts
+++ b/src/platforms/tec1g/tec1g-cartridge.ts
@@ -1,17 +1,20 @@
 /**
- * @fileoverview TEC-1G cartridge loading helpers.
+ * @file TEC-1G cartridge loading helpers.
  */
 
 import fs from 'fs';
-import { TEC1G_EXPAND_SIZE, TEC1G_EXPAND_START } from '../platforms/tec-common';
-import { extractRomHex } from './program-loader';
-import { parseIntelHex } from '../z80/loaders';
+import { TEC1G_EXPAND_SIZE, TEC1G_EXPAND_START } from '../tec-common';
+import { extractRomHex } from '../../debug/program-loader';
+import { parseIntelHex } from '../../z80/loaders';
 
 export type Tec1gCartridgeImage = {
   memory: Uint8Array;
   bootEntry: number | null;
 };
 
+/**
+ * Returns whether the loaded image contains any non-zero data in the cartridge expansion region.
+ */
 export function isTec1gCartridgeBootable(memory: Uint8Array): boolean {
   for (let addr = TEC1G_EXPAND_START; addr < 0x10000; addr += 1) {
     if (memory[addr] !== 0) {
@@ -21,6 +24,9 @@ export function isTec1gCartridgeBootable(memory: Uint8Array): boolean {
   return false;
 }
 
+/**
+ * Loads a TEC-1G cartridge image from either raw binary or Intel HEX content.
+ */
 export function loadTec1gCartridgeImage(cartridgePath: string): Tec1gCartridgeImage {
   const lower = cartridgePath.toLowerCase();
   let memory: Uint8Array;

--- a/src/platforms/tec1g/tec1g-memory.ts
+++ b/src/platforms/tec1g/tec1g-memory.ts
@@ -1,8 +1,8 @@
 /**
- * @fileoverview TEC-1G memory hook helpers for shadow/protect/expand behavior.
+ * @file TEC-1G memory hook helpers for shadow/protect/expand behavior.
  */
 
-import type { Tec1gState } from '../platforms/tec1g/runtime';
+import type { Tec1gState } from './runtime';
 import {
   ADDR_MASK,
   BYTE_MASK,
@@ -14,7 +14,7 @@ import {
   TEC1G_SHADOW_END,
   TEC1G_SHADOW_SIZE,
   TEC1G_SHADOW_START,
-} from '../platforms/tec-common';
+} from '../tec-common';
 import { ensureTec1gShadowRom } from './tec1g-shadow';
 
 export type Tec1gMemoryHooks = {
@@ -23,6 +23,9 @@ export type Tec1gMemoryHooks = {
   memWrite: (addr: number, value: number) => void;
 };
 
+/**
+ * Copies cartridge-backed expansion data into the active TEC-1G expand banks.
+ */
 export function applyCartridgeMemory(expandBanks: Uint8Array[], memory: Uint8Array): void {
   const bank0 = expandBanks[0];
   const bank1 = expandBanks[1];
@@ -40,6 +43,9 @@ export function applyCartridgeMemory(expandBanks: Uint8Array[], memory: Uint8Arr
   );
 }
 
+/**
+ * Builds memory read/write hooks that apply TEC-1G shadow, protect, and banked expansion logic.
+ */
 export function createTec1gMemoryHooks(
   baseMemory: Uint8Array,
   romRanges: Array<{ start: number; end: number }>,

--- a/src/platforms/tec1g/tec1g-shadow.ts
+++ b/src/platforms/tec1g/tec1g-shadow.ts
@@ -1,6 +1,5 @@
 /**
- * @fileoverview TEC-1G shadow ROM management.
- * Handles the ROM shadowing mechanism where ROM at 0xC000 is mirrored to 0x0000.
+ * @file TEC-1G shadow ROM management.
  */
 
 /**

--- a/tests/debug/tec1g-cartridge.test.ts
+++ b/tests/debug/tec1g-cartridge.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
-import { loadTec1gCartridgeImage } from '../../src/debug/tec1g-cartridge';
+import { loadTec1gCartridgeImage } from '../../src/platforms/tec1g/tec1g-cartridge';
 
 const withTempDir = (run: (dir: string) => void): void => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-cart-'));

--- a/tests/debug/tec1g-memory.test.ts
+++ b/tests/debug/tec1g-memory.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { applyCartridgeMemory, createTec1gMemoryHooks } from '../../src/debug/tec1g-memory';
+import {
+  applyCartridgeMemory,
+  createTec1gMemoryHooks,
+} from '../../src/platforms/tec1g/tec1g-memory';
 import { createTec1gRuntime } from '../../src/platforms/tec1g/runtime';
 import type { Tec1gPlatformConfigNormalized } from '../../src/platforms/types';
 

--- a/tests/debug/tec1g-shadow.test.ts
+++ b/tests/debug/tec1g-shadow.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { ensureTec1gShadowRom } from '../../src/debug/tec1g-shadow';
+import { ensureTec1gShadowRom } from '../../src/platforms/tec1g/tec1g-shadow';
 
 const makeMemory = (): Uint8Array => new Uint8Array(0x10000);
 

--- a/tests/platforms/provider.test.ts
+++ b/tests/platforms/provider.test.ts
@@ -23,7 +23,7 @@ vi.mock('../../src/debug/platform-host', () => ({
   buildPlatformIoHandlers,
 }));
 
-vi.mock('../../src/debug/tec1g-memory', () => ({
+vi.mock('../../src/platforms/tec1g/tec1g-memory', () => ({
   createTec1gMemoryHooks,
   applyCartridgeMemory,
 }));

--- a/tests/platforms/tec1g/memory-banking.test.ts
+++ b/tests/platforms/tec1g/memory-banking.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createTec1gMemoryHooks } from '../../../src/debug/tec1g-memory';
+import { createTec1gMemoryHooks } from '../../../src/platforms/tec1g/tec1g-memory';
 
 describe('TEC-1G memory banking', () => {
   it('reads shadow ROM when enabled', () => {


### PR DESCRIPTION
## Summary
- move TEC-1G-specific memory, shadow, and cartridge helpers from src/debug/ into src/platforms/tec1g/
- update TEC-1G provider and test imports to use the platform-owned modules
- keep behavior unchanged while removing TEC-1G ownership from the debug layer

## Testing
- npx vitest run tests/debug/tec1g-memory.test.ts tests/debug/tec1g-shadow.test.ts tests/debug/tec1g-cartridge.test.ts tests/platforms/tec1g/memory-banking.test.ts tests/platforms/provider.test.ts
- npx eslint src/platforms/tec1g/provider.ts src/platforms/tec1g/tec1g-memory.ts src/platforms/tec1g/tec1g-shadow.ts src/platforms/tec1g/tec1g-cartridge.ts tests/debug/tec1g-memory.test.ts tests/debug/tec1g-shadow.test.ts tests/debug/tec1g-cartridge.test.ts tests/platforms/tec1g/memory-banking.test.ts tests/platforms/provider.test.ts
- npm test

Closes #91