### PR TITLE
Extract TEC-1G serial controller

### DIFF
--- a/src/platforms/tec1g/runtime.ts
+++ b/src/platforms/tec1g/runtime.ts
@@ -8,13 +8,13 @@
 
 import { IoHandlers } from '../../z80/runtime';
 import { CycleClock } from '../cycle-clock';
-import { BitbangUartDecoder } from '../serial/bitbang-uart';
 import { Tec1gPlatformConfig, Tec1gPlatformConfigNormalized } from '../types';
 import { normalizeSimpleRegions } from '../simple/runtime';
 import { Tec1gSpeedMode, Tec1gUpdatePayload } from './types';
 import { decodeSysCtrl } from './sysctrl';
 import { Ds1302 } from './ds1302';
 import { SdSpi } from './sd-spi';
+import { createTec1gSerialController } from './serial';
 import {
   TEC1G_DIGIT_SERIAL_TX,
   TEC1G_DIGIT_SPEAKER,
@@ -249,7 +249,6 @@ export interface Tec1gRuntime {
 export const TEC1G_SLOW_HZ = TEC_SLOW_HZ;
 export const TEC1G_FAST_HZ = TEC_FAST_HZ;
 const TEC1G_SILENCE_CYCLES = TEC_SILENCE_CYCLES;
-const TEC1G_SERIAL_BAUD = 4800;
 const TEC1G_KEY_HOLD_MS = TEC_KEY_HOLD_MS;
 const TEC1G_LCD_BUSY_US = 37;
 const TEC1G_LCD_BUSY_CLEAR_US = 1600;
@@ -694,28 +693,7 @@ export function createTec1gRuntime(
     return busy | addr;
   };
 
-  let serialLevel: 0 | 1 = 1;
-  let serialRxLevel: 0 | 1 = 1;
-  let serialRxBusy = false;
-  let serialRxToken = 0;
-  let serialRxLeadCycles = 0;
-  let serialRxPending = false;
-  let serialCyclesPerBit = state.clockHz / TEC1G_SERIAL_BAUD;
-  const serialRxQueue: number[] = [];
-  let serialRxPrimed = false;
-  const serialDecoder = new BitbangUartDecoder(state.cycleClock, {
-    baud: TEC1G_SERIAL_BAUD,
-    cyclesPerSecond: state.clockHz,
-    dataBits: 8,
-    stopBits: 2,
-    parity: 'none',
-    inverted: false,
-  });
-  serialDecoder.setByteHandler((event) => {
-    if (onSerialByte) {
-      onSerialByte(event.byte);
-    }
-  });
+  const serial = createTec1gSerialController(state.cycleClock, state.clockHz, onSerialByte);
   const portWriteLog = new Map<number, number>();
   const logPortWrite = (port: number, value: number): void => {
     const prev = portWriteLog.get(port);
@@ -903,13 +881,9 @@ export function createTec1gRuntime(
       const p = fullPort & TEC1G_MASK_BYTE;
       const highByte = (fullPort >> 8) & TEC1G_MASK_BYTE;
       if (p === TEC1G_PORT_KEYBOARD) {
-        if (serialRxPending && !serialRxBusy && serialRxQueue.length > 0) {
-          serialRxPending = false;
-          serialRxLeadCycles = Math.max(1, Math.round(serialCyclesPerBit * 2));
-          startNextSerialRx();
-        }
+        serial.maybeStartQueuedRx();
         const key = state.keyValue & TEC1G_MASK_LOW7;
-        return key | (serialRxLevel ? TEC1G_STATUS_SERIAL_RX : 0);
+        return key | (serial.getRxLevel() ? TEC1G_STATUS_SERIAL_RX : 0);
       }
       if (p === TEC1G_PORT_MATRIX) {
         if (!state.matrixModeEnabled) {
@@ -963,7 +937,7 @@ export function createTec1gRuntime(
         if (!keyPressed) {
           value |= TEC1G_STATUS_NO_KEY;
         }
-        if (serialRxLevel) {
+        if (serial.getRxLevel()) {
           value |= TEC1G_STATUS_SERIAL_RX;
         }
         return value;
@@ -978,10 +952,7 @@ export function createTec1gRuntime(
         state.digitLatch = value & TEC1G_MASK_BYTE;
         const speaker = (value & TEC1G_DIGIT_SPEAKER) !== 0;
         const nextSerial: 0 | 1 = (value & TEC1G_DIGIT_SERIAL_TX) !== 0 ? 1 : 0;
-        if (nextSerial !== serialLevel) {
-          serialLevel = nextSerial;
-          serialDecoder.recordLevel(serialLevel);
-        }
+        serial.recordTxLevel(nextSerial);
         if (speaker !== state.speaker) {
           const now = state.cycleClock.now();
           if (state.lastEdgeCycle !== null) {
@@ -1261,85 +1232,8 @@ export function createTec1gRuntime(
     state.matrixModeEnabled = enabled;
   };
 
-  const setSerialRxLevel = (level: 0 | 1): void => {
-    serialRxLevel = level;
-  };
-
-  const scheduleSerialRxByte = (byte: number, leadCycles = 0): void => {
-    const token = serialRxToken;
-    const start = state.cycleClock.now() + leadCycles;
-    if (leadCycles <= 0) {
-      setSerialRxLevel(0);
-    } else {
-      setSerialRxLevel(1);
-      state.cycleClock.scheduleAt(start, () => {
-        if (serialRxToken !== token) {
-          return;
-        }
-        setSerialRxLevel(0);
-      });
-    }
-    for (let i = 0; i < 8; i += 1) {
-      const bit = ((byte >> i) & 1) as 0 | 1;
-      const at = start + serialCyclesPerBit * (i + 1);
-      state.cycleClock.scheduleAt(at, () => {
-        if (serialRxToken !== token) {
-          return;
-        }
-        setSerialRxLevel(bit);
-      });
-    }
-
-    const stopAt = start + serialCyclesPerBit * (1 + 8);
-    state.cycleClock.scheduleAt(stopAt, () => {
-      if (serialRxToken !== token) {
-        return;
-      }
-      setSerialRxLevel(1);
-    });
-
-    const doneAt = start + serialCyclesPerBit * (1 + 8 + 2);
-    state.cycleClock.scheduleAt(doneAt, () => {
-      if (serialRxToken !== token) {
-        return;
-      }
-      startNextSerialRx();
-    });
-  };
-
-  const startNextSerialRx = (): void => {
-    if (serialRxQueue.length === 0) {
-      serialRxBusy = false;
-      setSerialRxLevel(1);
-      return;
-    }
-    serialRxBusy = true;
-    const next = serialRxQueue.shift();
-    if (next === undefined) {
-      serialRxBusy = false;
-      setSerialRxLevel(1);
-      return;
-    }
-    const leadCycles = serialRxLeadCycles;
-    serialRxLeadCycles = 0;
-    scheduleSerialRxByte(next, leadCycles);
-  };
-
   const queueSerial = (bytes: number[]): void => {
-    if (!bytes.length) {
-      return;
-    }
-    if (!serialRxPrimed) {
-      // Prime RX once so the first real byte is aligned to the ROM's bitbang receiver.
-      serialRxQueue.push(0);
-      serialRxPrimed = true;
-    }
-    for (const value of bytes) {
-      serialRxQueue.push(value & TEC1G_MASK_BYTE);
-    }
-    if (!serialRxBusy) {
-      serialRxPending = true;
-    }
+    serial.queueSerial(bytes);
   };
 
   const recordCycles = (cycles: number): void => {
@@ -1365,8 +1259,7 @@ export function createTec1gRuntime(
   const setSpeed = (mode: Tec1gSpeedMode): void => {
     state.speedMode = mode;
     state.clockHz = mode === 'slow' ? TEC1G_SLOW_HZ : TEC1G_FAST_HZ;
-    serialDecoder.setCyclesPerSecond(state.clockHz);
-    serialCyclesPerBit = state.clockHz / TEC1G_SERIAL_BAUD;
+    serial.setClockHz(state.clockHz);
     glcdRescheduleBlink();
     sendUpdate();
   };
@@ -1437,11 +1330,7 @@ export function createTec1gRuntime(
       state.cycleClock.cancel(state.silenceEventId);
       state.silenceEventId = null;
     }
-    serialRxQueue.length = 0;
-    serialRxBusy = false;
-    serialRxPrimed = false;
-    serialRxToken += 1;
-    setSerialRxLevel(1);
+    serial.reset();
     queueUpdate();
   };
 

--- a/src/platforms/tec1g/serial.ts
+++ b/src/platforms/tec1g/serial.ts
@@ -1,0 +1,167 @@
+/**
+ * @file TEC-1G serial bitbang controller.
+ */
+
+import { CycleClock } from '../cycle-clock';
+import { BitbangUartDecoder } from '../serial/bitbang-uart';
+
+const TEC1G_SERIAL_BAUD = 4800;
+const TEC1G_MASK_BYTE = 0xff;
+
+export type Tec1gSerialLevel = 0 | 1;
+
+export interface Tec1gSerialController {
+  getRxLevel(): Tec1gSerialLevel;
+  recordTxLevel(level: Tec1gSerialLevel): void;
+  queueSerial(bytes: number[]): void;
+  maybeStartQueuedRx(): void;
+  setClockHz(hz: number): void;
+  reset(): void;
+}
+
+/**
+ * Builds the TEC-1G serial controller that handles TX decoding and queued RX bytes.
+ */
+export function createTec1gSerialController(
+  cycleClock: CycleClock,
+  clockHz: number,
+  onByte?: (byte: number) => void
+): Tec1gSerialController {
+  let serialLevel: Tec1gSerialLevel = 1;
+  let serialRxLevel: Tec1gSerialLevel = 1;
+  let serialRxBusy = false;
+  let serialRxToken = 0;
+  let serialRxLeadCycles = 0;
+  let serialRxPending = false;
+  let serialCyclesPerBit = clockHz / TEC1G_SERIAL_BAUD;
+  const serialRxQueue: number[] = [];
+  let serialRxPrimed = false;
+
+  const serialDecoder = new BitbangUartDecoder(cycleClock, {
+    baud: TEC1G_SERIAL_BAUD,
+    cyclesPerSecond: clockHz,
+    dataBits: 8,
+    stopBits: 2,
+    parity: 'none',
+    inverted: false,
+  });
+  serialDecoder.setByteHandler((event) => {
+    onByte?.(event.byte);
+  });
+
+  const setSerialRxLevel = (level: Tec1gSerialLevel): void => {
+    serialRxLevel = level;
+  };
+
+  const startNextSerialRx = (): void => {
+    if (serialRxQueue.length === 0) {
+      serialRxBusy = false;
+      setSerialRxLevel(1);
+      return;
+    }
+
+    serialRxBusy = true;
+    const next = serialRxQueue.shift();
+    if (next === undefined) {
+      serialRxBusy = false;
+      setSerialRxLevel(1);
+      return;
+    }
+
+    const token = serialRxToken;
+    const start = cycleClock.now() + serialRxLeadCycles;
+    const leadCycles = serialRxLeadCycles;
+    serialRxLeadCycles = 0;
+
+    if (leadCycles <= 0) {
+      setSerialRxLevel(0);
+    } else {
+      setSerialRxLevel(1);
+      cycleClock.scheduleAt(start, () => {
+        if (serialRxToken !== token) {
+          return;
+        }
+        setSerialRxLevel(0);
+      });
+    }
+
+    for (let i = 0; i < 8; i += 1) {
+      const bit = ((next >> i) & 1) as Tec1gSerialLevel;
+      const at = start + serialCyclesPerBit * (i + 1);
+      cycleClock.scheduleAt(at, () => {
+        if (serialRxToken !== token) {
+          return;
+        }
+        setSerialRxLevel(bit);
+      });
+    }
+
+    const stopAt = start + serialCyclesPerBit * (1 + 8);
+    cycleClock.scheduleAt(stopAt, () => {
+      if (serialRxToken !== token) {
+        return;
+      }
+      setSerialRxLevel(1);
+    });
+
+    const doneAt = start + serialCyclesPerBit * (1 + 8 + 2);
+    cycleClock.scheduleAt(doneAt, () => {
+      if (serialRxToken !== token) {
+        return;
+      }
+      startNextSerialRx();
+    });
+  };
+
+  const maybeStartQueuedRx = (): void => {
+    if (serialRxPending && !serialRxBusy && serialRxQueue.length > 0) {
+      serialRxPending = false;
+      serialRxLeadCycles = Math.max(1, Math.round(serialCyclesPerBit * 2));
+      startNextSerialRx();
+    }
+  };
+
+  return {
+    getRxLevel: () => serialRxLevel,
+    recordTxLevel: (level: Tec1gSerialLevel): void => {
+      if (serialLevel === level) {
+        return;
+      }
+      serialLevel = level;
+      serialDecoder.recordLevel(serialLevel);
+    },
+    queueSerial: (bytes: number[]): void => {
+      if (bytes.length === 0) {
+        return;
+      }
+      if (!serialRxPrimed) {
+        // Prime RX once so the first real byte is aligned to the ROM's bitbang receiver.
+        serialRxQueue.push(0);
+        serialRxPrimed = true;
+      }
+      for (const value of bytes) {
+        serialRxQueue.push(value & TEC1G_MASK_BYTE);
+      }
+      if (!serialRxBusy) {
+        serialRxPending = true;
+      }
+    },
+    maybeStartQueuedRx,
+    setClockHz: (hz: number): void => {
+      if (hz <= 0) {
+        return;
+      }
+      serialDecoder.setCyclesPerSecond(hz);
+      serialCyclesPerBit = hz / TEC1G_SERIAL_BAUD;
+    },
+    reset: (): void => {
+      serialRxQueue.length = 0;
+      serialRxBusy = false;
+      serialRxPrimed = false;
+      serialRxLeadCycles = 0;
+      serialRxPending = false;
+      serialRxToken += 1;
+      setSerialRxLevel(1);
+    },
+  };
+}

--- a/tests/platforms/tec1g/serial.test.ts
+++ b/tests/platforms/tec1g/serial.test.ts
@@ -1,39 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { createTec1gRuntime } from '../../../src/platforms/tec1g/runtime';
-import type { Tec1gPlatformConfigNormalized } from '../../../src/platforms/types';
-
-function makeRuntime(onByte: (byte: number) => void) {
-  const config: Tec1gPlatformConfigNormalized = {
-    regions: [
-      { start: 0x0000, end: 0x7fff, kind: 'ram' as const },
-      { start: 0xc000, end: 0xffff, kind: 'rom' as const },
-    ],
-    romRanges: [{ start: 0xc000, end: 0xffff }],
-    appStart: 0x0000,
-    entry: 0x0000,
-    updateMs: 100,
-    yieldMs: 0,
-    gimpSignal: false,
-    expansionBankHi: false,
-    matrixMode: false,
-    protectOnReset: false,
-    rtcEnabled: false,
-    sdEnabled: false,
-    sdHighCapacity: true,
-  };
-  return createTec1gRuntime(config, () => {}, onByte);
-}
+import { CycleClock } from '../../../src/platforms/cycle-clock';
+import { TEC_FAST_HZ } from '../../../src/platforms/tec-common';
+import { createTec1gSerialController } from '../../../src/platforms/tec1g/serial';
 
 describe('TEC-1G serial bitbang', () => {
   it('decodes a transmitted byte on TX line', () => {
     const bytes: number[] = [];
-    const rt = makeRuntime((byte) => bytes.push(byte));
-    const cyclesPerBit = rt.state.clockHz / 4800;
+    const clock = new CycleClock();
+    const serial = createTec1gSerialController(clock, TEC_FAST_HZ, (byte) => bytes.push(byte));
+    const cyclesPerBit = TEC_FAST_HZ / 4800;
     const writeSerial = (level: 0 | 1): void => {
-      rt.ioHandlers.write(0x01, level ? 0x40 : 0x00);
+      serial.recordTxLevel(level);
     };
     const advance = (): void => {
-      rt.recordCycles(Math.ceil(cyclesPerBit));
+      clock.advance(Math.ceil(cyclesPerBit));
     };
 
     const value = 0x55;
@@ -48,7 +28,7 @@ describe('TEC-1G serial bitbang', () => {
     writeSerial(1); // stop bits
     advance();
     advance();
-    rt.recordCycles(Math.ceil(cyclesPerBit * 4));
+    clock.advance(Math.ceil(cyclesPerBit * 4));
 
     expect(bytes).toEqual([value]);
   });


### PR DESCRIPTION
Closes #93

## Summary
- extract TEC-1G serial bitbang scheduling into src/platforms/tec1g/serial.ts
- keep src/platforms/tec1g/runtime.ts as the orchestrator that wires the serial controller into the TEC-1G bus
- update tests/platforms/tec1g/serial.test.ts to exercise the controller directly

## Testing
- npx vitest run tests/platforms/tec1g/serial.test.ts
- npx eslint src/platforms/tec1g/runtime.ts src/platforms/tec1g/serial.ts tests/platforms/tec1g/serial.test.ts
- npm test

## Deferred extraction points
- HD44780 LCD state machine
- ST7920 GLCD state machine
- keypad / matrix scan handling
- memory controller / banking / shadow / cartridge logic

This PR intentionally keeps those responsibilities inside runtime.ts for a later, separate slice so the change stays small and reviewable.