### PR TITLE
Refactor platform view message routing

### DIFF
--- a/src/extension/platform-view-messages.ts
+++ b/src/extension/platform-view-messages.ts
@@ -1,0 +1,54 @@
+/**
+ * @file Message routing helpers for the Debug80 platform view webview.
+ */
+
+import type { Tec1Message } from '../platforms/tec1/ui-panel-messages';
+import type { Tec1gMessage } from '../platforms/tec1g/ui-panel-messages';
+
+export type PlatformViewPlatform = 'tec1' | 'tec1g' | 'simple';
+
+export type PlatformViewMessage = Tec1Message | Tec1gMessage | { type?: string; text?: string };
+
+export interface PlatformViewMessageDependencies {
+  currentPlatform: () => PlatformViewPlatform | undefined;
+  handleStartDebug: () => PromiseLike<void>;
+  handleSerialSendFile: () => PromiseLike<void>;
+  handleSerialSave: (text: string) => PromiseLike<void>;
+  clearSerialBuffer: (platform: Exclude<PlatformViewPlatform, 'simple'>) => void;
+  handleTec1Message: (msg: Tec1Message) => PromiseLike<void>;
+  handleTec1gMessage: (msg: Tec1gMessage) => PromiseLike<void>;
+}
+
+export async function handlePlatformViewMessage(
+  msg: PlatformViewMessage,
+  deps: PlatformViewMessageDependencies
+): Promise<void> {
+  if (msg?.type === 'startDebug') {
+    await deps.handleStartDebug();
+    return;
+  }
+  if (msg?.type === 'serialSendFile') {
+    await deps.handleSerialSendFile();
+    return;
+  }
+  if (msg?.type === 'serialSave' && typeof msg.text === 'string') {
+    await deps.handleSerialSave(msg.text);
+    return;
+  }
+  if (msg?.type === 'serialClear') {
+    const platform = deps.currentPlatform();
+    if (platform === 'tec1' || platform === 'tec1g') {
+      deps.clearSerialBuffer(platform);
+    }
+    return;
+  }
+
+  const platform = deps.currentPlatform();
+  if (platform === 'tec1') {
+    await deps.handleTec1Message(msg as Tec1Message);
+    return;
+  }
+  if (platform === 'tec1g') {
+    await deps.handleTec1gMessage(msg as Tec1gMessage);
+  }
+}

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -7,7 +7,7 @@ import { getTec1Html } from '../platforms/tec1/ui-panel-html';
 import {
   createMemoryViewState as createTec1MemoryViewState,
 } from '../platforms/tec1/ui-panel-memory';
-import { handleTec1Message, Tec1Message } from '../platforms/tec1/ui-panel-messages';
+import { handleTec1Message } from '../platforms/tec1/ui-panel-messages';
 import {
   createRefreshController as createTec1RefreshController,
   refreshSnapshot as refreshTec1Snapshot,
@@ -25,7 +25,7 @@ import { getTec1gHtml } from '../platforms/tec1g/ui-panel-html';
 import {
   createMemoryViewState as createTec1gMemoryViewState,
 } from '../platforms/tec1g/ui-panel-memory';
-import { handleTec1gMessage, Tec1gMessage } from '../platforms/tec1g/ui-panel-messages';
+import { handleTec1gMessage } from '../platforms/tec1g/ui-panel-messages';
 import {
   createRefreshController as createTec1gRefreshController,
   refreshSnapshot as refreshTec1gSnapshot,
@@ -41,14 +41,17 @@ import { appendSerialText as appendTec1gSerialText, clearSerialBuffer as clearTe
 import type { Tec1gUpdatePayload } from '../platforms/tec1g/types';
 import { type MemoryViewState } from '../platforms/panel-memory';
 import { type PanelTab } from '../platforms/panel-html';
-
-type PlatformId = 'tec1' | 'tec1g' | 'simple';
+import {
+  handlePlatformViewMessage,
+  type PlatformViewMessage,
+  type PlatformViewPlatform,
+} from './platform-view-messages';
 
 export class PlatformViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'debug80.platformView';
 
   private view: vscode.WebviewView | undefined;
-  private currentPlatform: PlatformId | undefined;
+  private currentPlatform: PlatformViewPlatform | undefined;
   private currentSession: vscode.DebugSession | undefined;
   private currentSessionId: string | undefined;
   private uiRevision = 0;
@@ -110,7 +113,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   }
 
   setPlatform(
-    platform: PlatformId,
+    platform: PlatformViewPlatform,
     session?: vscode.DebugSession,
     options?: { focus?: boolean; reveal?: boolean; tab?: PanelTab }
   ): void {
@@ -275,52 +278,44 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'out', 'webview')],
     };
 
-    webviewView.webview.onDidReceiveMessage(async (msg: Tec1Message | Tec1gMessage | { type?: string; text?: string }) => {
-      if (msg?.type === 'startDebug') {
-        await vscode.commands.executeCommand('workbench.action.debug.start');
-        return;
-      }
-      if (msg?.type === 'serialSendFile') {
-        await this.handleSerialSendFile();
-        return;
-      }
-      if (msg?.type === 'serialSave' && typeof msg.text === 'string') {
-        await this.handleSerialSave(msg.text);
-        return;
-      }
-      if (msg?.type === 'serialClear') {
-        if (this.currentPlatform === 'tec1') {
-          clearSerialBuffer(this.tec1SerialBuffer);
-        } else if (this.currentPlatform === 'tec1g') {
-          clearTec1gSerialBuffer(this.tec1gSerialBuffer);
-        }
-        return;
-      }
-      if (this.currentPlatform === 'tec1') {
-        await handleTec1Message(msg as Tec1Message, {
-          getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
-          refreshController: this.tec1RefreshController,
-          autoRefreshMs: 150,
-          setActiveTab: (tab) => {
-            this.tec1ActiveTab = tab;
-          },
-          getActiveTab: () => this.tec1ActiveTab,
-          isPanelVisible: () => this.view?.visible === true,
-          memoryViews: this.tec1MemoryViews,
-        });
-      } else if (this.currentPlatform === 'tec1g') {
-        await handleTec1gMessage(msg as Tec1gMessage, {
-          getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
-          refreshController: this.tec1gRefreshController,
-          autoRefreshMs: 150,
-          setActiveTab: (tab) => {
-            this.tec1gActiveTab = tab;
-          },
-          getActiveTab: () => this.tec1gActiveTab,
-          isPanelVisible: () => this.view?.visible === true,
-          memoryViews: this.tec1gMemoryViews,
-        });
-      }
+    webviewView.webview.onDidReceiveMessage((msg: PlatformViewMessage) => {
+      void handlePlatformViewMessage(msg, {
+        currentPlatform: () => this.currentPlatform,
+        handleStartDebug: () => vscode.commands.executeCommand('workbench.action.debug.start'),
+        handleSerialSendFile: () => this.handleSerialSendFile(),
+        handleSerialSave: (text) => this.handleSerialSave(text),
+        clearSerialBuffer: (platform) => {
+          if (platform === 'tec1') {
+            clearSerialBuffer(this.tec1SerialBuffer);
+          } else {
+            clearTec1gSerialBuffer(this.tec1gSerialBuffer);
+          }
+        },
+        handleTec1Message: async (message) =>
+          handleTec1Message(message, {
+            getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
+            refreshController: this.tec1RefreshController,
+            autoRefreshMs: 150,
+            setActiveTab: (tab) => {
+              this.tec1ActiveTab = tab;
+            },
+            getActiveTab: () => this.tec1ActiveTab,
+            isPanelVisible: () => this.view?.visible === true,
+            memoryViews: this.tec1MemoryViews,
+          }),
+        handleTec1gMessage: async (message) =>
+          handleTec1gMessage(message, {
+            getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
+            refreshController: this.tec1gRefreshController,
+            autoRefreshMs: 150,
+            setActiveTab: (tab) => {
+              this.tec1gActiveTab = tab;
+            },
+            getActiveTab: () => this.tec1gActiveTab,
+            isPanelVisible: () => this.view?.visible === true,
+            memoryViews: this.tec1gMemoryViews,
+          }),
+      });
     });
 
     webviewView.onDidDispose(() => {

--- a/tests/extension/platform-view-messages.test.ts
+++ b/tests/extension/platform-view-messages.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @file Message routing tests for the Debug80 platform view webview.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { handlePlatformViewMessage } from '../../src/extension/platform-view-messages';
+import type { Tec1Message } from '../../src/platforms/tec1/ui-panel-messages';
+import type { Tec1gMessage } from '../../src/platforms/tec1g/ui-panel-messages';
+
+function createDependencies(platform: 'simple' | 'tec1' | 'tec1g' | undefined) {
+  return {
+    currentPlatform: vi.fn(() => platform),
+    handleStartDebug: vi.fn(() => undefined),
+    handleSerialSendFile: vi.fn(() => undefined),
+    handleSerialSave: vi.fn(() => undefined),
+    clearSerialBuffer: vi.fn(() => undefined),
+    handleTec1Message: vi.fn(() => undefined),
+    handleTec1gMessage: vi.fn(() => undefined),
+  };
+}
+
+describe('platform-view message routing', () => {
+  it('routes control messages to the expected handlers', async () => {
+    const deps = createDependencies('simple');
+
+    await handlePlatformViewMessage({ type: 'startDebug' }, deps);
+    await handlePlatformViewMessage({ type: 'serialSendFile' }, deps);
+    await handlePlatformViewMessage({ type: 'serialSave', text: 'hello' }, deps);
+
+    expect(deps.handleStartDebug).toHaveBeenCalledTimes(1);
+    expect(deps.handleSerialSendFile).toHaveBeenCalledTimes(1);
+    expect(deps.handleSerialSave).toHaveBeenCalledWith('hello');
+  });
+
+  it('clears the active serial buffer for TEC-1 and TEC-1G', async () => {
+    const tec1Deps = createDependencies('tec1');
+    const tec1gDeps = createDependencies('tec1g');
+
+    await handlePlatformViewMessage({ type: 'serialClear' }, tec1Deps);
+    await handlePlatformViewMessage({ type: 'serialClear' }, tec1gDeps);
+
+    expect(tec1Deps.clearSerialBuffer).toHaveBeenCalledWith('tec1');
+    expect(tec1gDeps.clearSerialBuffer).toHaveBeenCalledWith('tec1g');
+  });
+
+  it('routes platform payloads to the active platform handler', async () => {
+    const tec1Deps = createDependencies('tec1');
+    const tec1gDeps = createDependencies('tec1g');
+
+    const tec1Message = { type: 'update' } as Tec1Message;
+    const tec1gMessage = { type: 'update' } as Tec1gMessage;
+
+    await handlePlatformViewMessage(tec1Message, tec1Deps);
+    await handlePlatformViewMessage(tec1gMessage, tec1gDeps);
+
+    expect(tec1Deps.handleTec1Message).toHaveBeenCalledWith(tec1Message);
+    expect(tec1gDeps.handleTec1gMessage).toHaveBeenCalledWith(tec1gMessage);
+  });
+
+  it('ignores serialClear for idle simple view state', async () => {
+    const deps = createDependencies('simple');
+
+    await handlePlatformViewMessage({ type: 'serialClear' }, deps);
+
+    expect(deps.clearSerialBuffer).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Extract the platform-view webview message routing from `src/extension/platform-view-provider.ts` into `src/extension/platform-view-messages.ts`.

## Files changed
- `src/extension/platform-view-provider.ts`
- `src/extension/platform-view-messages.ts`
- `tests/extension/platform-view-messages.test.ts`

## Verification
- `./node_modules/.bin/eslint src/extension/platform-view-provider.ts src/extension/platform-view-messages.ts tests/extension/platform-view-messages.test.ts`
- `./node_modules/.bin/vitest run tests/extension/platform-view-messages.test.ts`
- `npm test`

## Deferred follow-ups
- Webview HTML/render assembly extraction
- Tab/state persistence extraction
- Snapshot/request orchestration extraction
- Per-platform coordination cleanup

This PR is intentionally limited to one reviewable responsibility slice.