### PR TITLE
Extract TEC-1G LCD controller

### DIFF
--- a/src/platforms/tec1g/lcd.ts
+++ b/src/platforms/tec1g/lcd.ts
@@ -1,0 +1,308 @@
+/**
+ * @file TEC-1G HD44780 LCD controller.
+ */
+
+import { CycleClock } from '../cycle-clock';
+import { microsecondsToClocks } from '../tec-common';
+import {
+  LCD_BLINK_ON,
+  LCD_CMD_CGRAM,
+  LCD_CMD_CLEAR,
+  LCD_CMD_DDRAM,
+  LCD_CMD_DISPLAY,
+  LCD_CMD_ENTRY_MODE,
+  LCD_CMD_FUNCTION,
+  LCD_CMD_HOME,
+  LCD_CMD_SHIFT,
+  LCD_CURSOR_ON,
+  LCD_DISPLAY_MASK,
+  LCD_DISPLAY_ON,
+  LCD_ENTRY_INCREMENT,
+  LCD_ENTRY_MODE_MASK,
+  LCD_ENTRY_SHIFT,
+  LCD_FUNC_2LINE,
+  LCD_FUNC_8BIT,
+  LCD_FUNC_FONT5X8,
+  LCD_FUNCTION_MASK,
+  LCD_SHIFT_DISPLAY,
+  LCD_SHIFT_MASK,
+  LCD_SHIFT_RIGHT,
+  LCD_STATUS_BUSY,
+  TEC1G_LCD_ROW0_END,
+  TEC1G_LCD_ROW0_START,
+  TEC1G_LCD_ROW1_END,
+  TEC1G_LCD_ROW1_OFFSET,
+  TEC1G_LCD_ROW1_START,
+  TEC1G_LCD_ROW2_END,
+  TEC1G_LCD_ROW2_OFFSET,
+  TEC1G_LCD_ROW2_START,
+  TEC1G_LCD_ROW3_END,
+  TEC1G_LCD_ROW3_OFFSET,
+  TEC1G_LCD_ROW3_START,
+  TEC1G_LCD_SPACE,
+  TEC1G_MASK_BYTE,
+  TEC1G_MASK_LOW6,
+  TEC1G_MASK_LOW7,
+} from './constants';
+
+export interface Tec1gLcdFunctionState {
+  dataLength8: boolean;
+  lines2: boolean;
+  font5x8: boolean;
+}
+
+export interface Tec1gLcdState {
+  lcd: number[];
+  lcdAddr: number;
+  lcdAddrMode: 'ddram' | 'cgram';
+  lcdEntryIncrement: boolean;
+  lcdEntryShift: boolean;
+  lcdDisplayOn: boolean;
+  lcdCursorOn: boolean;
+  lcdCursorBlink: boolean;
+  lcdDisplayShift: number;
+  lcdCgram: Uint8Array;
+  lcdCgramAddr: number;
+  lcdFunction: Tec1gLcdFunctionState;
+}
+
+export interface Tec1gLcdController {
+  readStatus(): number;
+  readData(): number;
+  writeCommand(instruction: number): void;
+  writeData(value: number): void;
+  setClockHz(hz: number): void;
+  reset(): void;
+}
+
+/**
+ * Creates the TEC-1G HD44780 LCD controller.
+ */
+export function createTec1gLcdController(
+  state: Tec1gLcdState,
+  cycleClock: CycleClock,
+  clockHz: number,
+  onUpdate: () => void
+): Tec1gLcdController {
+  let lcdBusyUntil = 0;
+  let currentClockHz = clockHz;
+
+  const LCD_BUSY_US = 37;
+  const LCD_BUSY_CLEAR_US = 1600;
+
+  const lcdIndexForAddr = (addr: number): number | null => {
+    if (addr >= TEC1G_LCD_ROW0_START && addr <= TEC1G_LCD_ROW0_END) {
+      return addr - TEC1G_LCD_ROW0_START;
+    }
+    if (addr >= TEC1G_LCD_ROW1_START && addr <= TEC1G_LCD_ROW1_END) {
+      return TEC1G_LCD_ROW1_OFFSET + (addr - TEC1G_LCD_ROW1_START);
+    }
+    if (addr >= TEC1G_LCD_ROW2_START && addr <= TEC1G_LCD_ROW2_END) {
+      return TEC1G_LCD_ROW2_OFFSET + (addr - TEC1G_LCD_ROW2_START);
+    }
+    if (addr >= TEC1G_LCD_ROW3_START && addr <= TEC1G_LCD_ROW3_END) {
+      return TEC1G_LCD_ROW3_OFFSET + (addr - TEC1G_LCD_ROW3_START);
+    }
+    return null;
+  };
+
+  const lcdAddrForIndex = (index: number): number => {
+    if (index < TEC1G_LCD_ROW1_OFFSET) {
+      return TEC1G_LCD_ROW0_START + index;
+    }
+    if (index < TEC1G_LCD_ROW2_OFFSET) {
+      return TEC1G_LCD_ROW1_START + (index - TEC1G_LCD_ROW1_OFFSET);
+    }
+    if (index < TEC1G_LCD_ROW3_OFFSET) {
+      return TEC1G_LCD_ROW2_START + (index - TEC1G_LCD_ROW2_OFFSET);
+    }
+    return TEC1G_LCD_ROW3_START + (index - TEC1G_LCD_ROW3_OFFSET);
+  };
+
+  const lcdAdvanceAddr = (addr: number, increment: boolean): number => {
+    const masked = addr & TEC1G_MASK_BYTE;
+    const index = lcdIndexForAddr(masked);
+    if (index !== null) {
+      const next = (index + (increment ? 1 : -1) + state.lcd.length) % state.lcd.length;
+      return lcdAddrForIndex(next);
+    }
+    return (masked + (increment ? 1 : -1)) & TEC1G_MASK_BYTE;
+  };
+
+  const lcdAdvanceCgramAddr = (addr: number, increment: boolean): number => {
+    const delta = increment ? 1 : -1;
+    return (addr + delta + state.lcdCgram.length) & TEC1G_MASK_LOW6;
+  };
+
+  const shiftLcdDisplay = (delta: number): void => {
+    const next = (state.lcdDisplayShift + delta + 20) % 20;
+    if (next !== state.lcdDisplayShift) {
+      state.lcdDisplayShift = next;
+      onUpdate();
+    }
+  };
+
+  const lcdSetBusy = (microseconds: number): void => {
+    const cycles = microsecondsToClocks(currentClockHz, microseconds);
+    const until = cycleClock.now() + cycles;
+    if (until > lcdBusyUntil) {
+      lcdBusyUntil = until;
+    }
+  };
+
+  const lcdIsBusy = (): boolean => cycleClock.now() < lcdBusyUntil;
+
+  const lcdSetAddr = (addr: number): void => {
+    state.lcdAddr = addr & TEC1G_MASK_BYTE;
+    state.lcdAddrMode = 'ddram';
+  };
+
+  const lcdClear = (): void => {
+    state.lcd.fill(TEC1G_LCD_SPACE);
+    lcdSetAddr(TEC1G_LCD_ROW0_START);
+    state.lcdDisplayShift = 0;
+    onUpdate();
+    lcdSetBusy(LCD_BUSY_CLEAR_US);
+  };
+
+  const lcdWriteData = (value: number): void => {
+    if (state.lcdAddrMode === 'cgram') {
+      const addr = state.lcdCgramAddr & TEC1G_MASK_LOW6;
+      state.lcdCgram[addr] = value & TEC1G_MASK_BYTE;
+      state.lcdCgramAddr = lcdAdvanceCgramAddr(state.lcdCgramAddr, state.lcdEntryIncrement);
+      lcdSetBusy(LCD_BUSY_US);
+      return;
+    }
+    const index = lcdIndexForAddr(state.lcdAddr);
+    if (index !== null) {
+      state.lcd[index] = value & TEC1G_MASK_BYTE;
+      onUpdate();
+    }
+    state.lcdAddr = lcdAdvanceAddr(state.lcdAddr, state.lcdEntryIncrement);
+    if (state.lcdEntryShift) {
+      shiftLcdDisplay(state.lcdEntryIncrement ? 1 : -1);
+    }
+    lcdSetBusy(LCD_BUSY_US);
+  };
+
+  const lcdReadData = (): number => {
+    if (state.lcdAddrMode === 'cgram') {
+      const addr = state.lcdCgramAddr & TEC1G_MASK_LOW6;
+      const value = state.lcdCgram[addr] ?? 0;
+      state.lcdCgramAddr = lcdAdvanceCgramAddr(state.lcdCgramAddr, state.lcdEntryIncrement);
+      lcdSetBusy(LCD_BUSY_US);
+      return value & TEC1G_MASK_BYTE;
+    }
+    const index = lcdIndexForAddr(state.lcdAddr);
+    const value =
+      index !== null ? (state.lcd[index] ?? TEC1G_LCD_SPACE) : TEC1G_LCD_SPACE;
+    state.lcdAddr = lcdAdvanceAddr(state.lcdAddr, state.lcdEntryIncrement);
+    if (state.lcdEntryShift) {
+      shiftLcdDisplay(state.lcdEntryIncrement ? 1 : -1);
+    }
+    lcdSetBusy(LCD_BUSY_US);
+    return value & TEC1G_MASK_BYTE;
+  };
+
+  const lcdReadStatus = (): number => {
+    const busy = lcdIsBusy() ? LCD_STATUS_BUSY : 0;
+    const addr =
+      state.lcdAddrMode === 'cgram'
+        ? state.lcdCgramAddr & TEC1G_MASK_LOW6
+        : state.lcdAddr & TEC1G_MASK_LOW7;
+    return busy | addr;
+  };
+
+  const lcdWriteCommand = (instruction: number): void => {
+    if (instruction === LCD_CMD_CLEAR) {
+      lcdClear();
+      return;
+    }
+    if (instruction === LCD_CMD_HOME) {
+      lcdSetAddr(LCD_CMD_DDRAM);
+      state.lcdDisplayShift = 0;
+      lcdSetBusy(LCD_BUSY_CLEAR_US);
+      return;
+    }
+    if ((instruction & LCD_CMD_DDRAM) !== 0) {
+      lcdSetAddr(instruction);
+      lcdSetBusy(LCD_BUSY_US);
+      return;
+    }
+    if ((instruction & LCD_CMD_CGRAM) !== 0) {
+      state.lcdCgramAddr = instruction & TEC1G_MASK_LOW6;
+      state.lcdAddrMode = 'cgram';
+      lcdSetBusy(LCD_BUSY_US);
+      return;
+    }
+    if ((instruction & LCD_ENTRY_MODE_MASK) === LCD_CMD_ENTRY_MODE) {
+      state.lcdEntryIncrement = (instruction & LCD_ENTRY_INCREMENT) !== 0;
+      state.lcdEntryShift = (instruction & LCD_ENTRY_SHIFT) !== 0;
+      lcdSetBusy(LCD_BUSY_US);
+      return;
+    }
+    if ((instruction & LCD_DISPLAY_MASK) === LCD_CMD_DISPLAY) {
+      state.lcdDisplayOn = (instruction & LCD_DISPLAY_ON) !== 0;
+      state.lcdCursorOn = (instruction & LCD_CURSOR_ON) !== 0;
+      state.lcdCursorBlink = (instruction & LCD_BLINK_ON) !== 0;
+      onUpdate();
+      lcdSetBusy(LCD_BUSY_US);
+      return;
+    }
+    if ((instruction & LCD_SHIFT_MASK) === LCD_CMD_SHIFT) {
+      const displayShift = (instruction & LCD_SHIFT_DISPLAY) !== 0;
+      const shiftRight = (instruction & LCD_SHIFT_RIGHT) !== 0;
+      if (displayShift) {
+        shiftLcdDisplay(shiftRight ? 1 : -1);
+      } else {
+        state.lcdAddrMode = 'ddram';
+        state.lcdAddr = lcdAdvanceAddr(state.lcdAddr, shiftRight);
+      }
+      lcdSetBusy(LCD_BUSY_US);
+      return;
+    }
+    if ((instruction & LCD_FUNCTION_MASK) === LCD_CMD_FUNCTION) {
+      state.lcdFunction = {
+        dataLength8: (instruction & LCD_FUNC_8BIT) !== 0,
+        lines2: (instruction & LCD_FUNC_2LINE) !== 0,
+        font5x8: (instruction & LCD_FUNC_FONT5X8) === 0,
+      };
+      lcdSetBusy(LCD_BUSY_US);
+      return;
+    }
+    lcdSetBusy(LCD_BUSY_US);
+  };
+
+  const reset = (): void => {
+    state.lcd.fill(TEC1G_LCD_SPACE);
+    state.lcdAddr = TEC1G_LCD_ROW0_START;
+    state.lcdAddrMode = 'ddram';
+    state.lcdEntryIncrement = true;
+    state.lcdEntryShift = false;
+    state.lcdDisplayOn = true;
+    state.lcdCursorOn = false;
+    state.lcdCursorBlink = false;
+    state.lcdDisplayShift = 0;
+    state.lcdCgram.fill(0);
+    state.lcdCgramAddr = 0;
+    state.lcdFunction = {
+      dataLength8: true,
+      lines2: true,
+      font5x8: true,
+    };
+    lcdBusyUntil = 0;
+  };
+
+  return {
+    readStatus: lcdReadStatus,
+    readData: lcdReadData,
+    writeCommand: lcdWriteCommand,
+    writeData: lcdWriteData,
+    setClockHz: (hz: number): void => {
+      if (hz > 0) {
+        currentClockHz = hz;
+      }
+    },
+    reset,
+  };
+}

--- a/src/platforms/tec1g/runtime.ts
+++ b/src/platforms/tec1g/runtime.ts
@@ -14,6 +14,7 @@ import { Tec1gSpeedMode, Tec1gUpdatePayload } from './types';
 import { decodeSysCtrl } from './sysctrl';
 import { Ds1302 } from './ds1302';
 import { SdSpi } from './sd-spi';
+import { createTec1gLcdController } from './lcd';
 import { createTec1gSerialController } from './serial';
 import {
   TEC1G_DIGIT_SERIAL_TX,
@@ -46,29 +47,6 @@ import {
   GLCD_SHIFT_DISPLAY,
   GLCD_SHIFT_RIGHT,
   GLCD_STATUS_BUSY,
-  LCD_STATUS_BUSY,
-  LCD_CMD_CGRAM,
-  LCD_CMD_CLEAR,
-  LCD_CMD_DDRAM,
-  LCD_CMD_DISPLAY,
-  LCD_CMD_ENTRY_MODE,
-  LCD_DISPLAY_MASK,
-  LCD_ENTRY_MODE_MASK,
-  LCD_CMD_FUNCTION,
-  LCD_FUNCTION_MASK,
-  LCD_CMD_HOME,
-  LCD_CMD_SHIFT,
-  LCD_SHIFT_MASK,
-  LCD_BLINK_ON,
-  LCD_CURSOR_ON,
-  LCD_DISPLAY_ON,
-  LCD_ENTRY_INCREMENT,
-  LCD_ENTRY_SHIFT,
-  LCD_FUNC_2LINE,
-  LCD_FUNC_8BIT,
-  LCD_FUNC_FONT5X8,
-  LCD_SHIFT_DISPLAY,
-  LCD_SHIFT_RIGHT,
   TEC1G_PORT_DIGIT,
   TEC1G_PORT_GLCD_CMD,
   TEC1G_PORT_GLCD_DATA,
@@ -108,17 +86,7 @@ import {
   TEC1G_GLCD_ROW_MASK,
   TEC1G_GLCD_ROW_STRIDE,
   TEC1G_GLCD_COL_STRIDE,
-  TEC1G_LCD_ROW0_END,
   TEC1G_LCD_ROW0_START,
-  TEC1G_LCD_ROW1_END,
-  TEC1G_LCD_ROW1_OFFSET,
-  TEC1G_LCD_ROW1_START,
-  TEC1G_LCD_ROW2_END,
-  TEC1G_LCD_ROW2_OFFSET,
-  TEC1G_LCD_ROW2_START,
-  TEC1G_LCD_ROW3_END,
-  TEC1G_LCD_ROW3_OFFSET,
-  TEC1G_LCD_ROW3_START,
   TEC1G_LCD_SPACE,
   TEC1G_MASK_BYTE,
   TEC1G_MASK_LOW7,
@@ -147,8 +115,8 @@ import {
   calculateSpeakerFrequency,
   calculateKeyHoldCycles,
   shouldUpdate,
-  microsecondsToClocks,
   millisecondsToClocks,
+  microsecondsToClocks,
 } from '../tec-common';
 
 /**
@@ -250,8 +218,6 @@ export const TEC1G_SLOW_HZ = TEC_SLOW_HZ;
 export const TEC1G_FAST_HZ = TEC_FAST_HZ;
 const TEC1G_SILENCE_CYCLES = TEC_SILENCE_CYCLES;
 const TEC1G_KEY_HOLD_MS = TEC_KEY_HOLD_MS;
-const TEC1G_LCD_BUSY_US = 37;
-const TEC1G_LCD_BUSY_CLEAR_US = 1600;
 const TEC1G_GLCD_BUSY_US = 72;
 const TEC1G_GLCD_BUSY_CLEAR_US = 1600;
 const TEC1G_GLCD_BLINK_MS = 400;
@@ -470,7 +436,6 @@ export function createTec1gRuntime(
     state.lcd[lcdTest.length + 2] = TEC1G_LCD_ARROW_RIGHT;
   }
 
-  let lcdBusyUntil = 0;
   let glcdBusyUntil = 0;
 
   const sendUpdate = (): void => {
@@ -728,131 +693,10 @@ export function createTec1gRuntime(
     sendUpdate();
   };
 
+  const lcd = createTec1gLcdController(state, state.cycleClock, state.clockHz, queueUpdate);
+
   const updateDisplay = (): void => {
     if (updateDisplayDigits(state.digits, state.digitLatch, state.segmentLatch)) {
-      queueUpdate();
-    }
-  };
-
-  const lcdIndexForAddr = (addr: number): number | null => {
-    if (addr >= TEC1G_LCD_ROW0_START && addr <= TEC1G_LCD_ROW0_END) {
-      return addr - TEC1G_LCD_ROW0_START;
-    }
-    if (addr >= TEC1G_LCD_ROW1_START && addr <= TEC1G_LCD_ROW1_END) {
-      return TEC1G_LCD_ROW1_OFFSET + (addr - TEC1G_LCD_ROW1_START);
-    }
-    if (addr >= TEC1G_LCD_ROW2_START && addr <= TEC1G_LCD_ROW2_END) {
-      return TEC1G_LCD_ROW2_OFFSET + (addr - TEC1G_LCD_ROW2_START);
-    }
-    if (addr >= TEC1G_LCD_ROW3_START && addr <= TEC1G_LCD_ROW3_END) {
-      return TEC1G_LCD_ROW3_OFFSET + (addr - TEC1G_LCD_ROW3_START);
-    }
-    return null;
-  };
-
-  const lcdSetBusy = (microseconds: number): void => {
-    const cycles = microsecondsToClocks(state.clockHz, microseconds);
-    const until = state.cycleClock.now() + cycles;
-    if (until > lcdBusyUntil) {
-      lcdBusyUntil = until;
-    }
-  };
-
-  const lcdIsBusy = (): boolean => state.cycleClock.now() < lcdBusyUntil;
-
-  const lcdReadStatus = (): number => {
-    const busy = lcdIsBusy() ? LCD_STATUS_BUSY : 0;
-    const addr =
-      state.lcdAddrMode === 'cgram'
-        ? state.lcdCgramAddr & TEC1G_MASK_LOW6
-        : state.lcdAddr & TEC1G_MASK_LOW7;
-    return busy | addr;
-  };
-
-  const lcdSetAddr = (addr: number): void => {
-    state.lcdAddr = addr & TEC1G_MASK_BYTE;
-    state.lcdAddrMode = 'ddram';
-  };
-
-  const lcdWriteData = (value: number): void => {
-    if (state.lcdAddrMode === 'cgram') {
-      const addr = state.lcdCgramAddr & TEC1G_MASK_LOW6;
-      state.lcdCgram[addr] = value & TEC1G_MASK_BYTE;
-      state.lcdCgramAddr = lcdAdvanceCgramAddr(state.lcdCgramAddr, state.lcdEntryIncrement);
-      lcdSetBusy(TEC1G_LCD_BUSY_US);
-      return;
-    }
-    const index = lcdIndexForAddr(state.lcdAddr);
-    if (index !== null) {
-      state.lcd[index] = value & TEC1G_MASK_BYTE;
-      queueUpdate();
-    }
-    state.lcdAddr = lcdAdvanceAddr(state.lcdAddr, state.lcdEntryIncrement);
-    if (state.lcdEntryShift) {
-      shiftLcdDisplay(state.lcdEntryIncrement ? 1 : -1);
-    }
-    lcdSetBusy(TEC1G_LCD_BUSY_US);
-  };
-
-  const lcdReadData = (): number => {
-    if (state.lcdAddrMode === 'cgram') {
-      const addr = state.lcdCgramAddr & TEC1G_MASK_LOW6;
-      const value = state.lcdCgram[addr] ?? 0;
-      state.lcdCgramAddr = lcdAdvanceCgramAddr(state.lcdCgramAddr, state.lcdEntryIncrement);
-      lcdSetBusy(TEC1G_LCD_BUSY_US);
-      return value & TEC1G_MASK_BYTE;
-    }
-    const index = lcdIndexForAddr(state.lcdAddr);
-    const value =
-      index !== null ? (state.lcd[index] ?? TEC1G_LCD_SPACE) : TEC1G_LCD_SPACE;
-    state.lcdAddr = lcdAdvanceAddr(state.lcdAddr, state.lcdEntryIncrement);
-    if (state.lcdEntryShift) {
-      shiftLcdDisplay(state.lcdEntryIncrement ? 1 : -1);
-    }
-    lcdSetBusy(TEC1G_LCD_BUSY_US);
-    return value & TEC1G_MASK_BYTE;
-  };
-
-  const lcdClear = (): void => {
-    state.lcd.fill(TEC1G_LCD_SPACE);
-    lcdSetAddr(TEC1G_LCD_ROW0_START);
-    state.lcdDisplayShift = 0;
-    queueUpdate();
-    lcdSetBusy(TEC1G_LCD_BUSY_CLEAR_US);
-  };
-
-  const lcdAdvanceAddr = (addr: number, increment: boolean): number => {
-    const masked = addr & TEC1G_MASK_BYTE;
-    const index = lcdIndexForAddr(masked);
-    if (index !== null) {
-      const next = (index + (increment ? 1 : -1) + state.lcd.length) % state.lcd.length;
-      return lcdAddrForIndex(next);
-    }
-    return (masked + (increment ? 1 : -1)) & TEC1G_MASK_BYTE;
-  };
-
-  const lcdAddrForIndex = (index: number): number => {
-    if (index < TEC1G_LCD_ROW1_OFFSET) {
-      return TEC1G_LCD_ROW0_START + index;
-    }
-    if (index < TEC1G_LCD_ROW2_OFFSET) {
-      return TEC1G_LCD_ROW1_START + (index - TEC1G_LCD_ROW1_OFFSET);
-    }
-    if (index < TEC1G_LCD_ROW3_OFFSET) {
-      return TEC1G_LCD_ROW2_START + (index - TEC1G_LCD_ROW2_OFFSET);
-    }
-    return TEC1G_LCD_ROW3_START + (index - TEC1G_LCD_ROW3_OFFSET);
-  };
-
-  const lcdAdvanceCgramAddr = (addr: number, increment: boolean): number => {
-    const delta = increment ? 1 : -1;
-    return (addr + delta + state.lcdCgram.length) & TEC1G_MASK_LOW6;
-  };
-
-  const shiftLcdDisplay = (delta: number): void => {
-    const next = (state.lcdDisplayShift + delta + 20) % 20;
-    if (next !== state.lcdDisplayShift) {
-      state.lcdDisplayShift = next;
       queueUpdate();
     }
   };
@@ -893,10 +737,10 @@ export function createTec1gRuntime(
         return state.matrixKeyStates[row] ?? TEC1G_MASK_BYTE;
       }
       if (p === TEC1G_PORT_LCD_CMD) {
-        return lcdReadStatus();
+        return lcd.readStatus();
       }
       if (p === TEC1G_PORT_LCD_DATA) {
-        return lcdReadData();
+        return lcd.readData();
       }
       if (p === TEC1G_PORT_RTC) {
         return rtcEnabled && rtc ? rtc.read() : TEC1G_MASK_BYTE;
@@ -995,68 +839,11 @@ export function createTec1gRuntime(
         return;
       }
       if (p === TEC1G_PORT_LCD_CMD) {
-        const instruction = value & TEC1G_MASK_BYTE;
-        if (instruction === LCD_CMD_CLEAR) {
-          lcdClear();
-          return;
-        }
-        if (instruction === LCD_CMD_HOME) {
-          lcdSetAddr(LCD_CMD_DDRAM);
-          state.lcdDisplayShift = 0;
-          lcdSetBusy(TEC1G_LCD_BUSY_CLEAR_US);
-          return;
-        }
-        if ((instruction & LCD_CMD_DDRAM) !== 0) {
-          lcdSetAddr(instruction);
-          lcdSetBusy(TEC1G_LCD_BUSY_US);
-          return;
-        }
-        if ((instruction & LCD_CMD_CGRAM) !== 0) {
-          state.lcdCgramAddr = instruction & TEC1G_MASK_LOW6;
-          state.lcdAddrMode = 'cgram';
-          lcdSetBusy(TEC1G_LCD_BUSY_US);
-          return;
-        }
-        if ((instruction & LCD_ENTRY_MODE_MASK) === LCD_CMD_ENTRY_MODE) {
-          state.lcdEntryIncrement = (instruction & LCD_ENTRY_INCREMENT) !== 0;
-          state.lcdEntryShift = (instruction & LCD_ENTRY_SHIFT) !== 0;
-          lcdSetBusy(TEC1G_LCD_BUSY_US);
-          return;
-        }
-        if ((instruction & LCD_DISPLAY_MASK) === LCD_CMD_DISPLAY) {
-          state.lcdDisplayOn = (instruction & LCD_DISPLAY_ON) !== 0;
-          state.lcdCursorOn = (instruction & LCD_CURSOR_ON) !== 0;
-          state.lcdCursorBlink = (instruction & LCD_BLINK_ON) !== 0;
-          queueUpdate();
-          lcdSetBusy(TEC1G_LCD_BUSY_US);
-          return;
-        }
-        if ((instruction & LCD_SHIFT_MASK) === LCD_CMD_SHIFT) {
-          const displayShift = (instruction & LCD_SHIFT_DISPLAY) !== 0;
-          const shiftRight = (instruction & LCD_SHIFT_RIGHT) !== 0;
-          if (displayShift) {
-            shiftLcdDisplay(shiftRight ? 1 : -1);
-          } else {
-            state.lcdAddrMode = 'ddram';
-            state.lcdAddr = lcdAdvanceAddr(state.lcdAddr, shiftRight);
-          }
-          lcdSetBusy(TEC1G_LCD_BUSY_US);
-          return;
-        }
-        if ((instruction & LCD_FUNCTION_MASK) === LCD_CMD_FUNCTION) {
-          state.lcdFunction = {
-            dataLength8: (instruction & LCD_FUNC_8BIT) !== 0,
-            lines2: (instruction & LCD_FUNC_2LINE) !== 0,
-            font5x8: (instruction & LCD_FUNC_FONT5X8) === 0,
-          };
-          lcdSetBusy(TEC1G_LCD_BUSY_US);
-          return;
-        }
-        lcdSetBusy(TEC1G_LCD_BUSY_US);
+        lcd.writeCommand(value & TEC1G_MASK_BYTE);
         return;
       }
       if (p === TEC1G_PORT_LCD_DATA) {
-        lcdWriteData(value);
+        lcd.writeData(value & TEC1G_MASK_BYTE);
         return;
       }
       if (p === TEC1G_PORT_GLCD_CMD) {
@@ -1260,6 +1047,7 @@ export function createTec1gRuntime(
     state.speedMode = mode;
     state.clockHz = mode === 'slow' ? TEC1G_SLOW_HZ : TEC1G_FAST_HZ;
     serial.setClockHz(state.clockHz);
+    lcd.setClockHz(state.clockHz);
     glcdRescheduleBlink();
     sendUpdate();
   };
@@ -1268,23 +1056,7 @@ export function createTec1gRuntime(
     state.speaker = false;
     state.speakerHz = 0;
     state.lastEdgeCycle = null;
-    state.lcd.fill(TEC1G_LCD_SPACE);
-    state.lcdAddr = TEC1G_LCD_ROW0_START;
-    state.lcdAddrMode = 'ddram';
-    state.lcdEntryIncrement = true;
-    state.lcdEntryShift = false;
-    state.lcdDisplayOn = true;
-    state.lcdCursorOn = false;
-    state.lcdCursorBlink = false;
-    state.lcdDisplayShift = 0;
-    state.lcdCgram.fill(0);
-    state.lcdCgramAddr = 0;
-    state.lcdFunction = {
-      dataLength8: true,
-      lines2: true,
-      font5x8: true,
-    };
-    lcdBusyUntil = 0;
+    lcd.reset();
     state.matrix.fill(0);
     state.matrixKeyStates.fill(TEC1G_MASK_BYTE);
     state.matrixModeEnabled = matrixMode;

--- a/tests/platforms/tec1g/lcd.test.ts
+++ b/tests/platforms/tec1g/lcd.test.ts
@@ -1,126 +1,118 @@
 import { describe, expect, it } from 'vitest';
-import { createTec1gRuntime } from '../../../src/platforms/tec1g/runtime';
-import type { Tec1gPlatformConfigNormalized } from '../../../src/platforms/types';
+import { CycleClock } from '../../../src/platforms/cycle-clock';
+import { TEC_FAST_HZ } from '../../../src/platforms/tec-common';
+import {
+  createTec1gLcdController,
+  type Tec1gLcdState,
+} from '../../../src/platforms/tec1g/lcd';
+import { TEC1G_LCD_ROW0_START, TEC1G_LCD_SPACE } from '../../../src/platforms/tec1g/constants';
 
-function makeRuntime() {
-  const config: Tec1gPlatformConfigNormalized = {
-    regions: [
-      { start: 0x0000, end: 0x7fff, kind: 'ram' as const },
-      { start: 0xc000, end: 0xffff, kind: 'rom' as const },
-    ],
-    romRanges: [{ start: 0xc000, end: 0xffff }],
-    appStart: 0x0000,
-    entry: 0x0000,
-    updateMs: 100,
-    yieldMs: 0,
-    gimpSignal: false,
-    expansionBankHi: false,
-    matrixMode: false,
-    protectOnReset: false,
-    rtcEnabled: false,
-    sdEnabled: false,
-    sdHighCapacity: true,
+function makeState(): Tec1gLcdState {
+  return {
+    lcd: Array.from({ length: 80 }, () => TEC1G_LCD_SPACE),
+    lcdAddr: TEC1G_LCD_ROW0_START,
+    lcdAddrMode: 'ddram',
+    lcdEntryIncrement: true,
+    lcdEntryShift: false,
+    lcdDisplayOn: true,
+    lcdCursorOn: false,
+    lcdCursorBlink: false,
+    lcdDisplayShift: 0,
+    lcdCgram: new Uint8Array(64),
+    lcdCgramAddr: 0,
+    lcdFunction: {
+      dataLength8: true,
+      lines2: true,
+      font5x8: true,
+    },
   };
-  return createTec1gRuntime(config, () => {});
 }
 
-describe('TEC-1G LCD instruction handling', () => {
-  it('entry mode decrement moves cursor backward', () => {
-    const rt = makeRuntime();
-    rt.state.lcdAddr = 0x80;
-    rt.ioHandlers.write(0x04, 0x04); // entry mode: decrement, no shift
-    rt.ioHandlers.write(0x84, 0x41);
-    expect(rt.state.lcdAddr).toBe(0xe7);
+function makeController() {
+  const clock = new CycleClock();
+  const state = makeState();
+  const controller = createTec1gLcdController(state, clock, TEC_FAST_HZ, () => {});
+  return { clock, state, controller };
+}
+
+describe('TEC-1G LCD controller', () => {
+  it('moves the cursor backward in decrement mode', () => {
+    const { state, controller } = makeController();
+    state.lcdAddr = 0x80;
+    controller.writeCommand(0x04);
+    controller.writeData(0x41);
+    expect(state.lcdAddr).toBe(0xe7);
   });
 
-  it('entry mode shift updates display offset on write', () => {
-    const rt = makeRuntime();
-    rt.state.lcdDisplayShift = 0;
-    rt.ioHandlers.write(0x04, 0x07); // entry mode: increment + shift
-    rt.ioHandlers.write(0x84, 0x41);
-    expect(rt.state.lcdDisplayShift).toBe(1);
+  it('applies display shift on write when entry shift is enabled', () => {
+    const { state, controller } = makeController();
+    controller.writeCommand(0x07);
+    controller.writeData(0x41);
+    expect(state.lcdDisplayShift).toBe(1);
   });
 
-  it('display on/off control toggles state', () => {
-    const rt = makeRuntime();
-    rt.ioHandlers.write(0x04, 0x08); // display off
-    expect(rt.state.lcdDisplayOn).toBe(false);
-    rt.ioHandlers.write(0x04, 0x0c); // display on, cursor off
-    expect(rt.state.lcdDisplayOn).toBe(true);
+  it('updates display, cursor, and blink flags', () => {
+    const { state, controller } = makeController();
+    controller.writeCommand(0x0f);
+    expect(state.lcdDisplayOn).toBe(true);
+    expect(state.lcdCursorOn).toBe(true);
+    expect(state.lcdCursorBlink).toBe(true);
   });
 
-  it('display control updates cursor and blink state', () => {
-    const rt = makeRuntime();
-    rt.ioHandlers.write(0x04, 0x0f); // display on, cursor on, blink on
-    expect(rt.state.lcdCursorOn).toBe(true);
-    expect(rt.state.lcdCursorBlink).toBe(true);
+  it('shifts the cursor address', () => {
+    const { state, controller } = makeController();
+    state.lcdAddr = 0x80;
+    controller.writeCommand(0x10);
+    expect(state.lcdAddr).toBe(0xe7);
   });
 
-  it('cursor shift updates address', () => {
-    const rt = makeRuntime();
-    rt.state.lcdAddr = 0x80;
-    rt.ioHandlers.write(0x04, 0x10); // cursor move left
-    expect(rt.state.lcdAddr).toBe(0xe7);
+  it('shifts the display offset', () => {
+    const { state, controller } = makeController();
+    controller.writeCommand(0x18);
+    expect(state.lcdDisplayShift).toBe(19);
   });
 
-  it('display shift updates display offset', () => {
-    const rt = makeRuntime();
-    rt.state.lcdDisplayShift = 0;
-    rt.ioHandlers.write(0x04, 0x18); // display shift left
-    expect(rt.state.lcdDisplayShift).toBe(19);
+  it('stores function-set flags', () => {
+    const { state, controller } = makeController();
+    controller.writeCommand(0x38);
+    expect(state.lcdFunction).toEqual({
+      dataLength8: true,
+      lines2: true,
+      font5x8: true,
+    });
   });
 
-  it('function set updates stored state', () => {
-    const rt = makeRuntime();
-    rt.ioHandlers.write(0x04, 0x38); // 8-bit, 2-line, 5x8
-    expect(rt.state.lcdFunction.dataLength8).toBe(true);
-    expect(rt.state.lcdFunction.lines2).toBe(true);
-    expect(rt.state.lcdFunction.font5x8).toBe(true);
+  it('reads and writes cgram data', () => {
+    const { controller } = makeController();
+    controller.writeCommand(0x40);
+    controller.writeData(0x1f);
+    controller.writeCommand(0x40);
+    expect(controller.readData()).toBe(0x1f);
   });
 
-  it('cgram read/write uses cgram address', () => {
-    const rt = makeRuntime();
-    rt.ioHandlers.write(0x04, 0x40); // set CGRAM addr 0
-    rt.ioHandlers.write(0x84, 0x1f);
-    rt.ioHandlers.write(0x04, 0x40); // reset addr
-    const value = rt.ioHandlers.read(0x84);
-    expect(value).toBe(0x1f);
+  it('reports busy status until the clear delay elapses', () => {
+    const { clock, controller } = makeController();
+    controller.writeCommand(0x01);
+    expect(controller.readStatus() & 0x80).toBe(0x80);
+    clock.advance(7000);
+    expect(controller.readStatus() & 0x80).toBe(0x00);
   });
 
-  it('lcd status read ignores high byte of port address', () => {
-    const rt = makeRuntime();
-    const low = rt.ioHandlers.read(0x0004);
-    const high = rt.ioHandlers.read(0x1204);
-    expect(high).toBe(low);
+  it('resets address and display shift on clear and home', () => {
+    const { state, controller } = makeController();
+    state.lcdAddr = 0x94;
+    state.lcdDisplayShift = 3;
+    controller.writeCommand(0x02);
+    expect(state.lcdAddr).toBe(0x80);
+    expect(state.lcdDisplayShift).toBe(0);
   });
 
-  it('clear command resets DDRAM and clears busy flag after time', () => {
-    const rt = makeRuntime();
-    rt.ioHandlers.write(0x04, 0x80); // set DDRAM addr
-    rt.ioHandlers.write(0x84, 0x41);
-    rt.ioHandlers.write(0x04, 0x01); // clear display
-    expect(rt.ioHandlers.read(0x04) & 0x80).toBe(0x80);
-    rt.recordCycles(rt.state.clockHz);
-    expect(rt.ioHandlers.read(0x04) & 0x80).toBe(0x00);
-    expect(rt.state.lcd[0]).toBe(0x20);
-    expect(rt.state.lcdAddr).toBe(0x80);
-  });
-
-  it('home command resets address and display shift', () => {
-    const rt = makeRuntime();
-    rt.state.lcdAddr = 0x94;
-    rt.state.lcdDisplayShift = 3;
-    rt.ioHandlers.write(0x04, 0x02); // home
-    expect(rt.state.lcdAddr).toBe(0x80);
-    expect(rt.state.lcdDisplayShift).toBe(0);
-  });
-
-  it('ddram read/write returns stored data', () => {
-    const rt = makeRuntime();
-    rt.ioHandlers.write(0x04, 0x80);
-    rt.ioHandlers.write(0x84, 0x5a);
-    rt.ioHandlers.write(0x04, 0x80);
-    const value = rt.ioHandlers.read(0x84);
-    expect(value).toBe(0x5a);
+  it('returns stored ddram data', () => {
+    const { state, controller } = makeController();
+    controller.writeCommand(0x80);
+    controller.writeData(0x5a);
+    controller.writeCommand(0x80);
+    expect(controller.readData()).toBe(0x5a);
+    expect(state.lcd[0]).toBe(0x5a);
   });
 });


### PR DESCRIPTION
Closes #111\n\n## Summary\n- extract the TEC-1G HD44780 LCD state machine into src/platforms/tec1g/lcd.ts\n- keep src/platforms/tec1g/runtime.ts as the orchestrator that delegates LCD behavior to the controller\n- add direct LCD-controller coverage so the extracted slice is testable in isolation\n\n## Files changed\n- src/platforms/tec1g/runtime.ts\n- src/platforms/tec1g/lcd.ts\n- tests/platforms/tec1g/lcd.test.ts\n\n## Testing\n- ./node_modules/.bin/eslint src/platforms/tec1g/runtime.ts src/platforms/tec1g/lcd.ts tests/platforms/tec1g/lcd.test.ts\n- ./node_modules/.bin/vitest run tests/platforms/tec1g/lcd.test.ts\n- npm test\n\n## Deferred extraction points\n- ST7920 GLCD state machine\n- keypad / matrix scanning\n- other tightly grouped TEC-1G device logic still embedded in runtime.ts\n\nThis PR keeps the first extraction slice narrow and behavior-preserving so the next TEC-1G runtime seams can land separately.