### PR TITLE
Refactor TEC-1G display renderers out of index.ts

### DIFF
--- a/tests/webview/tec1g-display-renderers.test.ts
+++ b/tests/webview/tec1g-display-renderers.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @file Regression tests: TEC-1G LCD/GLCD renderer contracts.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createGlcdRenderer } from '../../webview/tec1g/glcd-renderer';
+import { createLcdRenderer, type LcdRenderer } from '../../webview/tec1g/lcd-renderer';
+
+const HTML_PATH = path.resolve(__dirname, '../../webview/tec1g/index.html');
+
+type FakeContext2d = {
+  clearRect: ReturnType<typeof vi.fn>;
+  createImageData: ReturnType<typeof vi.fn>;
+  drawImage: ReturnType<typeof vi.fn>;
+  imageSmoothingEnabled: boolean;
+  putImageData: ReturnType<typeof vi.fn>;
+};
+
+function buildDom(): Document {
+  const html = fs.readFileSync(HTML_PATH, 'utf8').replace(/\{\{\w+\}\}/g, '');
+  document.documentElement.innerHTML = html;
+  return document;
+}
+
+function createContext(): FakeContext2d {
+  return {
+    clearRect: vi.fn(),
+    createImageData: vi.fn((width: number, height: number) => ({
+      data: new Uint8ClampedArray(width * height * 4),
+    })),
+    drawImage: vi.fn(),
+    imageSmoothingEnabled: true,
+    putImageData: vi.fn(),
+  };
+}
+
+describe('tec1g display renderers', () => {
+  const originalGetContextDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLCanvasElement.prototype,
+    'getContext'
+  );
+  let lcdRenderer: LcdRenderer | null = null;
+
+  beforeEach(() => {
+    buildDom();
+    vi.useFakeTimers();
+    HTMLCanvasElement.prototype.getContext = function getContext() {
+      const canvas = this as HTMLCanvasElement & { __ctx?: FakeContext2d };
+      canvas.__ctx ??= createContext();
+      return canvas.__ctx as never;
+    };
+  });
+
+  afterEach(() => {
+    lcdRenderer?.dispose();
+    lcdRenderer = null;
+    if (originalGetContextDescriptor) {
+      Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', originalGetContextDescriptor);
+    }
+    vi.useRealTimers();
+  });
+
+  it('renders LCD updates and redraws for cursor blink changes', () => {
+    lcdRenderer = createLcdRenderer();
+    const canvas = document.getElementById('lcdCanvas') as HTMLCanvasElement & {
+      __ctx: FakeContext2d;
+    };
+
+    lcdRenderer.applyLcdUpdate({
+      lcd: [0x41],
+      lcdCgram: [0x1f],
+      lcdState: { cursorAddr: 0x80, cursorBlink: true, displayOn: true },
+    });
+    vi.advanceTimersByTime(500);
+
+    expect(canvas.width).toBeGreaterThan(0);
+    expect(canvas.height).toBeGreaterThan(0);
+    expect(canvas.__ctx.putImageData).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders GLCD updates through the visible canvas context', () => {
+    const glcdRenderer = createGlcdRenderer();
+    const canvas = document.getElementById('glcdCanvas') as HTMLCanvasElement & {
+      __ctx: FakeContext2d;
+    };
+
+    glcdRenderer.applyGlcdUpdate({
+      glcd: [0xff],
+      glcdDdram: [0x41],
+      glcdState: {
+        cursorOn: true,
+        ddramAddr: 0x80,
+        ddramPhase: 1,
+        displayOn: true,
+        graphicsOn: true,
+        reverseMask: 1,
+        scroll: 2,
+        textShift: 1,
+      },
+    });
+
+    expect(canvas.__ctx.clearRect).toHaveBeenCalledTimes(1);
+    expect(canvas.__ctx.drawImage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/webview/tec1g-visibility-controller.test.ts
+++ b/tests/webview/tec1g-visibility-controller.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @file Regression tests: TEC-1G visibility controller contract.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createVisibilityController } from '../../webview/tec1g/visibility-controller';
+
+const HTML_PATH = path.resolve(__dirname, '../../webview/tec1g/index.html');
+
+function buildDom(): Document {
+  const html = fs.readFileSync(HTML_PATH, 'utf8').replace(/\{\{\w+\}\}/g, '');
+  document.documentElement.innerHTML = html;
+  return document;
+}
+
+describe('tec1g visibility controller', () => {
+  beforeEach(() => {
+    buildDom();
+  });
+
+  it('loads persisted visibility state into the DOM and checkboxes', () => {
+    const controller = createVisibilityController({
+      getState: () => ({ uiVisibility: { glcd: true, serial: false } }),
+      postMessage: () => undefined,
+      setState: () => undefined,
+    });
+
+    controller.wire();
+
+    expect(
+      document.querySelector('.ui-section[data-section="glcd"]')?.classList.contains('ui-hidden')
+    ).toBe(false);
+    expect(
+      document.querySelector('.ui-section[data-section="serial"]')?.classList.contains('ui-hidden')
+    ).toBe(true);
+    expect(
+      (document.querySelector('[data-section="glcd"]') as HTMLInputElement).checked
+    ).toBe(true);
+    expect(
+      (document.querySelector('[data-section="serial"]') as HTMLInputElement).checked
+    ).toBe(false);
+  });
+
+  it('persists overrides and checkbox changes through vscode state', () => {
+    const setState = vi.fn<(state: { uiVisibility?: Record<string, boolean> }) => void>();
+    const controller = createVisibilityController({
+      getState: () => null,
+      postMessage: () => undefined,
+      setState,
+    });
+    const glcdCheckbox = document.querySelector(
+      '#uiControls input[data-section="glcd"]'
+    ) as HTMLInputElement;
+
+    controller.wire();
+    controller.applyOverride({ glcd: true }, true);
+    glcdCheckbox.checked = false;
+    glcdCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
+
+    const firstState = setState.mock.calls[0]?.[0] as { uiVisibility?: Record<string, boolean> };
+    const lastState = setState.mock.calls.at(-1)?.[0] as { uiVisibility?: Record<string, boolean> };
+
+    expect(firstState.uiVisibility?.glcd).toBe(true);
+    expect(lastState.uiVisibility?.glcd).toBe(false);
+    expect(document.querySelector('.glcd')?.classList.contains('ui-hidden')).toBe(true);
+  });
+});

--- a/vitest.webview.config.ts
+++ b/vitest.webview.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  assetsInclude: ['**/*.bin'],
   test: {
     environment: 'jsdom',
     include: ['tests/webview/**/*.test.ts'],

--- a/webview/tec1g/glcd-renderer.ts
+++ b/webview/tec1g/glcd-renderer.ts
@@ -1,0 +1,153 @@
+import ST7920_FONT from './st7920-font.bin';
+
+const GLCD_WIDTH = 128;
+const GLCD_HEIGHT = 64;
+const GLCD_BYTES = 1024;
+const GLCD_DDRAM_SIZE = 64;
+const GLCD_TEXT_COLS = 16;
+const GLCD_TEXT_ROWS = 4;
+
+type GlcdPayload = {
+  glcd?: number[];
+  glcdDdram?: number[];
+  glcdState?: {
+    displayOn?: boolean; graphicsOn?: boolean; cursorOn?: boolean; cursorBlink?: boolean;
+    blinkVisible?: boolean; ddramAddr?: number; ddramPhase?: number; textShift?: number;
+    scroll?: number; reverseMask?: number;
+  };
+};
+
+export interface GlcdRenderer { applyGlcdUpdate(payload: GlcdPayload): void; draw(): void; }
+
+const copyPadded = (source: number[], size: number, fill: number) => {
+  const values = source.slice(0, size);
+  while (values.length < size) values.push(fill);
+  return values;
+};
+
+export function createGlcdRenderer(): GlcdRenderer {
+  const canvas = document.getElementById('glcdCanvas') as HTMLCanvasElement | null;
+  const ctx = canvas?.getContext('2d') ?? null;
+  const baseCanvas = ctx ? document.createElement('canvas') : null;
+  const baseCtx = baseCanvas?.getContext('2d') ?? null;
+  if (baseCanvas) { baseCanvas.width = GLCD_WIDTH; baseCanvas.height = GLCD_HEIGHT; }
+  const image = baseCtx && baseCanvas ? baseCtx.createImageData(GLCD_WIDTH, GLCD_HEIGHT) : null;
+  let ddram = new Array(GLCD_DDRAM_SIZE).fill(0x20);
+  let displayOn = true;
+  let graphicsOn = true;
+  let cursorOn = false;
+  let cursorBlink = false;
+  let cursorAddr = 0x80;
+  let cursorPhase = 0;
+  let textShift = 0;
+  let scroll = 0;
+  let reverseMask = 0;
+  let blinkVisible = true;
+  let bytes = new Array(GLCD_BYTES).fill(0x00);
+
+  const draw = () => {
+    if (!ctx || !canvas || !baseCtx || !baseCanvas || !image) return;
+    const data = image.data;
+    const shift = Math.max(-15, Math.min(15, Math.trunc(textShift || 0)));
+    const scrollOffset = scroll & 0x3f;
+    let ptr = 0;
+    for (let i = 0; i < data.length; i += 4) {
+      data[i] = 158; data[i + 1] = 182; data[i + 2] = 99; data[i + 3] = 255;
+    }
+    if (displayOn && graphicsOn) {
+      for (let row = 0; row < GLCD_HEIGHT; row += 1) {
+        const srcRow = (row + scrollOffset) & 0x3f;
+        for (let colByte = 0; colByte < 16; colByte += 1) {
+          const value = bytes[srcRow * 16 + colByte] || 0;
+          for (let bit = 0; bit < 8; bit += 1) {
+            const on = (value & (0x80 >> bit)) !== 0;
+            data[ptr++] = on ? 32 : 158;
+            data[ptr++] = on ? 58 : 182;
+            data[ptr++] = on ? 22 : 99;
+            data[ptr++] = 255;
+          }
+        }
+      }
+    }
+    if (!displayOn) {
+      baseCtx.putImageData(image, 0, 0);
+      ctx.imageSmoothingEnabled = false;
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(baseCanvas, 0, 0, canvas.width, canvas.height);
+      return;
+    }
+    for (let textRow = 0; textRow < GLCD_TEXT_ROWS; textRow += 1) {
+      for (let textCol = 0; textCol < GLCD_TEXT_COLS; textCol += 1) {
+        const memoryCol = textCol + shift;
+        if (memoryCol < 0 || memoryCol >= GLCD_TEXT_COLS) continue;
+        const charCode = ddram[textRow * GLCD_TEXT_COLS + memoryCol] || 0x20;
+        if (charCode === 0x20 || charCode === 0x00) continue;
+        for (let dy = 0; dy < 16; dy += 1) {
+          const bits = ST7920_FONT[(charCode & 0x7f) * 16 + dy] || 0;
+          if (bits === 0) continue;
+          for (let dx = 0; dx < 8; dx += 1) {
+            if ((bits & (0x80 >> dx)) === 0) continue;
+            const pixel = (((textRow * 16 + dy - scrollOffset + GLCD_HEIGHT) & 0x3f) * GLCD_WIDTH + textCol * 8 + dx) * 4;
+            const lit = data[pixel] === 32 && data[pixel + 1] === 58 && data[pixel + 2] === 22;
+            data[pixel] = graphicsOn && lit ? 158 : 32;
+            data[pixel + 1] = graphicsOn && lit ? 182 : 58;
+            data[pixel + 2] = graphicsOn && lit ? 99 : 22;
+          }
+        }
+      }
+    }
+    for (let textRow = 0; textRow < GLCD_TEXT_ROWS; textRow += 1) {
+      if ((reverseMask & (1 << textRow)) === 0) continue;
+      for (let dy = 0; dy < 16; dy += 1) {
+        const py = (textRow * 16 + dy - scrollOffset + GLCD_HEIGHT) & 0x3f;
+        for (let px = 0; px < GLCD_WIDTH; px += 1) {
+          const pixel = (py * GLCD_WIDTH + px) * 4;
+          const lit = data[pixel] === 32 && data[pixel + 1] === 58 && data[pixel + 2] === 22;
+          data[pixel] = lit ? 158 : 32;
+          data[pixel + 1] = lit ? 182 : 58;
+          data[pixel + 2] = lit ? 99 : 22;
+        }
+      }
+    }
+    if (cursorOn || (cursorBlink && blinkVisible)) {
+      const addr = cursorAddr & 0x7f;
+      const row = ((addr & 0x10) >> 4) | ((addr & 0x08) >> 2);
+      const col = addr & 0x07;
+      const dispCol = col * 2 + (cursorPhase ? 1 : 0) - shift;
+      if (dispCol >= 0 && dispCol < GLCD_TEXT_COLS) {
+        const underlineY = (row * 16 + 15 - scrollOffset + GLCD_HEIGHT) & 0x3f;
+        for (let dx = 0; dx < 8; dx += 1) {
+          const pixel = (underlineY * GLCD_WIDTH + dispCol * 8 + dx) * 4;
+          data[pixel] = 32; data[pixel + 1] = 58; data[pixel + 2] = 22;
+        }
+      }
+    }
+    baseCtx.putImageData(image, 0, 0);
+    ctx.imageSmoothingEnabled = false;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(baseCanvas, 0, 0, canvas.width, canvas.height);
+  };
+
+  return {
+    applyGlcdUpdate(payload) {
+      let shouldDraw = false;
+      if (Array.isArray(payload.glcdDdram)) { ddram = copyPadded(payload.glcdDdram, GLCD_DDRAM_SIZE, 0x20); shouldDraw = true; }
+      if (payload.glcdState && typeof payload.glcdState === 'object') {
+        if (typeof payload.glcdState.displayOn === 'boolean') displayOn = payload.glcdState.displayOn;
+        if (typeof payload.glcdState.graphicsOn === 'boolean') graphicsOn = payload.glcdState.graphicsOn;
+        if (typeof payload.glcdState.cursorOn === 'boolean') cursorOn = payload.glcdState.cursorOn;
+        if (typeof payload.glcdState.cursorBlink === 'boolean') cursorBlink = payload.glcdState.cursorBlink;
+        if (typeof payload.glcdState.blinkVisible === 'boolean') blinkVisible = payload.glcdState.blinkVisible;
+        if (typeof payload.glcdState.ddramAddr === 'number') cursorAddr = payload.glcdState.ddramAddr & 0xff;
+        if (typeof payload.glcdState.ddramPhase === 'number') cursorPhase = payload.glcdState.ddramPhase ? 1 : 0;
+        if (typeof payload.glcdState.textShift === 'number') textShift = payload.glcdState.textShift;
+        if (typeof payload.glcdState.scroll === 'number') scroll = payload.glcdState.scroll & 0x3f;
+        if (typeof payload.glcdState.reverseMask === 'number') reverseMask = payload.glcdState.reverseMask & 0x0f;
+        shouldDraw = true;
+      }
+      if (Array.isArray(payload.glcd)) { bytes = copyPadded(payload.glcd, GLCD_BYTES, 0x00); shouldDraw = true; }
+      if (shouldDraw) draw();
+    },
+    draw,
+  };
+}

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -1,10 +1,11 @@
 import { createDigit } from '../common/digits';
 import { MemoryPanel } from '../common/memory-panel';
 import { acquireVscodeApi } from '../common/vscode';
-import { A00 } from './hd44780-a00';
+import { createGlcdRenderer } from './glcd-renderer';
+import { createLcdRenderer } from './lcd-renderer';
 import { createMatrixUiController } from './matrix-ui';
-import ST7920_FONT from './st7920-font.bin';
 import { wireTec1gSerialUi } from './serial-ui';
+import { createVisibilityController } from './visibility-controller';
 
 type PanelTab = 'ui' | 'memory';
 
@@ -20,61 +21,15 @@ const statusShadow = document.getElementById('statusShadow') as HTMLElement;
 const statusProtect = document.getElementById('statusProtect') as HTMLElement;
 const statusExpand = document.getElementById('statusExpand') as HTMLElement;
 const statusCaps = document.getElementById('statusCaps') as HTMLElement;
-const lcdCanvas = document.getElementById('lcdCanvas') as HTMLCanvasElement | null;
-const lcdCtx = lcdCanvas?.getContext('2d') ?? null;
-const glcdCanvas = document.getElementById('glcdCanvas') as HTMLCanvasElement | null;
-const glcdCtx = glcdCanvas?.getContext('2d') ?? null;
-const glcdBaseCanvas = glcdCtx ? document.createElement('canvas') : null;
-const glcdBaseCtx = glcdBaseCanvas?.getContext('2d') ?? null;
 const tabButtons = Array.from(document.querySelectorAll<HTMLElement>('[data-tab]'));
 const panelUi = document.getElementById('panel-ui') as HTMLElement;
 const panelMemory = document.getElementById('panel-memory') as HTMLElement;
 const registerStrip = document.getElementById('registerStrip') as HTMLElement;
-const uiControls = document.getElementById('uiControls') as HTMLElement;
-const uiSectionNodes = Array.from(document.querySelectorAll<HTMLElement>('.ui-section'));
 const memoryPanel = document.getElementById('memoryPanel') as HTMLElement;
 const SHIFT_BIT = 0x20;
 const DIGITS = 6;
-const LCD_COLS = 20;
-const LCD_ROWS = 4;
-const LCD_BYTES = LCD_COLS * LCD_ROWS;
-const GLCD_WIDTH = 128;
-const GLCD_HEIGHT = 64;
-const GLCD_BYTES = 1024;
-let lcdBytes = new Array(LCD_BYTES).fill(0x20);
-let lcdCgram = new Array(64).fill(0x00);
-let lcdDisplayOn = true;
-let lcdCursorOn = false;
-let lcdCursorBlink = false;
-let lcdCursorAddr = 0x80;
-let lcdDisplayShift = 0;
-let lcdCursorBlinkVisible = true;
-let lcdCursorBlinkTimer = null;
-const GLCD_DDRAM_SIZE = 64;
-const GLCD_TEXT_COLS = 16;
-const GLCD_TEXT_ROWS = 4;
-let glcdDdram = new Array(GLCD_DDRAM_SIZE).fill(0x20);
-let glcdDisplayOn = true;
-let glcdGraphicsOn = true;
-let glcdCursorOn = false;
-let glcdCursorBlink = false;
-let glcdCursorAddr = 0x80;
-let glcdCursorPhase = 0;
-let glcdTextShift = 0;
-let glcdScroll = 0;
-let glcdReverseMask = 0;
-let glcdBlinkVisible = true;
-let glcdBytes = new Array(GLCD_BYTES).fill(0x00);
 let sysCtrlSegs = [];
 let sysCtrlValue = 0;
-if (glcdBaseCanvas) {
-  glcdBaseCanvas.width = GLCD_WIDTH;
-  glcdBaseCanvas.height = GLCD_HEIGHT;
-}
-const glcdImageData =
-  glcdBaseCtx && glcdBaseCanvas
-    ? glcdBaseCtx.createImageData(GLCD_WIDTH, GLCD_HEIGHT)
-    : null;
 const digitEls: HTMLElement[] = [];
 for (let i = 0; i < DIGITS; i++) {
   const digit = createDigit();
@@ -83,7 +38,10 @@ for (let i = 0; i < DIGITS; i++) {
 }
 
 let activeTab: PanelTab = DEFAULT_TAB === 'memory' ? 'memory' : 'ui';
+const glcdRenderer = createGlcdRenderer();
+const lcdRenderer = createLcdRenderer();
 const matrixUi = createMatrixUiController(vscode, () => activeTab === 'ui');
+const visibilityController = createVisibilityController(vscode);
 let memoryRowSize = 16;
 let resizeTimer: number | null = null;
 let memoryPanelController: MemoryPanel | null = null;
@@ -161,82 +119,6 @@ tabButtons.forEach((button) => {
   });
 });
 
-const defaultVisibility = {
-  lcd: true,
-  display: true,
-  keypad: true,
-  matrixKeyboard: true,
-  matrix: false,
-  glcd: false,
-  serial: true,
-};
-
-function applyVisibility(visibility) {
-  uiSectionNodes.forEach((node) => {
-    const key = node.dataset.section;
-    if (!key) {
-      return;
-    }
-    const enabled = visibility[key] !== false;
-    node.classList.toggle('ui-hidden', !enabled);
-  });
-  if (uiControls) {
-    uiControls
-      .querySelectorAll('input[type="checkbox"][data-section]')
-      .forEach((input) => {
-        const key = input.dataset.section;
-        if (!key) {
-          return;
-        }
-        input.checked = visibility[key] !== false;
-      });
-  }
-}
-
-function loadVisibility() {
-  const stored = vscode.getState();
-  const visibility = {
-    ...defaultVisibility,
-    ...(stored && stored.uiVisibility ? stored.uiVisibility : {}),
-  };
-  applyVisibility(visibility);
-  return visibility;
-}
-
-function saveVisibility(visibility) {
-  const stored = vscode.getState() || {};
-  vscode.setState({ ...stored, uiVisibility: visibility });
-}
-
-function applyVisibilityOverride(visibility, persist) {
-  if (!visibility || typeof visibility !== 'object') {
-    return;
-  }
-  uiVisibility = { ...defaultVisibility, ...visibility };
-  applyVisibility(uiVisibility);
-  if (persist) {
-    saveVisibility(uiVisibility);
-  }
-}
-
-let uiVisibility = loadVisibility();
-
-if (uiControls) {
-  uiControls.addEventListener('change', (event) => {
-    const target = event.target;
-    if (!(target instanceof HTMLInputElement)) {
-      return;
-    }
-    const key = target.dataset.section;
-    if (!key) {
-      return;
-    }
-    uiVisibility = { ...uiVisibility, [key]: target.checked };
-    applyVisibility(uiVisibility);
-    saveVisibility(uiVisibility);
-  });
-}
-
 const keyMap = {
   '0': 0x00, '1': 0x01, '2': 0x02, '3': 0x03, '4': 0x04,
   '5': 0x05, '6': 0x06, '7': 0x07, '8': 0x08, '9': 0x09,
@@ -273,233 +155,6 @@ function applySpeed(mode) {
   speedEl.textContent = mode.toUpperCase();
   speedEl.classList.toggle('slow', mode === 'slow');
   speedEl.classList.toggle('fast', mode === 'fast');
-}
-
-function drawLcd() {
-  drawLcdBitmap();
-}
-
-function drawLcdBitmap() {
-  if (!lcdCtx || !lcdCanvas) {
-    return;
-  }
-  const dot = 2;
-  const cellW = 5 * dot + 2;
-  const cellH = 8 * dot + 2;
-  const w = LCD_COLS * cellW;
-  const h = LCD_ROWS * cellH;
-  lcdCanvas.width = w;
-  lcdCanvas.height = h;
-  lcdCanvas.style.width = '';
-  lcdCanvas.style.height = '';
-  const img = lcdCtx.createImageData(w, h);
-  const d = img.data;
-  const bgR = 11, bgG = 26, bgB = 16;
-  const onR = 180, onG = 245, onB = 180;
-  for (let i = 0; i < d.length; i += 4) {
-    d[i] = bgR; d[i + 1] = bgG; d[i + 2] = bgB; d[i + 3] = 255;
-  }
-  const cursorVisible = lcdDisplayOn && (lcdCursorOn || (lcdCursorBlink && lcdCursorBlinkVisible));
-  const cursorIndex = getLcdIndex(lcdCursorAddr);
-  for (let row = 0; row < LCD_ROWS; row++) {
-    for (let col = 0; col < LCD_COLS; col++) {
-      const srcCol = (col + lcdDisplayShift + LCD_COLS) % LCD_COLS;
-      const index = row * LCD_COLS + srcCol;
-      const charCode = lcdDisplayOn ? ((lcdBytes[index] || 0x20) & 0xFF) : 0x20;
-      const romBase = charCode * 8;
-      const ox = col * cellW + 1;
-      const oy = row * cellH + 1;
-      for (let dy = 0; dy < 8; dy++) {
-        let bits = A00[romBase + dy] || 0;
-        if (charCode < 0x08) {
-          bits = lcdCgram[charCode * 8 + dy] || 0;
-        }
-        for (let dx = 0; dx < 5; dx++) {
-          if (bits & (0x10 >> dx)) {
-            const sx = ox + dx * dot;
-            const sy = oy + dy * dot;
-            for (let py = 0; py < dot; py++) {
-              for (let px = 0; px < dot; px++) {
-                const idx = ((sy + py) * w + (sx + px)) * 4;
-                if (idx >= 0 && idx < d.length - 3) {
-                  d[idx] = onR;
-                  d[idx + 1] = onG;
-                  d[idx + 2] = onB;
-                }
-              }
-            }
-          }
-        }
-      }
-      if (cursorVisible && cursorIndex === index) {
-        const dy = 7;
-        for (let dx = 0; dx < 5; dx++) {
-          const sx = ox + dx * dot;
-          const sy = oy + dy * dot;
-          for (let py = 0; py < dot; py++) {
-            for (let px = 0; px < dot; px++) {
-              const idx = ((sy + py) * w + (sx + px)) * 4;
-              if (idx >= 0 && idx < d.length - 3) {
-                d[idx] = onR;
-                d[idx + 1] = onG;
-                d[idx + 2] = onB;
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  lcdCtx.putImageData(img, 0, 0);
-}
-
-function getLcdIndex(addr) {
-  const masked = addr & 0xFF;
-  if (masked >= 0x80 && masked <= 0x93) return masked - 0x80;
-  if (masked >= 0xC0 && masked <= 0xD3) return 20 + (masked - 0xC0);
-  if (masked >= 0x94 && masked <= 0xA7) return 40 + (masked - 0x94);
-  if (masked >= 0xD4 && masked <= 0xE7) return 60 + (masked - 0xD4);
-  return -1;
-}
-
-function updateLcdCursorBlink() {
-  if (lcdCursorBlinkTimer) {
-    clearInterval(lcdCursorBlinkTimer);
-    lcdCursorBlinkTimer = null;
-  }
-  lcdCursorBlinkVisible = true;
-  if (!lcdCursorBlink) {
-    return;
-  }
-  lcdCursorBlinkTimer = setInterval(() => {
-    lcdCursorBlinkVisible = !lcdCursorBlinkVisible;
-    drawLcd();
-  }, 500);
-}
-
-function drawGlcd() {
-  if (!glcdCtx || !glcdCanvas || !glcdBaseCtx || !glcdBaseCanvas || !glcdImageData) {
-    return;
-  }
-  const data = glcdImageData.data;
-  const onR = 32;
-  const onG = 58;
-  const onB = 22;
-  const offR = 158;
-  const offG = 182;
-  const offB = 99;
-  const scroll = glcdScroll & 0x3f;
-  const shift = Math.max(-15, Math.min(15, Math.trunc(glcdTextShift || 0)));
-  let ptr = 0;
-  if (!glcdDisplayOn) {
-    for (let i = 0; i < data.length; i += 4) {
-      data[i] = offR;
-      data[i + 1] = offG;
-      data[i + 2] = offB;
-      data[i + 3] = 255;
-    }
-  } else {
-    if (glcdGraphicsOn) {
-      for (let row = 0; row < GLCD_HEIGHT; row += 1) {
-        const srcRow = (row + scroll) & 0x3f;
-        for (let colByte = 0; colByte < 16; colByte += 1) {
-          const value = glcdBytes[srcRow * 16 + colByte] || 0;
-          for (let bit = 0; bit < 8; bit += 1) {
-            const on = (value & (0x80 >> bit)) !== 0;
-            data[ptr++] = on ? onR : offR;
-            data[ptr++] = on ? onG : offG;
-            data[ptr++] = on ? onB : offB;
-            data[ptr++] = 255;
-          }
-        }
-      }
-    } else {
-      for (let i = 0; i < data.length; i += 4) {
-        data[i] = offR;
-        data[i + 1] = offG;
-        data[i + 2] = offB;
-        data[i + 3] = 255;
-      }
-    }
-    // Overlay DDRAM text layer using ST7920 half-height font (8x16, 16 cols x 4 rows)
-    for (let tRow = 0; tRow < GLCD_TEXT_ROWS; tRow++) {
-      for (let tCol = 0; tCol < GLCD_TEXT_COLS; tCol++) {
-        const memCol = tCol + shift;
-        if (memCol < 0 || memCol >= GLCD_TEXT_COLS) {
-          continue;
-        }
-        const ch = glcdDdram[tRow * GLCD_TEXT_COLS + memCol] || 0x20;
-        if (ch === 0x20 || ch === 0x00) continue; // skip spaces
-        const romBase = (ch & 0x7F) * 16;
-        const px0 = tCol * 8;
-        const py0 = tRow * 16;
-        for (let dy = 0; dy < 16; dy++) {
-          const bits = ST7920_FONT[romBase + dy] || 0;
-          if (bits === 0) continue;
-          for (let dx = 0; dx < 8; dx++) {
-            if (bits & (0x80 >> dx)) {
-              const px = px0 + dx;
-              const py = (py0 + dy - scroll + GLCD_HEIGHT) & 0x3f;
-              if (px < GLCD_WIDTH && py < GLCD_HEIGHT) {
-                const idx = (py * GLCD_WIDTH + px) * 4;
-                if (glcdGraphicsOn) {
-                  const isOn =
-                    data[idx] === onR && data[idx + 1] === onG && data[idx + 2] === onB;
-                  data[idx] = isOn ? offR : onR;
-                  data[idx + 1] = isOn ? offG : onG;
-                  data[idx + 2] = isOn ? offB : onB;
-                } else {
-                  data[idx] = onR;
-                  data[idx + 1] = onG;
-                  data[idx + 2] = onB;
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    if (glcdReverseMask) {
-      for (let tRow = 0; tRow < GLCD_TEXT_ROWS; tRow++) {
-        if ((glcdReverseMask & (1 << tRow)) === 0) continue;
-        for (let dy = 0; dy < 16; dy++) {
-          const py = (tRow * 16 + dy - scroll + GLCD_HEIGHT) & 0x3f;
-          for (let px = 0; px < GLCD_WIDTH; px++) {
-            const idx = (py * GLCD_WIDTH + px) * 4;
-            const isOn = data[idx] === onR && data[idx + 1] === onG && data[idx + 2] === onB;
-            data[idx] = isOn ? offR : onR;
-            data[idx + 1] = isOn ? offG : onG;
-            data[idx + 2] = isOn ? offB : onB;
-          }
-        }
-      }
-    }
-    const cursorVisible = glcdCursorOn || (glcdCursorBlink && glcdBlinkVisible);
-    if (cursorVisible) {
-      const addr = glcdCursorAddr & 0x7f;
-      const row = ((addr & 0x10) >> 4) | ((addr & 0x08) >> 2);
-      const col = addr & 0x07;
-      const memCol = col * 2 + (glcdCursorPhase ? 1 : 0);
-      const dispCol = memCol - shift;
-      if (dispCol >= 0 && dispCol < GLCD_TEXT_COLS) {
-        const px0 = dispCol * 8;
-        const py0 = (row * 16 - scroll + GLCD_HEIGHT) & 0x3f;
-        const underlineY = (py0 + 15) & 0x3f;
-        for (let dx = 0; dx < 8; dx++) {
-          const px = px0 + dx;
-          if (px >= GLCD_WIDTH) continue;
-          const idx = (underlineY * GLCD_WIDTH + px) * 4;
-          data[idx] = onR;
-          data[idx + 1] = onG;
-          data[idx + 2] = onB;
-        }
-      }
-    }
-  }
-  glcdBaseCtx.putImageData(glcdImageData, 0, 0);
-  glcdCtx.imageSmoothingEnabled = false;
-  glcdCtx.clearRect(0, 0, glcdCanvas.width, glcdCanvas.height);
-  glcdCtx.drawImage(glcdBaseCanvas, 0, 0, glcdCanvas.width, glcdCanvas.height);
 }
 
 function setShiftLatched(value) {
@@ -694,40 +349,7 @@ function applyUpdate(payload) {
   if (data.speedMode === 'slow' || data.speedMode === 'fast') {
     applySpeed(data.speedMode);
   }
-  if (Array.isArray(data.lcd)) {
-    lcdBytes = data.lcd.slice(0, LCD_BYTES);
-    while (lcdBytes.length < LCD_BYTES) {
-      lcdBytes.push(0x20);
-    }
-    drawLcd();
-  }
-  if (Array.isArray(data.lcdCgram)) {
-    lcdCgram = data.lcdCgram.slice(0, 64);
-    while (lcdCgram.length < 64) {
-      lcdCgram.push(0x00);
-    }
-    drawLcd();
-  }
-  if (data.lcdState && typeof data.lcdState === 'object') {
-    if (typeof data.lcdState.displayOn === 'boolean') {
-      lcdDisplayOn = data.lcdState.displayOn;
-    }
-    if (typeof data.lcdState.cursorOn === 'boolean') {
-      lcdCursorOn = data.lcdState.cursorOn;
-    }
-    if (typeof data.lcdState.cursorBlink === 'boolean') {
-      lcdCursorBlink = data.lcdState.cursorBlink;
-    }
-    if (typeof data.lcdState.cursorAddr === 'number') {
-      lcdCursorAddr = data.lcdState.cursorAddr & 0xFF;
-    }
-    if (typeof data.lcdState.displayShift === 'number') {
-      const shift = Math.trunc(data.lcdState.displayShift || 0);
-      lcdDisplayShift = ((shift % LCD_COLS) + LCD_COLS) % LCD_COLS;
-    }
-    updateLcdCursorBlink();
-    drawLcd();
-  }
+  lcdRenderer.applyLcdUpdate(data);
   if (Array.isArray(data.matrix)) {
     matrixUi.applyMatrixRows(data.matrix);
   }
@@ -742,51 +364,7 @@ function applyUpdate(payload) {
   if (typeof data.matrixMode === 'boolean') {
     matrixUi.applyMatrixMode(data.matrixMode);
   }
-  if (Array.isArray(data.glcdDdram)) {
-    glcdDdram = data.glcdDdram.slice(0, GLCD_DDRAM_SIZE);
-    while (glcdDdram.length < GLCD_DDRAM_SIZE) {
-      glcdDdram.push(0x20);
-    }
-  }
-  if (data.glcdState && typeof data.glcdState === 'object') {
-    if (typeof data.glcdState.displayOn === 'boolean') {
-      glcdDisplayOn = data.glcdState.displayOn;
-    }
-    if (typeof data.glcdState.graphicsOn === 'boolean') {
-      glcdGraphicsOn = data.glcdState.graphicsOn;
-    }
-    if (typeof data.glcdState.cursorOn === 'boolean') {
-      glcdCursorOn = data.glcdState.cursorOn;
-    }
-    if (typeof data.glcdState.cursorBlink === 'boolean') {
-      glcdCursorBlink = data.glcdState.cursorBlink;
-    }
-    if (typeof data.glcdState.blinkVisible === 'boolean') {
-      glcdBlinkVisible = data.glcdState.blinkVisible;
-    }
-    if (typeof data.glcdState.ddramAddr === 'number') {
-      glcdCursorAddr = data.glcdState.ddramAddr & 0xFF;
-    }
-    if (typeof data.glcdState.ddramPhase === 'number') {
-      glcdCursorPhase = data.glcdState.ddramPhase ? 1 : 0;
-    }
-    if (typeof data.glcdState.textShift === 'number') {
-      glcdTextShift = data.glcdState.textShift;
-    }
-    if (typeof data.glcdState.scroll === 'number') {
-      glcdScroll = data.glcdState.scroll & 0x3F;
-    }
-    if (typeof data.glcdState.reverseMask === 'number') {
-      glcdReverseMask = data.glcdState.reverseMask & 0x0F;
-    }
-  }
-  if (Array.isArray(data.glcd)) {
-    glcdBytes = data.glcd.slice(0, GLCD_BYTES);
-    while (glcdBytes.length < GLCD_BYTES) {
-      glcdBytes.push(0);
-    }
-  }
-  drawGlcd();
+  glcdRenderer.applyGlcdUpdate(data);
 }
 
 const statusEl = document.getElementById('status');
@@ -842,7 +420,7 @@ window.addEventListener('message', event => {
     return;
   }
   if (event.data.type === 'uiVisibility') {
-    applyVisibilityOverride(event.data.visibility, event.data.persist === true);
+    visibilityController.applyOverride(event.data.visibility, event.data.persist === true);
     return;
   }
   if (event.data.type === 'update') {
@@ -870,8 +448,9 @@ window.addEventListener('message', event => {
 applySpeed(speedMode);
 applyMuteState();
 matrixUi.init();
-drawLcd();
-drawGlcd();
+visibilityController.wire();
+lcdRenderer.draw();
+glcdRenderer.draw();
 setTab(DEFAULT_TAB, false);
 window.addEventListener('resize', scheduleMemoryResize);
 updateMemoryLayout(false);

--- a/webview/tec1g/lcd-renderer.ts
+++ b/webview/tec1g/lcd-renderer.ts
@@ -1,0 +1,129 @@
+import { A00 } from './hd44780-a00';
+
+const LCD_COLS = 20;
+const LCD_ROWS = 4;
+const LCD_BYTES = LCD_COLS * LCD_ROWS;
+const LCD_CGRAM_BYTES = 64;
+
+type LcdPayload = {
+  lcd?: number[];
+  lcdCgram?: number[];
+  lcdState?: { displayOn?: boolean; cursorOn?: boolean; cursorBlink?: boolean; cursorAddr?: number; displayShift?: number; };
+};
+
+export interface LcdRenderer { applyLcdUpdate(payload: LcdPayload): void; dispose(): void; draw(): void; }
+
+const copyPadded = (source: number[], size: number, fill: number) => {
+  const values = source.slice(0, size);
+  while (values.length < size) values.push(fill);
+  return values;
+};
+
+export function createLcdRenderer(): LcdRenderer {
+  const canvas = document.getElementById('lcdCanvas') as HTMLCanvasElement | null;
+  const ctx = canvas?.getContext('2d') ?? null;
+  let bytes = new Array(LCD_BYTES).fill(0x20);
+  let cgram = new Array(LCD_CGRAM_BYTES).fill(0x00);
+  let displayOn = true;
+  let cursorOn = false;
+  let cursorBlink = false;
+  let cursorAddr = 0x80;
+  let displayShift = 0;
+  let cursorBlinkVisible = true;
+  let cursorBlinkTimer: number | null = null;
+
+  const getIndex = (addr: number) => {
+    const masked = addr & 0xff;
+    if (masked >= 0x80 && masked <= 0x93) return masked - 0x80;
+    if (masked >= 0xc0 && masked <= 0xd3) return 20 + (masked - 0xc0);
+    if (masked >= 0x94 && masked <= 0xa7) return 40 + (masked - 0x94);
+    if (masked >= 0xd4 && masked <= 0xe7) return 60 + (masked - 0xd4);
+    return -1;
+  };
+
+  const draw = () => {
+    if (!ctx || !canvas) return;
+    const dot = 2;
+    const cellW = 5 * dot + 2;
+    const cellH = 8 * dot + 2;
+    const width = LCD_COLS * cellW;
+    const height = LCD_ROWS * cellH;
+    canvas.width = width;
+    canvas.height = height;
+    canvas.style.width = '';
+    canvas.style.height = '';
+    const image = ctx.createImageData(width, height);
+    const data = image.data;
+    for (let i = 0; i < data.length; i += 4) {
+      data[i] = 11; data[i + 1] = 26; data[i + 2] = 16; data[i + 3] = 255;
+    }
+    const cursorVisible = displayOn && (cursorOn || (cursorBlink && cursorBlinkVisible));
+    const cursorIndex = getIndex(cursorAddr);
+    for (let row = 0; row < LCD_ROWS; row += 1) {
+      for (let col = 0; col < LCD_COLS; col += 1) {
+        const index = row * LCD_COLS + ((col + displayShift + LCD_COLS) % LCD_COLS);
+        const charCode = displayOn ? ((bytes[index] || 0x20) & 0xff) : 0x20;
+        const ox = col * cellW + 1;
+        const oy = row * cellH + 1;
+        for (let dy = 0; dy < 8; dy += 1) {
+          let bits = A00[charCode * 8 + dy] || 0;
+          if (charCode < 0x08) bits = cgram[charCode * 8 + dy] || 0;
+          for (let dx = 0; dx < 5; dx += 1) {
+            if ((bits & (0x10 >> dx)) === 0) continue;
+            for (let py = 0; py < dot; py += 1) {
+              for (let px = 0; px < dot; px += 1) {
+                const pixel = ((oy + dy * dot + py) * width + (ox + dx * dot + px)) * 4;
+                if (pixel >= data.length - 3) continue;
+                data[pixel] = 180; data[pixel + 1] = 245; data[pixel + 2] = 180;
+              }
+            }
+          }
+        }
+        if (!cursorVisible || cursorIndex !== index) continue;
+        for (let dx = 0; dx < 5; dx += 1) {
+          for (let py = 0; py < dot; py += 1) {
+            for (let px = 0; px < dot; px += 1) {
+              const pixel = ((oy + 7 * dot + py) * width + (ox + dx * dot + px)) * 4;
+              data[pixel] = 180; data[pixel + 1] = 245; data[pixel + 2] = 180;
+            }
+          }
+        }
+      }
+    }
+    ctx.putImageData(image, 0, 0);
+  };
+
+  const updateCursorBlink = () => {
+    if (cursorBlinkTimer !== null) clearInterval(cursorBlinkTimer);
+    cursorBlinkVisible = true;
+    cursorBlinkTimer = null;
+    if (!cursorBlink) return;
+    cursorBlinkTimer = window.setInterval(() => {
+      cursorBlinkVisible = !cursorBlinkVisible;
+      draw();
+    }, 500);
+  };
+
+  return {
+    applyLcdUpdate(payload) {
+      let shouldDraw = false;
+      if (Array.isArray(payload.lcd)) { bytes = copyPadded(payload.lcd, LCD_BYTES, 0x20); shouldDraw = true; }
+      if (Array.isArray(payload.lcdCgram)) { cgram = copyPadded(payload.lcdCgram, LCD_CGRAM_BYTES, 0x00); shouldDraw = true; }
+      if (payload.lcdState && typeof payload.lcdState === 'object') {
+        if (typeof payload.lcdState.displayOn === 'boolean') displayOn = payload.lcdState.displayOn;
+        if (typeof payload.lcdState.cursorOn === 'boolean') cursorOn = payload.lcdState.cursorOn;
+        if (typeof payload.lcdState.cursorBlink === 'boolean') cursorBlink = payload.lcdState.cursorBlink;
+        if (typeof payload.lcdState.cursorAddr === 'number') cursorAddr = payload.lcdState.cursorAddr & 0xff;
+        if (typeof payload.lcdState.displayShift === 'number') {
+          const shift = Math.trunc(payload.lcdState.displayShift || 0);
+          displayShift = ((shift % LCD_COLS) + LCD_COLS) % LCD_COLS;
+        }
+        updateCursorBlink();
+        shouldDraw = true;
+      }
+      if (shouldDraw) draw();
+    },
+    dispose() { if (cursorBlinkTimer !== null) clearInterval(cursorBlinkTimer); },
+    draw,
+  };
+}

--- a/webview/tec1g/visibility-controller.ts
+++ b/webview/tec1g/visibility-controller.ts
@@ -1,0 +1,80 @@
+import type { VscodeApi } from '../common/vscode';
+
+const DEFAULT_VISIBILITY = {
+  lcd: true,
+  display: true,
+  keypad: true,
+  matrixKeyboard: true,
+  matrix: false,
+  glcd: false,
+  serial: true,
+};
+
+type UiVisibility = Record<string, boolean>;
+
+export interface VisibilityController {
+  applyOverride(visibility: UiVisibility, persist: boolean): void;
+  wire(): void;
+}
+
+const applyVisibility = (
+  nodes: HTMLElement[],
+  controls: HTMLElement | null,
+  visibility: UiVisibility,
+) => {
+  nodes.forEach((node) => {
+    const key = node.dataset.section;
+    if (!key) return;
+    node.classList.toggle('ui-hidden', visibility[key] === false);
+  });
+  controls?.querySelectorAll<HTMLInputElement>('input[type="checkbox"][data-section]').forEach((input) => {
+    const key = input.dataset.section;
+    if (!key) return;
+    input.checked = visibility[key] !== false;
+  });
+};
+
+export function createVisibilityController(vscode: VscodeApi): VisibilityController {
+  const controls = document.getElementById('uiControls') as HTMLElement | null;
+  const nodes = Array.from(document.querySelectorAll<HTMLElement>('.ui-section'));
+  let visibility = { ...DEFAULT_VISIBILITY };
+
+  const save = () => {
+    const stored = vscode.getState();
+    const state = stored && typeof stored === 'object' ? stored : {};
+    vscode.setState({ ...state, uiVisibility: visibility });
+  };
+
+  const sync = () => applyVisibility(nodes, controls, visibility);
+
+  return {
+    applyOverride(next, persist) {
+      if (!next || typeof next !== 'object') return;
+      visibility = { ...DEFAULT_VISIBILITY, ...next };
+      sync();
+      if (persist) save();
+    },
+    wire() {
+      const stored = vscode.getState();
+      const state = stored && typeof stored === 'object' ? stored : null;
+      const savedVisibility =
+        state &&
+        'uiVisibility' in state &&
+        state.uiVisibility &&
+        typeof state.uiVisibility === 'object'
+          ? (state.uiVisibility as UiVisibility)
+          : {};
+      visibility = { ...DEFAULT_VISIBILITY, ...savedVisibility };
+      sync();
+      controls?.addEventListener('change', (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLInputElement)) return;
+        const key = target.dataset.section;
+        if (!key) return;
+        visibility = { ...visibility, [key]: target.checked };
+        sync();
+        save();
+      });
+    },
+  };
+}


### PR DESCRIPTION
Closes #126

## Summary
- extract the TEC-1G GLCD canvas renderer into `webview/tec1g/glcd-renderer.ts`
- extract the TEC-1G LCD canvas renderer into `webview/tec1g/lcd-renderer.ts`
- extract sidebar visibility persistence/wiring into `webview/tec1g/visibility-controller.ts`
- reduce `webview/tec1g/index.ts` to bootstrap and event wiring while keeping runtime behavior unchanged

## Testing
- `npm run build:webview`
- `npx vitest run -c vitest.webview.config.ts tests/webview/tec1g-display-renderers.test.ts tests/webview/tec1g-visibility-controller.test.ts`
- `npx eslint webview/tec1g/index.ts webview/tec1g/glcd-renderer.ts webview/tec1g/lcd-renderer.ts webview/tec1g/visibility-controller.ts tests/webview/tec1g-display-renderers.test.ts tests/webview/tec1g-visibility-controller.test.ts`

## Residual risk
- The display renderers are still tightly coupled to DOM state and canvas availability, but the behavior is covered by focused webview tests.
- I left the matrix UI and serial wiring in `index.ts` to keep the PR narrow and avoid broad TEC-1G cleanup beyond the current slice.
