### PR TITLE
chore: fix repo metadata and Claude config hygiene

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(cat:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 .idea/
 /.vscode/
 .husky/_/
+.claude/
 
 # OS
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "GPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "https://example.com/your/repo.git"
+    "url": "https://github.com/jhlagado/debug80.git"
   },
   "engines": {
     "vscode": "^1.80.0"


### PR DESCRIPTION
## Summary
- Replaced the placeholder repository URL in `package.json` with the real GitHub URL.
- Removed the tracked personal Claude Code settings file from the repo.
- Added `.claude/` to `.gitignore` so local Claude workspace/settings artifacts stay out of version control.

## Files changed
- `package.json`
- `.gitignore`
- `.claude/settings.json` (removed from tracking)

## Verification
- `node -e "const p=require('./package.json'); if(p.repository?.url!=='https://github.com/jhlagado/debug80.git') process.exit(1); console.log(p.repository.url)"`
- `git check-ignore -v .claude/worktrees/ .claude/settings.json`

## Notes
- No code paths changed; this is repo metadata and hygiene only.
