### PR TITLE
docs: align README ownership pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 
 Minimal VS Code debug adapter for Z80 programs. It loads Intel HEX + .lst listings, runs asm80 by default before each debug session (when an asm root is provided), supports source-level stepping/breakpoints, and exposes registers. “Debug80” is the debugger name used in the examples below.
 
-Machine-specific setups now live in separate repos. For TEC-1, see `debug80-tec1`:
+TEC-1-specific workspace setups live in the separate `debug80-tec1` repo:
 https://github.com/jhlagado/debug80-tec1
+
+This repository keeps the shared debugger plus the in-repo example workspaces for Simple and TEC-1G.
 
 <table>
   <tr>
@@ -32,7 +34,8 @@ npm test
 ## Quick start (examples)
 
 - Open `examples/HelloWorld` for the Simple platform terminal demo.
-- Open `examples/Tec1` for the TEC-1 monitor + serial demo.
+- Open `examples/Tec1g` for the TEC-1G monitor + serial demo.
+- Open the separate `debug80-tec1` repo for TEC-1 monitor + serial workflows.
 - Press F5 to start debugging.
 
 These example folders already include `.vscode` configs, so you can run them immediately.
@@ -100,7 +103,7 @@ After scaffolding, adjust the `sourceFile`, `outputDir`, and `artifactBase` as n
 
 To target a different platform (e.g., `tec1`):
 - Set `platform: "tec1"` in `.vscode/debug80.json`.
-- Copy relevant fields from `examples/Tec1/.vscode/debug80.json` (e.g., memory regions, ROM, `ramInitHex`).
+- Copy relevant fields from the dedicated `debug80-tec1` repo’s `.vscode/debug80.json` (e.g., memory regions, ROM, `ramInitHex`).
 - Update `sourceFile` to your program and build outputs.
 
 ## Z80 workflow

--- a/src/platforms/simple/README.md
+++ b/src/platforms/simple/README.md
@@ -36,4 +36,5 @@ enabled via the `terminal` configuration:
 
 ## Where the platform lives in code
 
-- Emulator and I/O: `src/debug/adapter.ts`
+- Emulator and I/O: `src/platforms/simple/runtime.ts`
+- Debug adapter wiring: `src/platforms/simple/provider.ts`

--- a/src/platforms/tec1/README.md
+++ b/src/platforms/tec1/README.md
@@ -154,6 +154,7 @@ You can override with `romHex` in the platform config.
 
 ## Where the platform lives in code
 
-- Emulator and I/O: `src/debug/adapter.ts`
-- Webview panel UI: `src/extension/extension.ts`
+- Emulator and I/O: `src/platforms/tec1/runtime.ts`
+- Debug adapter wiring and TEC-1 custom requests: `src/platforms/tec1/provider.ts`
+- Memory panel webview: `src/platforms/tec1/memory-panel.ts` and `src/platforms/tec1/memory-panel-html.ts`
 - Bundled ROM: `roms/tec1/mon-1b/mon-1b.hex`


### PR DESCRIPTION
## Summary
- Updated the root README to make the TEC-1 support story consistent with the current repo split.
- Repointed the root README’s TEC-1 guidance at the separate `debug80-tec1` repo instead of the removed in-repo path.
- Updated the TEC-1 and Simple platform READMEs so their “where the platform lives in code” sections point at the current `runtime.ts` / `provider.ts` modules instead of the old adapter/extension entry points.

## Files changed
- `README.md`
- `src/platforms/tec1/README.md`
- `src/platforms/simple/README.md`

## Verification
- `git diff --check`
- `rg -n "examples/Tec1|src/debug/adapter.ts|src/extension/extension.ts" README.md src/platforms/tec1/README.md src/platforms/simple/README.md`

## Notes
- `package.json` is not part of this PR; the repository URL fix is already handled in #146.
