### PR TITLE
refactor: extract platform view serial and idle helpers

### DIFF
--- a/src/extension/platform-view-idle-html.ts
+++ b/src/extension/platform-view-idle-html.ts
@@ -1,0 +1,75 @@
+/**
+ * @file Idle HTML for the Debug80 platform view.
+ */
+
+/**
+ * Creates a CSP nonce for the idle webview.
+ */
+export function createPlatformViewNonce(): string {
+  let text = '';
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < 32; i += 1) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+}
+
+/**
+ * Renders the platform view idle HTML.
+ */
+export function getPlatformViewIdleHtml(options: {
+  hasProject: boolean;
+  selectedWorkspaceName?: string;
+  multiRoot: boolean;
+  nonce?: string;
+}): string {
+  const nonce = options.nonce ?? createPlatformViewNonce();
+  if (!options.hasProject) {
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="padding: 16px; font-family: var(--vscode-font-family); color: var(--vscode-foreground);">
+  <p>Debug80</p>
+  <p style="opacity: 0.7;">Create a Debug80 project to get started.</p>
+</body>
+</html>`;
+  }
+  const selectedLabel = options.selectedWorkspaceName ?? 'Workspace';
+  const selectionHint =
+    options.multiRoot && (options.selectedWorkspaceName === undefined || options.selectedWorkspaceName === '')
+      ? 'Select a workspace folder with “Debug80: Select Workspace Folder”.'
+      : '';
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="padding: 16px; font-family: var(--vscode-font-family); color: var(--vscode-foreground);">
+  <p>Debug80</p>
+  <p style="opacity: 0.7;">Project detected (${selectedLabel}). Start a debug session to see the platform UI.</p>
+  <button id="startDebug" style="margin-top: 8px; padding: 6px 10px; font-size: 12px;">
+    Start Debugging
+  </button>
+  ${selectionHint ? `<p style="opacity: 0.7;">${selectionHint}</p>` : ''}
+  <script nonce="${nonce}">
+    (function () {
+      const vscode = acquireVsCodeApi();
+      const button = document.getElementById('startDebug');
+      if (button) {
+        button.addEventListener('click', () => {
+          vscode.postMessage({ type: 'startDebug' });
+        });
+      }
+    }());
+  </script>
+</body>
+</html>`;
+}

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -38,6 +38,11 @@ import {
   type PlatformViewPlatform,
 } from './platform-view-messages';
 import {
+  handlePlatformSerialSave,
+  handlePlatformSerialSendFile,
+} from './platform-view-serial-actions';
+import { getPlatformViewIdleHtml } from './platform-view-idle-html';
+import {
   type PlatformViewState,
   buildSnapshotPayload,
   clearPlatformState,
@@ -332,8 +337,12 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       void handlePlatformViewMessage(msg, {
         currentPlatform: () => this.currentPlatform,
         handleStartDebug: () => vscode.commands.executeCommand('workbench.action.debug.start'),
-        handleSerialSendFile: () => this.handleSerialSendFile(),
-        handleSerialSave: (text) => this.handleSerialSave(text),
+        handleSerialSendFile: () =>
+          handlePlatformSerialSendFile({
+            getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
+            getPlatform: () => this.currentPlatform,
+          }),
+        handleSerialSave: (text) => handlePlatformSerialSave(text),
         clearSerialBuffer: (platform) => {
           const ps = this.platformStateFor(platform);
           if (ps) {clearSerialBuffer(ps.serialBuffer);}
@@ -409,7 +418,14 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       return;
     }
     if (rehydrate || this.view.webview.html.length === 0) {
-      this.view.webview.html = this.getIdleHtml();
+      const idleHtmlOptions = {
+        hasProject: this.hasProject,
+        multiRoot: (vscode.workspace.workspaceFolders ?? []).length > 1,
+        ...(this.selectedWorkspace?.name !== undefined
+          ? { selectedWorkspaceName: this.selectedWorkspace.name }
+          : {}),
+      };
+      this.view.webview.html = getPlatformViewIdleHtml(idleHtmlOptions);
     }
   }
 
@@ -440,112 +456,6 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     return this.currentSessionId === sessionId;
   }
 
-  private async handleSerialSendFile(): Promise<void> {
-    const uris = await vscode.window.showOpenDialog({
-      canSelectMany: false,
-      filters: {
-        'Intel HEX': ['hex'],
-        'Text Files': ['txt'],
-        'All Files': ['*'],
-      },
-      title: 'Select file to send',
-    });
-    if (!uris || uris.length === 0) {
-      return;
-    }
-    const fileUri = uris[0]!;
-    const fileName = fileUri.path.split('/').pop() ?? 'file';
-    const fileBytes = await vscode.workspace.fs.readFile(fileUri);
-    const fileText = new TextDecoder('utf-8').decode(fileBytes);
-
-    const session = this.currentSession ?? vscode.debug.activeDebugSession;
-    if (!session || session.type !== 'z80') {
-      void vscode.window.showErrorMessage('Debug80: No active debug session.');
-      return;
-    }
-
-    const command =
-      this.currentPlatform === 'tec1g' ? 'debug80/tec1gSerialInput' : 'debug80/tec1SerialInput';
-
-    // Stream characters with a small delay between each for reliable reception
-    const charDelayMs = 2;
-    const lineDelayMs = 10;
-
-    void vscode.window.withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-        title: `Sending ${fileName}...`,
-        cancellable: true,
-      },
-      async (progress, token) => {
-        const lines = fileText.split(/\r?\n/);
-        let charsSent = 0;
-        const totalChars = fileText.length;
-
-        for (const line of lines) {
-          if (token.isCancellationRequested) {
-            void vscode.window.showWarningMessage('Debug80: File send cancelled.');
-            return;
-          }
-          for (const char of line) {
-            if (token.isCancellationRequested) {
-              return;
-            }
-            try {
-              await session.customRequest(command, { text: char });
-            } catch {
-              void vscode.window.showErrorMessage('Debug80: Failed to send character.');
-              return;
-            }
-            charsSent += 1;
-            if (charDelayMs > 0) {
-              await new Promise((r) => setTimeout(r, charDelayMs));
-            }
-          }
-          // Send CR at end of line
-          try {
-            await session.customRequest(command, { text: '\r' });
-          } catch {
-            /* ignore */
-          }
-          charsSent += 1;
-          progress.report({ increment: (100 * (line.length + 1)) / totalChars });
-          if (lineDelayMs > 0) {
-            await new Promise((r) => setTimeout(r, lineDelayMs));
-          }
-        }
-        void vscode.window.showInformationMessage(`Debug80: Sent ${charsSent} characters.`);
-      }
-    );
-  }
-
-  private async handleSerialSave(text: string): Promise<void> {
-    if (!text || text.length === 0) {
-      void vscode.window.showWarningMessage('Debug80: Serial buffer is empty.');
-      return;
-    }
-
-    // Detect if content is Intel HEX format
-    const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
-    const isHex = lines.length > 0 && lines.every((l) => l.startsWith(':') || l.trim() === '');
-
-    const filters: Record<string, string[]> = isHex
-      ? { 'Intel HEX': ['hex'], 'Text Files': ['txt'] }
-      : { 'Text Files': ['txt'], 'All Files': ['*'] };
-
-    const uri = await vscode.window.showSaveDialog({
-      filters,
-      title: 'Save serial output',
-    });
-    if (!uri) {
-      return;
-    }
-
-    const encoder = new TextEncoder();
-    await vscode.workspace.fs.writeFile(uri, encoder.encode(text));
-    void vscode.window.showInformationMessage(`Debug80: Saved to ${uri.path.split('/').pop()}`);
-  }
-
   private nextUiRevision(): number {
     this.uiRevision += 1;
     return this.uiRevision;
@@ -574,66 +484,4 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     this.postMessage({ type: 'snapshot', ...snapshotObject });
   }
 
-  private getNonce(): string {
-    let text = '';
-    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 32; i += 1) {
-      text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
-  }
-
-  private getIdleHtml(): string {
-    const nonce = this.getNonce();
-    const folders = vscode.workspace.workspaceFolders ?? [];
-    const multiRoot = folders.length > 1;
-    if (!this.hasProject) {
-      return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy"
-        content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-</head>
-<body style="padding: 16px; font-family: var(--vscode-font-family); color: var(--vscode-foreground);">
-  <p>Debug80</p>
-  <p style="opacity: 0.7;">Create a Debug80 project to get started.</p>
-</body>
-</html>`;
-    }
-    const selectedLabel = this.selectedWorkspace?.name ?? 'Workspace';
-    const selectionHint =
-      multiRoot && !this.selectedWorkspace
-        ? 'Select a workspace folder with “Debug80: Select Workspace Folder”.'
-        : '';
-    return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy"
-        content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-</head>
-<body style="padding: 16px; font-family: var(--vscode-font-family); color: var(--vscode-foreground);">
-  <p>Debug80</p>
-  <p style="opacity: 0.7;">Project detected (${selectedLabel}). Start a debug session to see the platform UI.</p>
-  <button id="startDebug" style="margin-top: 8px; padding: 6px 10px; font-size: 12px;">
-    Start Debugging
-  </button>
-  ${selectionHint ? `<p style="opacity: 0.7;">${selectionHint}</p>` : ''}
-  <script nonce="${nonce}">
-    (function () {
-      const vscode = acquireVsCodeApi();
-      const button = document.getElementById('startDebug');
-      if (button) {
-        button.addEventListener('click', () => {
-          vscode.postMessage({ type: 'startDebug' });
-        });
-      }
-    }());
-  </script>
-</body>
-</html>`;
-  }
 }

--- a/src/extension/platform-view-serial-actions.ts
+++ b/src/extension/platform-view-serial-actions.ts
@@ -1,0 +1,122 @@
+/**
+ * @file Serial file workflows for the Debug80 platform view.
+ */
+
+import * as vscode from 'vscode';
+
+import type { PlatformViewPlatform } from './platform-view-messages';
+
+export interface PlatformSerialActionsContext {
+  getSession: () => vscode.DebugSession | undefined;
+  getPlatform: () => PlatformViewPlatform | undefined;
+}
+
+/**
+ * Sends a file to the active serial input one character at a time.
+ */
+export async function handlePlatformSerialSendFile(
+  ctx: PlatformSerialActionsContext
+): Promise<void> {
+  const uris = await vscode.window.showOpenDialog({
+    canSelectMany: false,
+    filters: {
+      'Intel HEX': ['hex'],
+      'Text Files': ['txt'],
+      'All Files': ['*'],
+    },
+    title: 'Select file to send',
+  });
+  if (!uris || uris.length === 0) {
+    return;
+  }
+
+  const fileUri = uris[0]!;
+  const fileName = fileUri.path.split('/').pop() ?? 'file';
+  const fileBytes = await vscode.workspace.fs.readFile(fileUri);
+  const fileText = new TextDecoder('utf-8').decode(fileBytes);
+
+  const session = ctx.getSession();
+  if (!session || session.type !== 'z80') {
+    void vscode.window.showErrorMessage('Debug80: No active debug session.');
+    return;
+  }
+
+  const command = ctx.getPlatform() === 'tec1g' ? 'debug80/tec1gSerialInput' : 'debug80/tec1SerialInput';
+  const charDelayMs = 2;
+  const lineDelayMs = 10;
+
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: `Sending ${fileName}...`,
+      cancellable: true,
+    },
+    async (progress, token) => {
+      const lines = fileText.split(/\r?\n/);
+      let charsSent = 0;
+      const totalChars = fileText.length;
+
+      for (const line of lines) {
+        if (token.isCancellationRequested) {
+          void vscode.window.showWarningMessage('Debug80: File send cancelled.');
+          return;
+        }
+        for (const char of line) {
+          if (token.isCancellationRequested) {
+            return;
+          }
+          try {
+            await session.customRequest(command, { text: char });
+          } catch {
+            void vscode.window.showErrorMessage('Debug80: Failed to send character.');
+            return;
+          }
+          charsSent += 1;
+          if (charDelayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, charDelayMs));
+          }
+        }
+        try {
+          await session.customRequest(command, { text: '\r' });
+        } catch {
+          /* ignore */
+        }
+        charsSent += 1;
+        progress.report({ increment: (100 * (line.length + 1)) / totalChars });
+        if (lineDelayMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, lineDelayMs));
+        }
+      }
+      void vscode.window.showInformationMessage(`Debug80: Sent ${charsSent} characters.`);
+    }
+  );
+}
+
+/**
+ * Saves the current serial buffer to a file, preferring HEX when the
+ * contents look like Intel HEX.
+ */
+export async function handlePlatformSerialSave(text: string): Promise<void> {
+  if (!text || text.length === 0) {
+    void vscode.window.showWarningMessage('Debug80: Serial buffer is empty.');
+    return;
+  }
+
+  const lines = text.split(/\r?\n/).filter((line) => line.length > 0);
+  const isHex = lines.length > 0 && lines.every((line) => line.startsWith(':') || line.trim() === '');
+  const filters: Record<string, string[]> = isHex
+    ? { 'Intel HEX': ['hex'], 'Text Files': ['txt'] }
+    : { 'Text Files': ['txt'], 'All Files': ['*'] };
+
+  const uri = await vscode.window.showSaveDialog({
+    filters,
+    title: 'Save serial output',
+  });
+  if (!uri) {
+    return;
+  }
+
+  const encoder = new TextEncoder();
+  await vscode.workspace.fs.writeFile(uri, encoder.encode(text));
+  void vscode.window.showInformationMessage(`Debug80: Saved to ${uri.path.split('/').pop()}`);
+}

--- a/tests/extension/platform-view-idle-html.test.ts
+++ b/tests/extension/platform-view-idle-html.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @file Regression tests for platform view idle HTML.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  createPlatformViewNonce,
+  getPlatformViewIdleHtml,
+} from '../../src/extension/platform-view-idle-html';
+
+describe('platform-view idle html', () => {
+  it('renders the no-project placeholder with a nonce', () => {
+    const html = getPlatformViewIdleHtml({
+      hasProject: false,
+      nonce: 'abc123',
+      multiRoot: false,
+    });
+
+    expect(html).toContain('Create a Debug80 project to get started.');
+    expect(html).toContain("script-src 'nonce-abc123'");
+    expect(html).not.toContain('Start Debugging');
+  });
+
+  it('renders the project-detected view and workspace hint', () => {
+    const html = getPlatformViewIdleHtml({
+      hasProject: true,
+      multiRoot: true,
+      nonce: 'xyz789',
+    });
+
+    expect(html).toContain('Project detected (Workspace).');
+    expect(html).toContain('Start Debugging');
+    expect(html).toContain("script-src 'nonce-xyz789'");
+    expect(html).toContain('Select a workspace folder with');
+  });
+
+  it('creates a 32-character nonce', () => {
+    expect(createPlatformViewNonce()).toHaveLength(32);
+  });
+});

--- a/tests/extension/platform-view-serial-actions.test.ts
+++ b/tests/extension/platform-view-serial-actions.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @file Regression tests for platform view serial file workflows.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const showOpenDialog = vi.fn();
+  const showSaveDialog = vi.fn();
+  const showErrorMessage = vi.fn();
+  const showWarningMessage = vi.fn();
+  const showInformationMessage = vi.fn();
+  const readFile = vi.fn();
+  const writeFile = vi.fn();
+  const withProgress = vi.fn();
+  const customRequest = vi.fn(() => Promise.resolve(undefined));
+  return {
+    showOpenDialog,
+    showSaveDialog,
+    showErrorMessage,
+    showWarningMessage,
+    showInformationMessage,
+    readFile,
+    writeFile,
+    withProgress,
+    activeDebugSession: { type: 'z80', customRequest },
+    customRequest,
+  };
+});
+
+vi.mock('vscode', () => ({
+  ProgressLocation: { Notification: 1 },
+  debug: { activeDebugSession: mocks.activeDebugSession },
+  window: {
+    showOpenDialog: mocks.showOpenDialog,
+    showSaveDialog: mocks.showSaveDialog,
+    showErrorMessage: mocks.showErrorMessage,
+    showWarningMessage: mocks.showWarningMessage,
+    showInformationMessage: mocks.showInformationMessage,
+    withProgress: mocks.withProgress,
+  },
+  workspace: {
+    fs: {
+      readFile: mocks.readFile,
+      writeFile: mocks.writeFile,
+    },
+  },
+}));
+
+import {
+  handlePlatformSerialSave,
+  handlePlatformSerialSendFile,
+} from '../../src/extension/platform-view-serial-actions';
+
+describe('platform-view serial actions', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    mocks.customRequest.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it('streams selected file bytes to the TEC-1 serial input', async () => {
+    const fileUri = { path: '/tmp/send.txt' };
+    mocks.showOpenDialog.mockResolvedValueOnce([fileUri]);
+    mocks.readFile.mockResolvedValueOnce(new TextEncoder().encode('AB'));
+    mocks.withProgress.mockImplementationOnce(async (_opts, callback: (progress: { report: (value: unknown) => void }, token: { isCancellationRequested: boolean }) => Promise<void> | void) => {
+      await callback(
+        {
+          report: vi.fn<(value: unknown) => void>(),
+        },
+        {
+          isCancellationRequested: false,
+        }
+      );
+    });
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: TimerHandler) => {
+      if (typeof callback === 'function') {
+        callback();
+      }
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+
+    await handlePlatformSerialSendFile({
+      getSession: () => mocks.activeDebugSession,
+      getPlatform: () => 'tec1',
+    });
+
+    expect(mocks.customRequest).toHaveBeenCalledWith('debug80/tec1SerialInput', {
+      text: 'A',
+    });
+    expect(mocks.customRequest).toHaveBeenCalledWith('debug80/tec1SerialInput', {
+      text: 'B',
+    });
+    expect(mocks.customRequest).toHaveBeenCalledWith('debug80/tec1SerialInput', {
+      text: '\r',
+    });
+    expect(mocks.showInformationMessage).toHaveBeenCalledWith('Debug80: Sent 3 characters.');
+  });
+
+  it('saves serial text using HEX filters when the buffer looks like Intel HEX', async () => {
+    mocks.showSaveDialog.mockResolvedValueOnce({ path: '/tmp/out.hex' });
+    await handlePlatformSerialSave(':00000001FF\n');
+
+    expect(mocks.showSaveDialog).toHaveBeenCalledWith({
+      filters: { 'Intel HEX': ['hex'], 'Text Files': ['txt'] },
+      title: 'Save serial output',
+    });
+    expect(mocks.writeFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns when the serial buffer is empty', async () => {
+    await handlePlatformSerialSave('');
+
+    expect(mocks.showWarningMessage).toHaveBeenCalledWith('Debug80: Serial buffer is empty.');
+    expect(mocks.showSaveDialog).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Extracted the serial file send/save workflows from `src/extension/platform-view-provider.ts` into `src/extension/platform-view-serial-actions.ts`.
- Extracted idle webview HTML generation into `src/extension/platform-view-idle-html.ts`.
- Kept provider behavior unchanged while removing the remaining inline serial/idle responsibilities from the provider class.

## Files changed
- `src/extension/platform-view-provider.ts`
- `src/extension/platform-view-serial-actions.ts`
- `src/extension/platform-view-idle-html.ts`
- `tests/extension/platform-view-serial-actions.test.ts`
- `tests/extension/platform-view-idle-html.test.ts`

## Verification
- `npx eslint src/extension/platform-view-provider.ts src/extension/platform-view-serial-actions.ts src/extension/platform-view-idle-html.ts tests/extension/platform-view-serial-actions.test.ts tests/extension/platform-view-idle-html.test.ts`
- `npx vitest run tests/extension/platform-view-serial-actions.test.ts tests/extension/platform-view-idle-html.test.ts`

## Notes
- The repo’s `typecheck` and `lint-staged` hooks also ran during commit.
