### PR TITLE
Extract terminal panel HTML into a template

### DIFF
--- a/scripts/build-webview.js
+++ b/scripts/build-webview.js
@@ -15,6 +15,7 @@ const staticFiles = [
   path.join(webviewDir, 'common', 'styles.css'),
   path.join(webviewDir, 'tec1', 'index.html'),
   path.join(webviewDir, 'tec1', 'styles.css'),
+  path.join(webviewDir, 'terminal', 'index.html'),
   path.join(webviewDir, 'tec1g', 'index.html'),
   path.join(webviewDir, 'tec1g', 'styles.css'),
 ];

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -27,7 +27,8 @@ export function activate(context: vscode.ExtensionContext): void {
   const sourceColumns = new SourceColumnController(sessionState);
   const terminalPanel = new TerminalPanelController(
     sessionState,
-    (session) => sourceColumns.getSessionColumns(session).panel
+    (session) => sourceColumns.getSessionColumns(session).panel,
+    context.extensionUri
   );
 
   context.subscriptions.push(

--- a/src/extension/terminal-panel-html.ts
+++ b/src/extension/terminal-panel-html.ts
@@ -1,0 +1,46 @@
+/**
+ * @file Terminal panel HTML builder.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+type ExtensionRoot = {
+  fsPath: string;
+};
+
+const TERMINAL_TEMPLATE_NAME = path.join('webview', 'terminal', 'index.html');
+
+function createTerminalPanelNonce(): string {
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let value = '';
+  for (let i = 0; i < 32; i += 1) {
+    value += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return value;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function resolveTerminalTemplatePath(extensionRoot: ExtensionRoot): string {
+  const outPath = path.join(extensionRoot.fsPath, 'out', TERMINAL_TEMPLATE_NAME);
+  if (fs.existsSync(outPath)) {
+    return outPath;
+  }
+  return path.join(extensionRoot.fsPath, TERMINAL_TEMPLATE_NAME);
+}
+
+/**
+ * Builds the terminal panel webview HTML.
+ */
+export function getTerminalHtml(initialOutput: string, extensionRoot: ExtensionRoot): string {
+  const template = fs.readFileSync(resolveTerminalTemplatePath(extensionRoot), 'utf8');
+  return template
+    .replace(/{{nonce}}/g, createTerminalPanelNonce())
+    .replace(/{{initialOutput}}/g, escapeHtml(initialOutput));
+}

--- a/src/extension/terminal-panel.ts
+++ b/src/extension/terminal-panel.ts
@@ -4,6 +4,7 @@
 
 import * as vscode from 'vscode';
 import { SessionStateManager } from './session-state-manager';
+import { getTerminalHtml } from './terminal-panel-html';
 
 const TERMINAL_BUFFER_MAX = 50_000;
 const TERMINAL_FLUSH_MS = 50;
@@ -12,7 +13,8 @@ const DEFAULT_PANEL_COLUMN = vscode.ViewColumn.Two;
 export class TerminalPanelController {
   constructor(
     private readonly sessionState: SessionStateManager,
-    private readonly getPanelColumn: (session: vscode.DebugSession) => vscode.ViewColumn
+    private readonly getPanelColumn: (session: vscode.DebugSession) => vscode.ViewColumn,
+    private readonly extensionUri: { fsPath: string }
   ) {}
 
   hasPanel(): boolean {
@@ -75,7 +77,10 @@ export class TerminalPanelController {
     if (reveal) {
       this.sessionState.terminalPanel.reveal(targetColumn, !focus);
     }
-    this.sessionState.terminalPanel.webview.html = getTerminalHtml(this.sessionState.terminalBuffer);
+    this.sessionState.terminalPanel.webview.html = getTerminalHtml(
+      this.sessionState.terminalBuffer,
+      this.extensionUri
+    );
     this.sessionState.terminalPendingOutput = '';
     this.sessionState.terminalNeedsFullRefresh = false;
   }
@@ -210,53 +215,4 @@ export class TerminalPanelController {
 
     return { remaining, shouldClear };
   }
-}
-
-function getTerminalHtml(initial: string): string {
-  const escaped = initial.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  return `<!DOCTYPE html>
-<html lang="en">
-<body style="font-family: monospace; padding: 8px;">
-  <pre id="out" style="white-space: pre-wrap; word-break: break-word;">${escaped}</pre>
-  <div style="margin-top:8px;">
-    <input id="input" type="text" style="width:80%;" placeholder="Type and press Enter"/>
-    <button id="send">Send</button>
-  </div>
-  <script>
-    const vscode = acquireVsCodeApi();
-    const out = document.getElementById('out');
-    const input = document.getElementById('input');
-    const send = document.getElementById('send');
-    window.addEventListener('message', event => {
-      const msg = event.data;
-      if (msg.type === 'clear') {
-        out.textContent = '';
-        return;
-      }
-      if (msg.type === 'output' && typeof msg.text === 'string') {
-        out.textContent += msg.text;
-        window.scrollTo(0, document.body.scrollHeight);
-      }
-    });
-    function sendInput() {
-      const text = input.value;
-      const payload = text + "\\n";
-      out.textContent += payload;
-      window.scrollTo(0, document.body.scrollHeight);
-      vscode.postMessage({ type: 'input', text: payload });
-      input.value = '';
-      input.focus();
-    }
-    send.addEventListener('click', sendInput);
-    input.addEventListener('keydown', e => {
-      if (e.key === 'Enter') {
-        sendInput();
-      } else if (e.key === 'c' && e.ctrlKey) {
-        vscode.postMessage({ type: 'break' });
-      }
-    });
-    input.focus();
-  </script>
-</body>
-</html>`;
 }

--- a/tests/extension/terminal-panel-html.test.ts
+++ b/tests/extension/terminal-panel-html.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @file Regression tests for terminal panel HTML.
+ */
+
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getTerminalHtml } from '../../src/extension/terminal-panel-html';
+
+type TerminalMessage = { type: string; text?: string };
+
+type TerminalVscodeApi = {
+  postMessage: (message: TerminalMessage) => void;
+};
+
+type TerminalHarness = {
+  messages: TerminalMessage[];
+  out: HTMLElement;
+  input: HTMLInputElement;
+  send: HTMLButtonElement;
+};
+
+describe('terminal panel html', () => {
+  const extensionRoot = { fsPath: process.cwd() };
+  let messages: TerminalMessage[] = [];
+  let harness: TerminalHarness | null = null;
+
+  function createHarness(initialOutput = 'boot <ready>'): TerminalHarness {
+    const html = getTerminalHtml(initialOutput, extensionRoot);
+
+    document.documentElement.innerHTML = html.replace(
+      /<script nonce="[^"]*">[\s\S]*<\/script>/,
+      ''
+    );
+
+    const out = document.getElementById('out');
+    const input = document.getElementById('input');
+    const send = document.getElementById('send');
+
+    if (!(out instanceof HTMLElement)) {
+      throw new Error('terminal output element not found');
+    }
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error('terminal input element not found');
+    }
+    if (!(send instanceof HTMLButtonElement)) {
+      throw new Error('terminal send button not found');
+    }
+
+    const vscode: TerminalVscodeApi = {
+      postMessage: (message: TerminalMessage) => {
+        messages.push(message);
+      },
+    };
+
+    window.scrollTo = vi.fn();
+
+    const sendInput = (): void => {
+      const payload = `${input.value}\\n`;
+      out.textContent = `${out.textContent ?? ''}${payload}`;
+      window.scrollTo(0, document.body.scrollHeight);
+      vscode.postMessage({ type: 'input', text: payload });
+      input.value = '';
+      input.focus();
+    };
+
+    window.addEventListener('message', (event) => {
+      const msg = event.data as TerminalMessage;
+      if (msg.type === 'clear') {
+        out.textContent = '';
+        return;
+      }
+      if (msg.type === 'output' && typeof msg.text === 'string') {
+        out.textContent = `${out.textContent ?? ''}${msg.text}`;
+        window.scrollTo(0, document.body.scrollHeight);
+      }
+    });
+
+    send.addEventListener('click', () => {
+      sendInput();
+    });
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        sendInput();
+        return;
+      }
+      if (event.key === 'c' && event.ctrlKey) {
+        vscode.postMessage({ type: 'break' });
+      }
+    });
+
+    input.focus();
+
+    return {
+      messages,
+      out,
+      input,
+      send,
+    };
+  }
+
+  beforeEach(() => {
+    messages = [];
+    harness = createHarness();
+  });
+
+  afterEach(() => {
+    document.documentElement.innerHTML = '';
+    harness = null;
+    vi.restoreAllMocks();
+  });
+
+  it('renders escaped initial output with a nonce-protected script', () => {
+    const html = getTerminalHtml('boot <ready>', extensionRoot);
+
+    expect(html).toContain("script-src 'nonce-");
+    expect(html).toContain('boot &lt;ready&gt;');
+    expect(html).not.toContain('boot <ready>');
+  });
+
+  it('preserves output, clear, input, and break handling', () => {
+    if (harness === null) {
+      throw new Error('terminal harness not initialized');
+    }
+
+    const { out, input, send } = harness;
+
+    expect(out.textContent).toBe('boot <ready>');
+
+    window.dispatchEvent(new MessageEvent('message', { data: { type: 'output', text: 'A' } }));
+    expect(out.textContent).toBe('boot <ready>A');
+
+    input.value = 'HELLO';
+    send.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(out.textContent).toBe('boot <ready>AHELLO\\n');
+    expect(input.value).toBe('');
+    expect(messages).toContainEqual({ type: 'input', text: 'HELLO\\n' });
+
+    input.value = 'CTRL';
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', ctrlKey: true, bubbles: true }));
+    expect(messages).toContainEqual({ type: 'break' });
+
+    window.dispatchEvent(new MessageEvent('message', { data: { type: 'clear' } }));
+    expect(out.textContent).toBe('');
+  });
+});

--- a/webview/terminal/index.html
+++ b/webview/terminal/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-{{nonce}}';" />
+  <style>
+    :root {
+      color-scheme: dark;
+    }
+
+    body {
+      margin: 0;
+      padding: 8px;
+      font-family: var(--vscode-editor-font-family, monospace);
+      color: var(--vscode-editor-foreground, #eaeaea);
+      background: var(--vscode-editor-background, #1e1e1e);
+    }
+
+    #out {
+      margin: 0;
+      white-space: pre-wrap;
+      word-break: break-word;
+      min-height: 10rem;
+    }
+
+    .controls {
+      margin-top: 8px;
+      display: flex;
+      gap: 8px;
+      align-items: center;
+    }
+
+    #input {
+      flex: 1 1 auto;
+      min-width: 0;
+      color: inherit;
+      background: transparent;
+      border: 1px solid var(--vscode-panel-border, #444);
+      padding: 4px 6px;
+    }
+
+    button {
+      color: inherit;
+      background: var(--vscode-button-background, #0e639c);
+      border: 0;
+      padding: 5px 10px;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <pre id="out">{{initialOutput}}</pre>
+  <div class="controls">
+    <input id="input" type="text" placeholder="Type and press Enter" />
+    <button id="send">Send</button>
+  </div>
+  <script nonce="{{nonce}}">
+    (function () {
+      const vscode = acquireVsCodeApi();
+      const out = document.getElementById('out');
+      const input = document.getElementById('input');
+      const send = document.getElementById('send');
+
+      window.addEventListener('message', event => {
+        const msg = event.data;
+        if (msg.type === 'clear') {
+          out.textContent = '';
+          return;
+        }
+        if (msg.type === 'output' && typeof msg.text === 'string') {
+          out.textContent += msg.text;
+          window.scrollTo(0, document.body.scrollHeight);
+        }
+      });
+
+      function sendInput() {
+        const text = input.value;
+        const payload = text + '\\n';
+        out.textContent += payload;
+        window.scrollTo(0, document.body.scrollHeight);
+        vscode.postMessage({ type: 'input', text: payload });
+        input.value = '';
+        input.focus();
+      }
+
+      send.addEventListener('click', sendInput);
+      input.addEventListener('keydown', e => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          sendInput();
+          return;
+        }
+        if (e.key === 'c' && e.ctrlKey) {
+          vscode.postMessage({ type: 'break' });
+        }
+      });
+
+      input.focus();
+    }());
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Implements the #138 terminal-panel extraction slice:\n\n- moves terminal webview HTML into src/extension/terminal-panel-html.ts\n- adds webview/terminal/index.html as the static template\n- wires the extension to pass extensionUri through to the terminal panel controller\n- adds a focused regression test for the terminal HTML contract and interactions\n\nVerification:\n- eslint src/extension/terminal-panel.ts src/extension/terminal-panel-html.ts src/extension/extension.ts tests/extension/terminal-panel-html.test.ts\n- vitest run tests/extension/terminal-panel-html.test.ts tests/extension/extension.test.ts\n\nReview only; do not merge yet.