### PR TITLE
refactor: extract TEC-1 webview modules

### DIFF
--- a/tests/webview/tec1-display-renderers.test.ts
+++ b/tests/webview/tec1-display-renderers.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @file Regression tests: TEC-1 LCD/matrix renderer contracts.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createLcdRenderer } from '../../webview/tec1/lcd-renderer';
+import { createMatrixRenderer } from '../../webview/tec1/matrix-renderer';
+
+const HTML_PATH = path.resolve(__dirname, '../../webview/tec1/index.html');
+
+type FakeContext2d = {
+  fillRect: ReturnType<typeof vi.fn>;
+  fillText: ReturnType<typeof vi.fn>;
+  fillStyle: string;
+  font: string;
+  textBaseline: CanvasTextBaseline;
+};
+
+function buildDom(): Document {
+  const html = fs.readFileSync(HTML_PATH, 'utf8').replace(/\{\{\w+\}\}/g, '');
+  document.documentElement.innerHTML = html;
+  return document;
+}
+
+function createContext(): FakeContext2d {
+  return {
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    fillStyle: '',
+    font: '',
+    textBaseline: 'top',
+  };
+}
+
+describe('tec1 display renderers', () => {
+  beforeEach(() => {
+    buildDom();
+    HTMLCanvasElement.prototype.getContext = function getContext() {
+      const canvas = this as HTMLCanvasElement & { __ctx?: FakeContext2d };
+      canvas.__ctx ??= createContext();
+      return canvas.__ctx as never;
+    };
+  });
+
+  it('renders LCD updates to the visible canvas', () => {
+    const renderer = createLcdRenderer();
+    const canvas = document.getElementById('lcdCanvas') as HTMLCanvasElement & {
+      __ctx: FakeContext2d;
+    };
+
+    renderer.applyLcdUpdate({ lcd: [0x41] });
+
+    expect(canvas.width).toBeGreaterThan(0);
+    expect(canvas.height).toBeGreaterThan(0);
+    expect(canvas.__ctx.fillRect).toHaveBeenCalledTimes(1);
+    expect(canvas.__ctx.fillText).toHaveBeenCalled();
+  });
+
+  it('builds the matrix grid and lights updated cells', () => {
+    const renderer = createMatrixRenderer();
+    const grid = document.getElementById('matrixGrid') as HTMLElement;
+
+    renderer.build();
+    renderer.applyMatrixUpdate({ matrix: [0x01] });
+
+    expect(grid.querySelectorAll('.matrix-dot')).toHaveLength(64);
+    expect(grid.querySelector('[data-row="0"][data-col="0"]')?.classList.contains('on')).toBe(true);
+    expect(grid.querySelector('[data-row="0"][data-col="1"]')?.classList.contains('on')).toBe(false);
+  });
+});

--- a/tests/webview/tec1-serial-ui.test.ts
+++ b/tests/webview/tec1-serial-ui.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @file Regression test: TEC-1 serial UI contract.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { wireTec1SerialUi } from '../../webview/tec1/serial-ui';
+
+const HTML_PATH = path.resolve(__dirname, '../../webview/tec1/index.html');
+
+type PostedMessage = { type: string; text?: string };
+
+function buildDom(): Document {
+  const html = fs.readFileSync(HTML_PATH, 'utf8').replace(/\{\{\w+\}\}/g, '');
+  document.documentElement.innerHTML = html;
+  return document;
+}
+
+function createVscodeMock(messages: PostedMessage[]) {
+  return {
+    postMessage: (message: unknown) => {
+      messages.push(message as PostedMessage);
+    },
+    getState: () => null,
+    setState: () => {},
+  };
+}
+
+describe('tec1 serial UI', () => {
+  let doc: Document;
+  let messages: PostedMessage[];
+  let controller: { dispose: () => void } | null;
+
+  beforeEach(() => {
+    doc = buildDom();
+    messages = [];
+    controller = wireTec1SerialUi(createVscodeMock(messages));
+  });
+
+  it('routes serial messages into the output panel', () => {
+    const serialOut = doc.getElementById('serialOut') as HTMLElement;
+
+    window.dispatchEvent(new MessageEvent('message', { data: { type: 'serial', text: 'abc' } }));
+    expect(serialOut.textContent).toBe('abc');
+
+    window.dispatchEvent(
+      new MessageEvent('message', { data: { type: 'serialInit', text: 'boot' } })
+    );
+    expect(serialOut.textContent).toBe('boot');
+
+    window.dispatchEvent(new MessageEvent('message', { data: { type: 'serialClear' } }));
+    expect(serialOut.textContent).toBe('');
+  });
+
+  it('preserves the serial send/save/clear postMessage contract', () => {
+    const serialOut = doc.getElementById('serialOut') as HTMLElement;
+    const serialInput = doc.getElementById('serialInput') as HTMLInputElement;
+    const serialSend = doc.getElementById('serialSend') as HTMLElement;
+    const serialSendFile = doc.getElementById('serialSendFile') as HTMLElement;
+    const serialSave = doc.getElementById('serialSave') as HTMLElement;
+    const serialClear = doc.getElementById('serialClear') as HTMLElement;
+
+    serialInput.value = 'HELLO  ';
+    serialSend.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(messages).toContainEqual({ type: 'serialSend', text: 'HELLO\r' });
+    expect(serialInput.value).toBe('');
+
+    serialOut.textContent = 'log line';
+    serialSendFile.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(messages).toContainEqual({ type: 'serialSendFile' });
+
+    serialSave.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(messages).toContainEqual({ type: 'serialSave', text: 'log line' });
+
+    serialClear.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(serialOut.textContent).toBe('');
+    expect(messages).toContainEqual({ type: 'serialClear' });
+  });
+
+  afterEach(() => {
+    controller?.dispose();
+    controller = null;
+  });
+});

--- a/webview/tec1/audio.ts
+++ b/webview/tec1/audio.ts
@@ -1,0 +1,73 @@
+type AudioContextCtor = typeof AudioContext;
+
+export interface Tec1AudioController {
+  applyMuteState(): void;
+  setSpeakerHz(hz: number): void;
+  toggleMute(): void;
+  updateAudio(): void;
+}
+
+export function createAudioController(muteEl: HTMLElement | null): Tec1AudioController {
+  let muted = true;
+  let speakerHz = 0;
+  let audioCtx: AudioContext | null = null;
+  let osc: OscillatorNode | null = null;
+  let gain: GainNode | null = null;
+
+  const ensureAudio = (): void => {
+    if (!audioCtx) {
+      const Ctx =
+        window.AudioContext ??
+        (window as Window & { webkitAudioContext?: AudioContextCtor }).webkitAudioContext;
+      if (!Ctx) {
+        return;
+      }
+      audioCtx = new Ctx();
+      osc = audioCtx.createOscillator();
+      osc.type = 'square';
+      gain = audioCtx.createGain();
+      gain.gain.value = 0;
+      osc.connect(gain).connect(audioCtx.destination);
+      osc.start();
+    }
+    if (audioCtx.state === 'suspended') {
+      void audioCtx.resume();
+    }
+  };
+
+  const updateAudio = (): void => {
+    if (!audioCtx || !osc || !gain || muted || speakerHz <= 0) {
+      if (gain) {
+        gain.gain.value = 0;
+      }
+      return;
+    }
+    osc.frequency.setValueAtTime(speakerHz, audioCtx.currentTime);
+    gain.gain.setTargetAtTime(0.15, audioCtx.currentTime, 0.01);
+  };
+
+  const applyMuteState = (): void => {
+    if (muteEl) {
+      muteEl.textContent = muted ? 'MUTED' : 'SOUND';
+    }
+    if (muted && gain) {
+      gain.gain.value = 0;
+    }
+    updateAudio();
+  };
+
+  return {
+    applyMuteState,
+    setSpeakerHz(hz: number): void {
+      speakerHz = hz;
+    },
+    toggleMute(): void {
+      muted = !muted;
+      if (!muted) {
+        ensureAudio();
+      }
+      applyMuteState();
+    },
+    updateAudio,
+  };
+}

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -1,9 +1,11 @@
 import { createDigit } from '../common/digits';
 import { MemoryPanel } from '../common/memory-panel';
-import { appendSerialText, sendSerialInput } from '../common/serial';
 import { acquireVscodeApi } from '../common/vscode';
-
-type PanelTab = 'ui' | 'memory';
+import { createAudioController } from './audio';
+import { createLcdRenderer } from './lcd-renderer';
+import { createMatrixRenderer } from './matrix-renderer';
+import { createPanelLayoutController, type PanelTab } from './panel-layout';
+import { wireTec1SerialUi } from './serial-ui';
 
 const vscode = acquireVscodeApi();
 const DEFAULT_TAB: PanelTab = document.body.dataset.activeTab === 'memory' ? 'memory' : 'ui';
@@ -13,29 +15,13 @@ const speakerEl = document.getElementById('speaker') as HTMLElement;
 const speakerHzEl = document.getElementById('speakerHz') as HTMLElement;
 const speedEl = document.getElementById('speed') as HTMLElement;
 const muteEl = document.getElementById('mute') as HTMLElement;
-const serialOutEl = document.getElementById('serialOut') as HTMLElement;
-const serialInputEl = document.getElementById('serialInput') as HTMLInputElement;
-const serialSendEl = document.getElementById('serialSend') as HTMLElement;
-const serialSendFileEl = document.getElementById('serialSendFile') as HTMLElement;
-const serialSaveEl = document.getElementById('serialSave') as HTMLElement;
-const serialClearEl = document.getElementById('serialClear') as HTMLElement;
-const lcdCanvas = document.getElementById('lcdCanvas') as HTMLCanvasElement | null;
-const lcdCtx = lcdCanvas?.getContext('2d') ?? null;
-const matrixGrid = document.getElementById('matrixGrid') as HTMLElement;
 const tabButtons = Array.from(document.querySelectorAll<HTMLElement>('[data-tab]'));
 const panelUi = document.getElementById('panel-ui') as HTMLElement;
 const panelMemory = document.getElementById('panel-memory') as HTMLElement;
 const registerStrip = document.getElementById('registerStrip') as HTMLElement;
 const memoryPanel = document.getElementById('memoryPanel') as HTMLElement;
-const SERIAL_MAX = 8000;
 const SHIFT_BIT = 0x20;
 const DIGITS = 6;
-const LCD_COLS = 16;
-const LCD_ROWS = 2;
-const LCD_CELL_W = 14;
-const LCD_CELL_H = 20;
-let lcdBytes = new Array(LCD_COLS * LCD_ROWS).fill(0x20);
-let matrixRows = new Array(8).fill(0);
 const digitEls = [];
 for (let i = 0; i < DIGITS; i++) {
   const digit = createDigit();
@@ -43,83 +29,17 @@ for (let i = 0; i < DIGITS; i++) {
   displayEl.appendChild(digit);
 }
 
-let activeTab: PanelTab = DEFAULT_TAB === 'memory' ? 'memory' : 'ui';
-let memoryRowSize = 16;
-let resizeTimer: number | null = null;
 let memoryPanelController: MemoryPanel | null = null;
-const MEMORY_NARROW_MAX = 480;
-const MEMORY_WIDE_MIN = 520;
-
-function resolveMemoryRowSize(width: number): number {
-  if (!Number.isFinite(width)) {
-    return memoryRowSize;
-  }
-  if (width <= MEMORY_NARROW_MAX) {
-    return 8;
-  }
-  if (width >= MEMORY_WIDE_MIN) {
-    return 16;
-  }
-  return memoryRowSize;
-}
-
-function updateMemoryLayout(forceRefresh: boolean): void {
-  if (activeTab !== 'memory') {
-    return;
-  }
-  if (!memoryPanel) {
-    return;
-  }
-  const next = resolveMemoryRowSize(memoryPanel.clientWidth);
-  if (next !== memoryRowSize) {
-    memoryRowSize = next;
-    memoryPanelController?.requestSnapshot();
-    return;
-  }
-  if (forceRefresh) {
-    memoryPanelController?.requestSnapshot();
-  }
-}
-
-function scheduleMemoryResize(): void {
-  if (resizeTimer !== null) {
-    clearTimeout(resizeTimer);
-  }
-  resizeTimer = setTimeout(() => {
-    resizeTimer = null;
-    updateMemoryLayout(false);
-  }, 150);
-}
-
-function setTab(tab: string, notify: boolean): void {
-  activeTab = tab === 'memory' ? 'memory' : 'ui';
-  if (panelUi) {
-    panelUi.classList.toggle('active', activeTab === 'ui');
-  }
-  if (panelMemory) {
-    panelMemory.classList.toggle('active', activeTab === 'memory');
-  }
-  tabButtons.forEach((button) => {
-    const isActive = button.dataset.tab === activeTab;
-    button.classList.toggle('active', isActive);
-  });
-  if (notify) {
-    vscode.postMessage({ type: 'tab', tab: activeTab });
-  }
-  if (activeTab === 'memory') {
-    updateMemoryLayout(true);
-  }
-}
-
-tabButtons.forEach((button) => {
-  button.addEventListener('click', () => {
-    const tab = button.dataset.tab;
-    if (!tab) {
-      return;
-    }
-    setTab(tab, true);
-  });
+const panelLayout = createPanelLayoutController({
+  defaultTab: DEFAULT_TAB,
+  memoryPanel,
+  panelMemory,
+  panelUi,
+  postMessage: (message) => vscode.postMessage(message),
+  requestSnapshot: () => memoryPanelController?.requestSnapshot(),
+  tabButtons,
 });
+panelLayout.wireTabButtons();
 
 const keyMap = {
   '0': 0x00, '1': 0x01, '2': 0x02, '3': 0x03, '4': 0x04,
@@ -138,13 +58,10 @@ const hexOrder = [
 
 let speedMode = 'fast';
 let uiRevision = 0;
-let muted = true;
-let lastSpeakerOn = false;
-let lastSpeakerHz = 0;
 let shiftLatched = false;
-let audioCtx = null;
-let osc = null;
-let gain = null;
+const audio = createAudioController(muteEl);
+const lcdRenderer = createLcdRenderer();
+const matrixRenderer = createMatrixRenderer();
 
 function applySpeed(mode: string): void {
   speedMode = mode;
@@ -153,110 +70,9 @@ function applySpeed(mode: string): void {
   speedEl.classList.toggle('fast', mode === 'fast');
 }
 
-function lcdByteToChar(value: number): string {
-  const code = value & 0xff;
-  if (code === 0x5c) {
-    return '¥';
-  }
-  if (code === 0x7e) {
-    return '▶';
-  }
-  if (code === 0x7f) {
-    return '◀';
-  }
-  if (code >= 0x20 && code <= 0x7e) {
-    return String.fromCharCode(code);
-  }
-  return ' ';
-}
-
-function drawLcd(): void {
-  if (!lcdCtx || !lcdCanvas) {
-    return;
-  }
-  lcdCanvas.width = LCD_COLS * LCD_CELL_W;
-  lcdCanvas.height = LCD_ROWS * LCD_CELL_H;
-  lcdCtx.fillStyle = '#0b1a10';
-  lcdCtx.fillRect(0, 0, lcdCanvas.width, lcdCanvas.height);
-  lcdCtx.font = '16px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
-  lcdCtx.textBaseline = 'top';
-  lcdCtx.fillStyle = '#b4f5b4';
-  for (let row = 0; row < LCD_ROWS; row += 1) {
-    for (let col = 0; col < LCD_COLS; col += 1) {
-      const idx = row * LCD_COLS + col;
-      const char = lcdByteToChar(lcdBytes[idx] || 0x20);
-      lcdCtx.fillText(char, col * LCD_CELL_W + 2, row * LCD_CELL_H + 2);
-    }
-  }
-}
-
-function buildMatrix(): void {
-  if (!matrixGrid) return;
-  matrixGrid.innerHTML = '';
-  for (let row = 0; row < 8; row += 1) {
-    for (let col = 0; col < 8; col += 1) {
-      const dot = document.createElement('div');
-      dot.className = 'matrix-dot';
-      dot.dataset.row = String(row);
-      dot.dataset.col = String(col);
-      matrixGrid.appendChild(dot);
-    }
-  }
-}
-
-function drawMatrix(): void {
-  if (!matrixGrid) return;
-  const dots = matrixGrid.querySelectorAll('.matrix-dot');
-  dots.forEach(dot => {
-    const row = parseInt(dot.dataset.row || '0', 10);
-    const col = parseInt(dot.dataset.col || '0', 10);
-    const mask = 1 << col;
-    if (matrixRows[row] & mask) {
-      dot.classList.add('on');
-    } else {
-      dot.classList.remove('on');
-    }
-  });
-}
-
 function setShiftLatched(value: boolean): void {
   shiftLatched = value;
   shiftButton.classList.toggle('active', shiftLatched);
-}
-
-function ensureAudio(): void {
-  if (!audioCtx) {
-    const Ctx = window.AudioContext || window.webkitAudioContext;
-    audioCtx = new Ctx();
-    osc = audioCtx.createOscillator();
-    osc.type = 'square';
-    gain = audioCtx.createGain();
-    gain.gain.value = 0;
-    osc.connect(gain).connect(audioCtx.destination);
-    osc.start();
-  }
-  if (audioCtx.state === 'suspended') {
-    audioCtx.resume();
-  }
-}
-
-function updateAudio(): void {
-  if (!gain || muted || lastSpeakerHz <= 0) {
-    if (gain) {
-      gain.gain.value = 0;
-    }
-    return;
-  }
-  osc.frequency.setValueAtTime(lastSpeakerHz, audioCtx.currentTime);
-  gain.gain.setTargetAtTime(0.15, audioCtx.currentTime, 0.01);
-}
-
-function applyMuteState(): void {
-  muteEl.textContent = muted ? 'MUTED' : 'SOUND';
-  if (muted && gain) {
-    gain.gain.value = 0;
-  }
-  updateAudio();
 }
 
 function sendKey(code: number): void {
@@ -308,11 +124,7 @@ speedEl.addEventListener('click', () => {
   vscode.postMessage({ type: 'speed', mode: next });
 });
 muteEl.addEventListener('click', () => {
-  muted = !muted;
-  if (!muted) {
-    ensureAudio();
-  }
-  applyMuteState();
+  audio.toggleMute();
 });
 
 function updateDigit(el: Element, value: number): void {
@@ -347,31 +159,18 @@ function applyUpdate(payload: {
   if (speakerHzEl && typeof payload.speakerHz === 'number') {
     if (payload.speakerHz > 0) {
       speakerHzEl.textContent = payload.speakerHz + ' Hz';
-      lastSpeakerHz = payload.speakerHz;
+      audio.setSpeakerHz(payload.speakerHz);
     } else {
       speakerHzEl.textContent = '';
-      lastSpeakerHz = 0;
+      audio.setSpeakerHz(0);
     }
   }
-  lastSpeakerOn = !!payload.speaker;
-  updateAudio();
+  audio.updateAudio();
   if (payload.speedMode === 'slow' || payload.speedMode === 'fast') {
     applySpeed(payload.speedMode);
   }
-  if (Array.isArray(payload.lcd)) {
-    lcdBytes = payload.lcd.slice(0, LCD_COLS * LCD_ROWS);
-    while (lcdBytes.length < LCD_COLS * LCD_ROWS) {
-      lcdBytes.push(0x20);
-    }
-    drawLcd();
-  }
-  if (Array.isArray(payload.matrix)) {
-    matrixRows = payload.matrix.slice(0, 8);
-    while (matrixRows.length < 8) {
-      matrixRows.push(0);
-    }
-    drawMatrix();
-  }
+  lcdRenderer.applyLcdUpdate(payload);
+  matrixRenderer.applyMatrixUpdate(payload);
 }
 
 const statusEl = document.getElementById('status');
@@ -415,15 +214,16 @@ memoryPanelController = new MemoryPanel({
   registerStrip,
   statusEl,
   views,
-  getRowSize: () => memoryRowSize,
-  isActive: () => activeTab === 'memory',
+  getRowSize: () => panelLayout.getMemoryRowSize(),
+  isActive: () => panelLayout.getActiveTab() === 'memory',
 });
 memoryPanelController.wire();
+const serialUi = wireTec1SerialUi(vscode);
 
 window.addEventListener('message', event => {
   if (!event.data) return;
   if (event.data.type === 'selectTab') {
-    setTab(event.data.tab, false);
+    panelLayout.setTab(event.data.tab, false);
     return;
   }
   if (event.data.type === 'update') {
@@ -434,21 +234,9 @@ window.addEventListener('message', event => {
       uiRevision = event.data.uiRevision;
     }
     applyUpdate(event.data);
-    if (activeTab === 'memory') {
+    if (panelLayout.getActiveTab() === 'memory') {
       memoryPanelController?.requestSnapshot();
     }
-    return;
-  }
-  if (event.data.type === 'serial') {
-    appendSerialText(serialOutEl, event.data.text || '', SERIAL_MAX);
-    return;
-  }
-  if (event.data.type === 'serialInit') {
-    serialOutEl.textContent = event.data.text || '';
-    return;
-  }
-  if (event.data.type === 'serialClear') {
-    serialOutEl.textContent = '';
     return;
   }
   if (event.data.type === 'snapshot') {
@@ -461,38 +249,13 @@ window.addEventListener('message', event => {
 });
 
 applySpeed(speedMode);
-applyMuteState();
-drawLcd();
-buildMatrix();
-drawMatrix();
-setTab(DEFAULT_TAB, false);
-window.addEventListener('resize', scheduleMemoryResize);
-updateMemoryLayout(false);
-if (document.activeElement !== serialInputEl) {
-  document.getElementById('app').focus();
-}
-
-serialSendEl.addEventListener('click', () => {
-  sendSerialInput(serialInputEl, vscode);
-});
-serialInputEl.addEventListener('keydown', event => {
-  if (event.key === 'Enter') {
-    sendSerialInput(serialInputEl, vscode);
-    event.preventDefault();
-  }
-});
-
-serialSendFileEl.addEventListener('click', () => {
-  vscode.postMessage({ type: 'serialSendFile' });
-});
-serialSaveEl.addEventListener('click', () => {
-  const text = serialOutEl.textContent || '';
-  vscode.postMessage({ type: 'serialSave', text });
-});
-serialClearEl.addEventListener('click', () => {
-  serialOutEl.textContent = '';
-  vscode.postMessage({ type: 'serialClear' });
-});
+audio.applyMuteState();
+lcdRenderer.draw();
+matrixRenderer.build();
+matrixRenderer.draw();
+panelLayout.setTab(DEFAULT_TAB, false);
+window.addEventListener('resize', () => panelLayout.scheduleMemoryResize());
+panelLayout.updateMemoryLayout(false);
 
 window.addEventListener('keydown', event => {
   if (event.repeat) return;
@@ -522,5 +285,9 @@ window.addEventListener('keydown', event => {
     sendKey(0x13);
     event.preventDefault();
   }
+});
+
+window.addEventListener('beforeunload', () => {
+  serialUi.dispose();
 });
   

--- a/webview/tec1/lcd-renderer.ts
+++ b/webview/tec1/lcd-renderer.ts
@@ -1,0 +1,76 @@
+const LCD_COLS = 16;
+const LCD_ROWS = 2;
+const LCD_CELL_W = 14;
+const LCD_CELL_H = 20;
+const LCD_BYTES = LCD_COLS * LCD_ROWS;
+
+export type Tec1LcdPayload = {
+  lcd?: number[];
+};
+
+export interface Tec1LcdRenderer {
+  applyLcdUpdate(payload: Tec1LcdPayload): void;
+  draw(): void;
+}
+
+function lcdByteToChar(value: number): string {
+  const code = value & 0xff;
+  if (code === 0x5c) {
+    return '¥';
+  }
+  if (code === 0x7e) {
+    return '▶';
+  }
+  if (code === 0x7f) {
+    return '◀';
+  }
+  if (code >= 0x20 && code <= 0x7e) {
+    return String.fromCharCode(code);
+  }
+  return ' ';
+}
+
+function copyPadded(source: number[], size: number, fill: number): number[] {
+  const values = source.slice(0, size);
+  while (values.length < size) {
+    values.push(fill);
+  }
+  return values;
+}
+
+export function createLcdRenderer(): Tec1LcdRenderer {
+  const canvas = document.getElementById('lcdCanvas') as HTMLCanvasElement | null;
+  const ctx = canvas?.getContext('2d') ?? null;
+  let lcdBytes = new Array(LCD_BYTES).fill(0x20);
+
+  const draw = (): void => {
+    if (!ctx || !canvas) {
+      return;
+    }
+    canvas.width = LCD_COLS * LCD_CELL_W;
+    canvas.height = LCD_ROWS * LCD_CELL_H;
+    ctx.fillStyle = '#0b1a10';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.font = '16px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
+    ctx.textBaseline = 'top';
+    ctx.fillStyle = '#b4f5b4';
+    for (let row = 0; row < LCD_ROWS; row += 1) {
+      for (let col = 0; col < LCD_COLS; col += 1) {
+        const idx = row * LCD_COLS + col;
+        const char = lcdByteToChar(lcdBytes[idx] || 0x20);
+        ctx.fillText(char, col * LCD_CELL_W + 2, row * LCD_CELL_H + 2);
+      }
+    }
+  };
+
+  return {
+    applyLcdUpdate(payload: Tec1LcdPayload): void {
+      if (!Array.isArray(payload.lcd)) {
+        return;
+      }
+      lcdBytes = copyPadded(payload.lcd, LCD_BYTES, 0x20);
+      draw();
+    },
+    draw,
+  };
+}

--- a/webview/tec1/matrix-renderer.ts
+++ b/webview/tec1/matrix-renderer.ts
@@ -1,0 +1,63 @@
+export type Tec1MatrixPayload = {
+  matrix?: number[];
+};
+
+export interface Tec1MatrixRenderer {
+  applyMatrixUpdate(payload: Tec1MatrixPayload): void;
+  build(): void;
+  draw(): void;
+}
+
+function copyPadded(source: number[], size: number, fill: number): number[] {
+  const values = source.slice(0, size);
+  while (values.length < size) {
+    values.push(fill);
+  }
+  return values;
+}
+
+export function createMatrixRenderer(): Tec1MatrixRenderer {
+  const matrixGrid = document.getElementById('matrixGrid') as HTMLElement | null;
+  let matrixRows = new Array(8).fill(0);
+
+  const build = (): void => {
+    if (!matrixGrid) {
+      return;
+    }
+    matrixGrid.innerHTML = '';
+    for (let row = 0; row < 8; row += 1) {
+      for (let col = 0; col < 8; col += 1) {
+        const dot = document.createElement('div');
+        dot.className = 'matrix-dot';
+        dot.dataset.row = String(row);
+        dot.dataset.col = String(col);
+        matrixGrid.appendChild(dot);
+      }
+    }
+  };
+
+  const draw = (): void => {
+    if (!matrixGrid) {
+      return;
+    }
+    const dots = matrixGrid.querySelectorAll<HTMLElement>('.matrix-dot');
+    dots.forEach((dot) => {
+      const row = parseInt(dot.dataset.row || '0', 10);
+      const col = parseInt(dot.dataset.col || '0', 10);
+      const mask = 1 << col;
+      dot.classList.toggle('on', (matrixRows[row] & mask) !== 0);
+    });
+  };
+
+  return {
+    applyMatrixUpdate(payload: Tec1MatrixPayload): void {
+      if (!Array.isArray(payload.matrix)) {
+        return;
+      }
+      matrixRows = copyPadded(payload.matrix, 8, 0);
+      draw();
+    },
+    build,
+    draw,
+  };
+}

--- a/webview/tec1/panel-layout.ts
+++ b/webview/tec1/panel-layout.ts
@@ -1,0 +1,99 @@
+export type PanelTab = 'ui' | 'memory';
+
+const MEMORY_NARROW_MAX = 480;
+const MEMORY_WIDE_MIN = 520;
+
+export interface PanelLayoutController {
+  getActiveTab(): PanelTab;
+  getMemoryRowSize(): number;
+  scheduleMemoryResize(): void;
+  setTab(tab: string, notify: boolean): void;
+  updateMemoryLayout(forceRefresh: boolean): void;
+  wireTabButtons(): void;
+}
+
+type PanelLayoutOptions = {
+  defaultTab: PanelTab;
+  memoryPanel: HTMLElement | null;
+  panelMemory: HTMLElement | null;
+  panelUi: HTMLElement | null;
+  postMessage: (message: unknown) => void;
+  requestSnapshot: () => void;
+  tabButtons: HTMLElement[];
+};
+
+function resolveMemoryRowSize(width: number, currentSize: number): number {
+  if (!Number.isFinite(width)) {
+    return currentSize;
+  }
+  if (width <= MEMORY_NARROW_MAX) {
+    return 8;
+  }
+  if (width >= MEMORY_WIDE_MIN) {
+    return 16;
+  }
+  return currentSize;
+}
+
+export function createPanelLayoutController(options: PanelLayoutOptions): PanelLayoutController {
+  let activeTab: PanelTab = options.defaultTab === 'memory' ? 'memory' : 'ui';
+  let memoryRowSize = 16;
+  let resizeTimer: number | null = null;
+
+  const updateMemoryLayout = (forceRefresh: boolean): void => {
+    if (activeTab !== 'memory' || !options.memoryPanel) {
+      return;
+    }
+    const next = resolveMemoryRowSize(options.memoryPanel.clientWidth, memoryRowSize);
+    if (next !== memoryRowSize) {
+      memoryRowSize = next;
+      options.requestSnapshot();
+      return;
+    }
+    if (forceRefresh) {
+      options.requestSnapshot();
+    }
+  };
+
+  const setTab = (tab: string, notify: boolean): void => {
+    activeTab = tab === 'memory' ? 'memory' : 'ui';
+    options.panelUi?.classList.toggle('active', activeTab === 'ui');
+    options.panelMemory?.classList.toggle('active', activeTab === 'memory');
+    options.tabButtons.forEach((button) => {
+      button.classList.toggle('active', button.dataset.tab === activeTab);
+    });
+    if (notify) {
+      options.postMessage({ type: 'tab', tab: activeTab });
+    }
+    if (activeTab === 'memory') {
+      updateMemoryLayout(true);
+    }
+  };
+
+  return {
+    getActiveTab: (): PanelTab => activeTab,
+    getMemoryRowSize: (): number => memoryRowSize,
+    scheduleMemoryResize(): void {
+      if (resizeTimer !== null) {
+        clearTimeout(resizeTimer);
+      }
+      resizeTimer = window.setTimeout(() => {
+        resizeTimer = null;
+        updateMemoryLayout(false);
+      }, 150);
+    },
+    setTab,
+    updateMemoryLayout,
+    wireTabButtons(): void {
+      options.tabButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const tab = button.dataset.tab;
+          if (!tab) {
+            return;
+          }
+          setTab(tab, true);
+        });
+      });
+    },
+  };
+}

--- a/webview/tec1/serial-ui.ts
+++ b/webview/tec1/serial-ui.ts
@@ -1,0 +1,79 @@
+import { appendSerialText, sendSerialInput } from '../common/serial';
+import type { VscodeApi } from '../common/vscode';
+
+const SERIAL_MAX = 8000;
+
+export interface Tec1SerialUiController {
+  dispose(): void;
+}
+
+export function wireTec1SerialUi(vscode: VscodeApi): Tec1SerialUiController {
+  const serialOutEl = document.getElementById('serialOut') as HTMLElement | null;
+  const serialInputEl = document.getElementById('serialInput') as HTMLInputElement | null;
+  const serialSendEl = document.getElementById('serialSend') as HTMLElement | null;
+  const serialSendFileEl = document.getElementById('serialSendFile') as HTMLElement | null;
+  const serialSaveEl = document.getElementById('serialSave') as HTMLElement | null;
+  const serialClearEl = document.getElementById('serialClear') as HTMLElement | null;
+  const appEl = document.getElementById('app') as HTMLElement | null;
+
+  if (
+    !serialOutEl ||
+    !serialInputEl ||
+    !serialSendEl ||
+    !serialSendFileEl ||
+    !serialSaveEl ||
+    !serialClearEl
+  ) {
+    return { dispose: (): void => {} };
+  }
+
+  const onMessage = (event: MessageEvent): void => {
+    if (!event.data) {
+      return;
+    }
+    if (event.data.type === 'serial') {
+      appendSerialText(serialOutEl, event.data.text || '', SERIAL_MAX);
+      return;
+    }
+    if (event.data.type === 'serialInit') {
+      serialOutEl.textContent = event.data.text || '';
+      return;
+    }
+    if (event.data.type === 'serialClear') {
+      serialOutEl.textContent = '';
+    }
+  };
+
+  window.addEventListener('message', onMessage);
+
+  serialSendEl.addEventListener('click', () => {
+    sendSerialInput(serialInputEl, vscode);
+  });
+  serialInputEl.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      sendSerialInput(serialInputEl, vscode);
+      event.preventDefault();
+    }
+  });
+  serialSendFileEl.addEventListener('click', () => {
+    vscode.postMessage({ type: 'serialSendFile' });
+  });
+  serialSaveEl.addEventListener('click', () => {
+    const text = serialOutEl.textContent || '';
+    vscode.postMessage({ type: 'serialSave', text });
+  });
+  serialClearEl.addEventListener('click', () => {
+    serialOutEl.textContent = '';
+    vscode.postMessage({ type: 'serialClear' });
+  });
+
+  if (document.activeElement !== serialInputEl) {
+    appEl?.focus();
+  }
+
+  return {
+    dispose(): void {
+      window.removeEventListener('message', onMessage);
+    },
+  };
+}


### PR DESCRIPTION
Closes #133

## Summary

Extracts the main TEC-1 webview monolith into focused modules while preserving the existing typed entrypoint contract.

## Changes

- `webview/tec1/index.ts`: 526 -> 293 lines
- new `webview/tec1/lcd-renderer.ts` for LCD canvas rendering
- new `webview/tec1/matrix-renderer.ts` for matrix LED rendering
- new `webview/tec1/audio.ts` for Web Audio oscillator/mute management
- new `webview/tec1/panel-layout.ts` for tab switching and memory layout refresh logic
- new `webview/tec1/serial-ui.ts` for serial message/event wiring
- new webview regression tests for TEC-1 display renderers and serial UI

## Acceptance Criteria

- [x] `webview/tec1/index.ts` is under 350 lines (`293`)
- [x] Extracted modules are each under 200 lines
- [x] All typing is preserved with no `any` introduced
- [x] Panel behavior validated through build and webview regression tests

## Validation

- `npm run build`
- `npx vitest run -c vitest.webview.config.ts tests/webview/tec1-*.test.ts tests/webview/tec1g-*.test.ts`
