### PR TITLE
refactor: group TEC-1G LCD state

### DIFF
--- a/src/platforms/tec1g/runtime.ts
+++ b/src/platforms/tec1g/runtime.ts
@@ -103,7 +103,7 @@ export interface Tec1gState {
     lastEdgeCycle: number | null;
     silenceEventId: number | null;
   };
-  lcd: Tec1gLcdState;
+  lcdCtrl: Tec1gLcdState;
   timing: {
     cycleClock: CycleClock;
     lastUpdateMs: number;
@@ -297,7 +297,7 @@ export function createTec1gRuntime(
       lastEdgeCycle: null,
       silenceEventId: null,
     },
-    lcd: {
+    lcdCtrl: {
       lcd: Array.from({ length: 80 }, () => TEC1G_LCD_SPACE),
       lcdAddr: TEC1G_LCD_ROW0_START,
       lcdAddrMode: 'ddram',
@@ -340,7 +340,7 @@ export function createTec1gRuntime(
   const display = state.display;
   const input = state.input;
   const audio = state.audio;
-  const lcdState = state.lcd;
+  const lcdState = state.lcdCtrl;
   const timing = state.timing;
   const system = state.system;
   const lcdTest = 'ARROWS: ';

--- a/tests/debug/debug-addressing.test.ts
+++ b/tests/debug/debug-addressing.test.ts
@@ -33,7 +33,7 @@ const makeRuntime = (shadowEnabled: boolean): Tec1gRuntime =>
         lastEdgeCycle: null,
         silenceEventId: null,
       },
-      lcd: {
+      lcdCtrl: {
         lcd: [],
         lcdAddr: 0,
         lcdAddrMode: 'ddram',

--- a/tests/platforms/provider.test.ts
+++ b/tests/platforms/provider.test.ts
@@ -154,7 +154,7 @@ describe('platform providers', () => {
           lastEdgeCycle: null,
           silenceEventId: null,
         },
-        lcd: {
+        lcdCtrl: {
           lcd: [],
           lcdAddr: 0,
           lcdAddrMode: 'ddram',


### PR DESCRIPTION
Closes #134

## Summary

Align TEC-1G LCD state with the existing GLCD pattern by making the LCD controller state explicit on Tec1gState as lcdCtrl.

## Changes

- rename Tec1gState.lcd to Tec1gState.lcdCtrl
- update createTec1gRuntime initialization and local runtime access
- update typed TEC-1G runtime fixtures in debug and provider tests

## Validation

- npm run build
- npx vitest run tests/debug/debug-addressing.test.ts tests/platforms/provider.test.ts tests/platforms/tec1g/lcd.test.ts