### PR TITLE
test: narrow coverage exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,3 @@ jobs:
         run: npm run build
       - name: Test
         run: npm test
-      - name: Webview Tests
-        run: npm run test:webview

--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "pretest": "npm run build",
-    "test": "vitest run",
+    "test": "vitest run && npm run test:webview",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "perf:z80": "npm run build && node scripts/perf-z80.js",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,27 +12,48 @@ export default defineConfig({
       all: true,
       include: ['src/**/*.ts'],
       exclude: [
+        // Declarations and source-embedded test files do not contribute runtime coverage.
         'src/**/*.d.ts',
         'src/**/*.test.ts',
+        // Webview-only panel shells are exercised through platform and webview tests, not unit coverage.
         'src/**/ui-panel.ts',
         'src/**/memory-panel.ts',
-        'src/extension/**',
+        // VS Code extension entrypoints require the extension host instead of plain Vitest.
+        'src/extension/extension.ts',
+        'src/extension/platform-view-provider.ts',
+        'src/extension/terminal-panel.ts',
+        // These extension helpers are integration-heavy and currently produce low-signal unit coverage.
+        'src/extension/commands.ts',
+        'src/extension/debug-session-events.ts',
+        'src/extension/platform-view-state.ts',
+        'src/extension/project-scaffolding.ts',
+        'src/extension/rom-sources.ts',
+        'src/extension/session-state-manager.ts',
+        'src/extension/source-columns.ts',
+        'src/extension/workspace-selection.ts',
+        // The DAP session is covered by adapter integration tests rather than direct unit coverage.
         'src/debug/adapter.ts',
+        // These are barrel/configuration files with negligible runtime branching.
         'src/debug/types.ts',
         'src/debug/index.ts',
-        'src/platforms/**/runtime.ts',
+        // Runtime orchestrators are still integration-heavy; keep only the concrete files excluded.
+        'src/platforms/tec1/runtime.ts',
+        'src/platforms/tec1g/runtime.ts',
+        // Platform type declarations and clock helpers are structural support code.
         'src/platforms/**/types.ts',
         'src/platforms/serial/bitbang-uart.ts',
         'src/platforms/cycle-clock.ts',
+        // Bundled font/ROM lookup data is static and not meaningful for coverage accounting.
         'src/platforms/tec1g/hd44780-a00.ts',
         'src/platforms/tec1g/st7920-font.ts',
+        // Core Z80 execution is currently covered through higher-level runtime and adapter tests.
         'src/z80/decode.ts',
         'src/z80/decode-tables.ts',
         'src/z80/cpu.ts',
         'src/z80/runtime.ts',
         'src/z80/types.ts',
         'src/z80/opcode-types.ts',
-        // Type-only files (no runtime code)
+        // Type-only files have no runtime branches to measure.
         'src/z80/decode-types.ts',
       ],
       lines: 80,


### PR DESCRIPTION
Closes #135

## Summary

Make the coverage exclusions explicit, bring webview tests into the default npm test path, and expose the honest coverage baseline instead of hiding large runtime surfaces behind broad glob exclusions.

## Changes

- replace broad extension and platform runtime coverage globs with explicit file exclusions and inline justifications
- keep extracted controllers such as glcd, lcd, ds1302, sd-spi, and serial under coverage measurement
- make npm test run both the main Vitest suite and the webview suite
- remove the now-redundant standalone webview test step from CI

## Validation

- npm test
- npm run coverage

## Coverage Baseline

After narrowing the exclusions, coverage reports:
- lines/statements: 80.39%
- branches: 79.39%
- functions: 58.82%

The coverage command now fails on the existing global thresholds for branches and functions, which is the honest baseline this change is meant to expose.
