### PR TITLE
test: deepen GLCD and display renderer coverage

### DIFF
--- a/tests/platforms/tec1g/glcd.test.ts
+++ b/tests/platforms/tec1g/glcd.test.ts
@@ -124,4 +124,32 @@ describe('TEC-1G GLCD instruction handling', () => {
     // Back to basic
     rt.ioHandlers.write(0x07, 0x20);
   });
+
+  it('applies scroll address only while scroll mode is enabled', () => {
+    const rt = makeRuntime();
+
+    rt.ioHandlers.write(0x07, 0x24); // function set: RE=1, G=0
+    rt.ioHandlers.write(0x07, 0x4a); // scroll address 10 without scroll mode
+    expect(rt.state.display.glcdCtrl.glcdScroll).toBe(0);
+
+    rt.ioHandlers.write(0x07, 0x03); // enable scroll mode
+    rt.ioHandlers.write(0x07, 0x4a); // scroll address 10
+    expect(rt.state.display.glcdCtrl.glcdScroll).toBe(10);
+  });
+
+  it('shifts text after a complete DDRAM write when entry shift is enabled', () => {
+    const rt = makeRuntime();
+
+    rt.ioHandlers.write(0x07, 0x07); // entry mode: increment with shift
+    rt.ioHandlers.write(0x07, 0x80); // DDRAM addr
+    rt.ioHandlers.write(0x87, 0x41); // first byte, phase only
+    expect(rt.state.display.glcdCtrl.glcdTextShift).toBe(0);
+
+    rt.recordCycles(rt.state.timing.clockHz);
+    rt.ioHandlers.write(0x87, 0x42); // second byte completes the character cell
+
+    expect(rt.state.display.glcdCtrl.glcdTextShift).toBe(1);
+    expect(rt.state.display.glcdCtrl.glcdDdramAddr).toBe(0x81);
+    expect(rt.state.display.glcdCtrl.glcdDdramPhase).toBe(0);
+  });
 });

--- a/tests/webview/tec1-display-renderers.test.ts
+++ b/tests/webview/tec1-display-renderers.test.ts
@@ -58,6 +58,21 @@ describe('tec1 display renderers', () => {
     expect(canvas.__ctx.fillText).toHaveBeenCalled();
   });
 
+  it('maps special LCD bytes and pads the remaining cells with spaces', () => {
+    const renderer = createLcdRenderer();
+    const canvas = document.getElementById('lcdCanvas') as HTMLCanvasElement & {
+      __ctx: FakeContext2d;
+    };
+
+    renderer.applyLcdUpdate({ lcd: [0x5c, 0x7e, 0x7f] });
+
+    expect(canvas.__ctx.fillText).toHaveBeenNthCalledWith(1, '¥', 2, 2);
+    expect(canvas.__ctx.fillText).toHaveBeenNthCalledWith(2, '▶', 16, 2);
+    expect(canvas.__ctx.fillText).toHaveBeenNthCalledWith(3, '◀', 30, 2);
+    expect(canvas.__ctx.fillText).toHaveBeenNthCalledWith(4, ' ', 44, 2);
+    expect(canvas.__ctx.fillText).toHaveBeenCalledTimes(32);
+  });
+
   it('builds the matrix grid and lights updated cells', () => {
     const renderer = createMatrixRenderer();
     const grid = document.getElementById('matrixGrid') as HTMLElement;

--- a/tests/webview/tec1g-display-renderers.test.ts
+++ b/tests/webview/tec1g-display-renderers.test.ts
@@ -15,6 +15,7 @@ type FakeContext2d = {
   createImageData: ReturnType<typeof vi.fn>;
   drawImage: ReturnType<typeof vi.fn>;
   imageSmoothingEnabled: boolean;
+  lastImageData?: { data: Uint8ClampedArray };
   putImageData: ReturnType<typeof vi.fn>;
 };
 
@@ -25,7 +26,7 @@ function buildDom(): Document {
 }
 
 function createContext(): FakeContext2d {
-  return {
+  const ctx: FakeContext2d = {
     clearRect: vi.fn(),
     createImageData: vi.fn((width: number, height: number) => ({
       data: new Uint8ClampedArray(width * height * 4),
@@ -34,6 +35,40 @@ function createContext(): FakeContext2d {
     imageSmoothingEnabled: true,
     putImageData: vi.fn(),
   };
+  ctx.putImageData = vi.fn((image: { data: Uint8ClampedArray }) => {
+    ctx.lastImageData = image;
+  });
+  return ctx;
+}
+
+function readRgb(image: { data: Uint8ClampedArray }, width: number, x: number, y: number) {
+  const offset = (y * width + x) * 4;
+  return [image.data[offset], image.data[offset + 1], image.data[offset + 2]];
+}
+
+function expectRgb(
+  image: { data: Uint8ClampedArray },
+  width: number,
+  x: number,
+  y: number,
+  rgb: [number, number, number],
+) {
+  expect(readRgb(image, width, x, y)).toEqual(rgb);
+}
+
+function lastGlcdImage(canvas: HTMLCanvasElement & { __ctx: FakeContext2d }) {
+  const baseCanvas = canvas.__ctx.drawImage.mock.calls.at(-1)?.[0] as
+    | (HTMLCanvasElement & { __ctx?: FakeContext2d })
+    | undefined;
+  const image = baseCanvas?.__ctx?.lastImageData;
+  expect(image).toBeDefined();
+  return image!;
+}
+
+function lastLcdImage(canvas: HTMLCanvasElement & { __ctx: FakeContext2d }) {
+  const image = canvas.__ctx.lastImageData;
+  expect(image).toBeDefined();
+  return image!;
 }
 
 describe('tec1g display renderers', () => {
@@ -103,5 +138,58 @@ describe('tec1g display renderers', () => {
 
     expect(canvas.__ctx.clearRect).toHaveBeenCalledTimes(1);
     expect(canvas.__ctx.drawImage).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the GLCD cursor underline at the shifted display position', () => {
+    const glcdRenderer = createGlcdRenderer();
+    const canvas = document.getElementById('glcdCanvas') as HTMLCanvasElement & {
+      __ctx: FakeContext2d;
+    };
+
+    glcdRenderer.applyGlcdUpdate({
+      glcdState: {
+        cursorOn: true,
+        ddramAddr: 0x80,
+        ddramPhase: 0,
+        displayOn: true,
+        graphicsOn: false,
+        textShift: 0,
+      },
+    });
+    const unshifted = lastGlcdImage(canvas);
+    expectRgb(unshifted, 128, 0, 15, [32, 58, 22]);
+
+    glcdRenderer.applyGlcdUpdate({
+      glcdState: {
+        cursorOn: true,
+        ddramAddr: 0x80,
+        ddramPhase: 0,
+        displayOn: true,
+        graphicsOn: false,
+        textShift: 1,
+      },
+    });
+    const shifted = lastGlcdImage(canvas);
+    expectRgb(shifted, 128, 0, 15, [158, 182, 99]);
+  });
+
+  it('renders the LCD cursor underline at the shifted display position', () => {
+    lcdRenderer = createLcdRenderer();
+    const canvas = document.getElementById('lcdCanvas') as HTMLCanvasElement & {
+      __ctx: FakeContext2d;
+    };
+
+    lcdRenderer.applyLcdUpdate({
+      lcdState: {
+        cursorAddr: 0x80,
+        cursorOn: true,
+        displayOn: true,
+        displayShift: 1,
+      },
+    });
+
+    const image = lastLcdImage(canvas);
+    expectRgb(image, canvas.width, 1, 15, [11, 26, 16]);
+    expectRgb(image, canvas.width, 229, 15, [180, 245, 180]);
   });
 });


### PR DESCRIPTION
Refs #163

## Summary
- add GLCD controller tests for scroll-address gating and entry-shift text movement
- deepen TEC-1G renderer coverage with GLCD and LCD cursor-shift pixel assertions
- expand TEC-1 LCD renderer coverage for special-character mapping and padding

## Verification
- npx vitest run tests/platforms/tec1g/glcd.test.ts
- npx vitest run -c vitest.webview.config.ts tests/webview/tec1g-display-renderers.test.ts tests/webview/tec1-display-renderers.test.ts
- npx eslint tests/platforms/tec1g/glcd.test.ts tests/webview/tec1g-display-renderers.test.ts tests/webview/tec1-display-renderers.test.ts

## Residual risk
- renderer assertions still sample specific pixels rather than validating full image output, so broad visual regressions outside these paths can still slip through