### PR TITLE
feat: lazy-load platform providers and runtimes

### DIFF
--- a/src/debug/adapter.ts
+++ b/src/debug/adapter.ts
@@ -186,7 +186,7 @@ export class Z80DebugSession extends DebugSession {
     }
 
     try {
-      const artifacts = buildLaunchSession(
+      const artifacts = await buildLaunchSession(
         merged,
         createLaunchSequenceContext({
           logger: launchLogger,
@@ -208,23 +208,23 @@ export class Z80DebugSession extends DebugSession {
           },
         })
       );
-    applyLaunchSessionArtifacts(
-      { platformState: this.platformState, sessionState: this.sessionState },
-      artifacts
-    );
-    applyLaunchBreakpoints(
-      this.breakpointManager,
-      {
-        listing: this.sessionState.listing,
-        listingPath: this.sessionState.listingPath,
-        mappingIndex: this.sessionState.mappingIndex,
-      },
-      (event) => {
-        this.sendEvent(event);
-      }
-    );
-    this.sendResponse(response);
-    this.sendEntryStopIfNeeded();
+      applyLaunchSessionArtifacts(
+        { platformState: this.platformState, sessionState: this.sessionState },
+        artifacts
+      );
+      applyLaunchBreakpoints(
+        this.breakpointManager,
+        {
+          listing: this.sessionState.listing,
+          listingPath: this.sessionState.listingPath,
+          mappingIndex: this.sessionState.mappingIndex,
+        },
+        (event) => {
+          this.sendEvent(event);
+        }
+      );
+      this.sendResponse(response);
+      this.sendEntryStopIfNeeded();
     } catch (err) {
       if (err instanceof MissingLaunchArtifactsError) {
         await respondToMissingArtifacts(

--- a/src/debug/launch-sequence.ts
+++ b/src/debug/launch-sequence.ts
@@ -191,11 +191,11 @@ export interface LaunchSequenceContext {
   sendErrorResponse: (response: DP.Response, id: number, message: string) => void;
 }
 
-export function buildLaunchSession(
+export async function buildLaunchSession(
   merged: LaunchRequestArguments,
   context: LaunchSequenceContext
-): LaunchSessionArtifacts {
-  const platformProvider = resolvePlatformProvider(merged);
+): Promise<LaunchSessionArtifacts> {
+  const platformProvider = await resolvePlatformProvider(merged);
   const platform = platformProvider.id;
   const simpleConfig = platformProvider.simpleConfig;
   const tec1Config = platformProvider.tec1Config;
@@ -318,7 +318,7 @@ export function buildLaunchSession(
 
   const emitPlatformEvent = (name: string) => (payload: unknown) =>
     context.emitDapEvent(name, payload);
-  const platformIo = platformProvider.buildIoHandlers({
+  const platformIo = await platformProvider.buildIoHandlers({
     ...(merged.terminal !== undefined ? { terminal: merged.terminal } : {}),
     onTec1Update: emitPlatformEvent('debug80/tec1Update'),
     onTec1Serial: emitPlatformEvent('debug80/tec1Serial'),

--- a/src/debug/platform-host.ts
+++ b/src/debug/platform-host.ts
@@ -4,10 +4,10 @@
 
 import type { IoHandlers } from '../z80/runtime';
 import type { Tec1PlatformConfigNormalized, Tec1gPlatformConfigNormalized } from '../platforms/types';
-import { createTec1Runtime, Tec1Runtime } from '../platforms/tec1/runtime';
-import { createTec1gRuntime, Tec1gRuntime } from '../platforms/tec1g/runtime';
 import type { PlatformKind } from './program-loader';
 import type { TerminalConfig, TerminalConfigNormalized, TerminalState } from './terminal-types';
+import type { Tec1Runtime } from '../platforms/tec1/runtime';
+import type { Tec1gRuntime } from '../platforms/tec1g/runtime';
 
 export interface PlatformIoBuildOptions {
   platform: PlatformKind;
@@ -31,7 +31,9 @@ export interface PlatformIoBuildResult {
 /**
  * Builds platform-specific IO handlers and runtimes.
  */
-export function buildPlatformIoHandlers(options: PlatformIoBuildOptions): PlatformIoBuildResult {
+export async function buildPlatformIoHandlers(
+  options: PlatformIoBuildOptions
+): Promise<PlatformIoBuildResult> {
   const {
     platform,
     terminal,
@@ -48,10 +50,11 @@ export function buildPlatformIoHandlers(options: PlatformIoBuildOptions): Platfo
     if (!tec1Config) {
       return { ioHandlers: undefined };
     }
+    const { createTec1Runtime } = await import('../platforms/tec1/runtime.js');
     const tec1Runtime = createTec1Runtime(
       tec1Config,
-      (payload) => onTec1Update(payload),
-      (byte) => {
+      (payload: unknown) => onTec1Update(payload),
+      (byte: number) => {
         const value = byte & 0xff;
         const text = String.fromCharCode(value);
         onTec1Serial({ byte: value, text });
@@ -64,10 +67,11 @@ export function buildPlatformIoHandlers(options: PlatformIoBuildOptions): Platfo
     if (!tec1gConfig) {
       return { ioHandlers: undefined };
     }
+    const { createTec1gRuntime } = await import('../platforms/tec1g/runtime.js');
     const tec1gRuntime = createTec1gRuntime(
       tec1gConfig,
-      (payload) => onTec1gUpdate(payload),
-      (byte) => {
+      (payload: unknown) => onTec1gUpdate(payload),
+      (byte: number) => {
         const value = byte & 0xff;
         const text = String.fromCharCode(value);
         onTec1gSerial({ byte: value, text });

--- a/src/platforms/manifest.ts
+++ b/src/platforms/manifest.ts
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Lazy platform manifest for debug adapter platform providers.
+ */
+
+import { normalizePlatformName } from '../debug/launch-args';
+import type { LaunchRequestArguments } from '../debug/types';
+import type { PlatformKind } from '../debug/program-loader';
+import type { ResolvedPlatformProvider } from './provider';
+
+type PlatformProviderLoader = (
+  args: LaunchRequestArguments
+) => Promise<ResolvedPlatformProvider>;
+
+const platformLoaders = new Map<PlatformKind, PlatformProviderLoader>([
+  [
+    'simple',
+    async (args): Promise<ResolvedPlatformProvider> => {
+      const { createSimplePlatformProvider } = await import('./simple/provider.js');
+      return createSimplePlatformProvider(args);
+    },
+  ],
+  [
+    'tec1',
+    async (args): Promise<ResolvedPlatformProvider> => {
+      const { createTec1PlatformProvider } = await import('./tec1/provider.js');
+      return createTec1PlatformProvider(args);
+    },
+  ],
+  [
+    'tec1g',
+    async (args): Promise<ResolvedPlatformProvider> => {
+      const { createTec1gPlatformProvider } = await import('./tec1g/provider.js');
+      return createTec1gPlatformProvider(args);
+    },
+  ],
+]);
+
+export function registerPlatform(
+  platform: PlatformKind,
+  loadProvider: PlatformProviderLoader
+): void {
+  platformLoaders.set(platform, loadProvider);
+}
+
+export function listPlatforms(): PlatformKind[] {
+  return Array.from(platformLoaders.keys());
+}
+
+export async function resolvePlatformProvider(
+  args: LaunchRequestArguments
+): Promise<ResolvedPlatformProvider> {
+  const platform = normalizePlatformName(args);
+  const loadProvider = platformLoaders.get(platform);
+  if (loadProvider === undefined) {
+    throw new Error(`Unsupported platform: ${platform}`);
+  }
+  return loadProvider(args);
+}

--- a/src/platforms/provider.ts
+++ b/src/platforms/provider.ts
@@ -7,7 +7,6 @@ import type { PlatformIoBuildResult } from "../debug/platform-host";
 import type { PlatformRegistry } from "../debug/platform-registry";
 import type { PlatformKind } from "../debug/program-loader";
 import type { SessionStateShape } from "../debug/session-state";
-import type { LaunchRequestArguments } from "../debug/types";
 import type { TerminalConfig } from "../debug/terminal-types";
 import type { Z80Runtime } from "../z80/runtime";
 import type { Logger } from "../util/logger";
@@ -16,10 +15,6 @@ import type {
   Tec1PlatformConfigNormalized,
   Tec1gPlatformConfigNormalized,
 } from "./types";
-import { normalizePlatformName } from "../debug/launch-args";
-import { createSimplePlatformProvider } from "./simple/provider";
-import { createTec1PlatformProvider } from "./tec1/provider";
-import { createTec1gPlatformProvider } from "./tec1g/provider";
 
 export interface PlatformCommandContext {
   sessionState: SessionStateShape;
@@ -64,21 +59,10 @@ export interface ResolvedPlatformProvider {
   extraListings: string[];
   runtimeOptions?: { romRanges: Array<{ start: number; end: number }> };
   registerCommands: (registry: PlatformRegistry, context: PlatformCommandContext) => void;
-  buildIoHandlers: (callbacks: PlatformIoCallbacks) => PlatformIoBuildResult;
+  buildIoHandlers: (callbacks: PlatformIoCallbacks) => Promise<PlatformIoBuildResult>;
   loadAssets?: (context: PlatformAssetLoadContext) => unknown;
   resolveEntry: (assets?: unknown) => number | undefined;
   finalizeRuntime?: (context: PlatformRuntimeFinalizeContext) => void;
 }
 
-export function resolvePlatformProvider(
-  args: LaunchRequestArguments
-): ResolvedPlatformProvider {
-  switch (normalizePlatformName(args)) {
-    case "simple":
-      return createSimplePlatformProvider(args);
-    case "tec1":
-      return createTec1PlatformProvider(args);
-    case "tec1g":
-      return createTec1gPlatformProvider(args);
-  }
-}
+export { listPlatforms, registerPlatform, resolvePlatformProvider } from './manifest';

--- a/src/platforms/simple/provider.ts
+++ b/src/platforms/simple/provider.ts
@@ -18,7 +18,7 @@ export function createSimplePlatformProvider(
     extraListings: simpleConfig.extraListings ?? [],
     runtimeOptions: { romRanges: simpleConfig.romRanges },
     registerCommands: () => undefined,
-    buildIoHandlers: (callbacks) =>
+    buildIoHandlers: async (callbacks) =>
       buildPlatformIoHandlers({
         platform: "simple",
         ...(callbacks.terminal !== undefined ? { terminal: callbacks.terminal } : {}),

--- a/src/platforms/tec1/provider.ts
+++ b/src/platforms/tec1/provider.ts
@@ -95,7 +95,7 @@ export function createTec1PlatformProvider(
     registerCommands: (registry, context): void => {
       registry.register(buildTec1Contribution(context));
     },
-    buildIoHandlers: (callbacks): PlatformIoBuildResult =>
+    buildIoHandlers: async (callbacks): Promise<PlatformIoBuildResult> =>
       buildPlatformIoHandlers({
         platform: 'tec1',
         tec1Config,

--- a/src/platforms/tec1g/provider.ts
+++ b/src/platforms/tec1g/provider.ts
@@ -169,7 +169,7 @@ export function createTec1gPlatformProvider(
     registerCommands: (registry, context): void => {
       registry.register(buildTec1gContribution(context));
     },
-    buildIoHandlers: (callbacks): PlatformIoBuildResult =>
+    buildIoHandlers: async (callbacks): Promise<PlatformIoBuildResult> =>
       buildPlatformIoHandlers({
         platform: 'tec1g',
         tec1gConfig,

--- a/tests/debug/platform-host.test.ts
+++ b/tests/debug/platform-host.test.ts
@@ -30,8 +30,8 @@ describe('platform-host', () => {
     vi.clearAllMocks();
   });
 
-  it('returns undefined handlers when platform config is missing', () => {
-    const result = buildPlatformIoHandlers({
+  it('returns undefined handlers when platform config is missing', async () => {
+    const result = await buildPlatformIoHandlers({
       platform: 'tec1',
       onTec1Update: () => undefined,
       onTec1Serial: () => undefined,
@@ -44,8 +44,8 @@ describe('platform-host', () => {
     expect(result.tec1Runtime).toBeUndefined();
   });
 
-  it('creates tec1 runtime when config is provided', () => {
-    const result = buildPlatformIoHandlers({
+  it('creates tec1 runtime when config is provided', async () => {
+    const result = await buildPlatformIoHandlers({
       platform: 'tec1',
       tec1Config: { regions: [], romRanges: [], entry: 0, appStart: 0, updateMs: 16, yieldMs: 0 },
       onTec1Update: () => undefined,
@@ -59,8 +59,8 @@ describe('platform-host', () => {
     expect(result.tec1Runtime).toBeDefined();
   });
 
-  it('creates tec1g runtime when config is provided', () => {
-    const result = buildPlatformIoHandlers({
+  it('creates tec1g runtime when config is provided', async () => {
+    const result = await buildPlatformIoHandlers({
       platform: 'tec1g',
       tec1gConfig: { regions: [], romRanges: [], entry: 0, appStart: 0, updateMs: 16, yieldMs: 0 },
       onTec1Update: () => undefined,
@@ -74,9 +74,9 @@ describe('platform-host', () => {
     expect(result.tec1gRuntime).toBeDefined();
   });
 
-  it('builds terminal io handlers for simple platform', () => {
+  it('builds terminal io handlers for simple platform', async () => {
     const output: string[] = [];
-    const result = buildPlatformIoHandlers({
+    const result = await buildPlatformIoHandlers({
       platform: 'simple',
       terminal: { txPort: 4, rxPort: 5, statusPort: 6, interrupt: true },
       onTec1Update: () => undefined,
@@ -106,8 +106,8 @@ describe('platform-host', () => {
     expect(tickResult?.interrupt?.data).toBe(0x38);
   });
 
-  it('returns undefined handlers for simple platform without terminal', () => {
-    const result = buildPlatformIoHandlers({
+  it('returns undefined handlers for simple platform without terminal', async () => {
+    const result = await buildPlatformIoHandlers({
       platform: 'simple',
       onTec1Update: () => undefined,
       onTec1Serial: () => undefined,

--- a/tests/platforms/provider.test.ts
+++ b/tests/platforms/provider.test.ts
@@ -28,7 +28,10 @@ vi.mock('../../src/platforms/tec1g/tec1g-memory', () => ({
   applyCartridgeMemory,
 }));
 
-import { resolvePlatformProvider } from '../../src/platforms/provider';
+import {
+  listPlatforms,
+  resolvePlatformProvider,
+} from '../../src/platforms/provider';
 import { PlatformRegistry } from '../../src/debug/platform-registry';
 import { createSessionState } from '../../src/debug/session-state';
 import type { Tec1gRuntime } from '../../src/platforms/tec1g/runtime';
@@ -49,8 +52,12 @@ describe('platform providers', () => {
     vi.clearAllMocks();
   });
 
-  it('builds a simple provider with terminal IO delegation', () => {
-    const provider = resolvePlatformProvider({
+  it('lists the built-in platform manifest entries', () => {
+    expect(listPlatforms()).toEqual(['simple', 'tec1', 'tec1g']);
+  });
+
+  it('builds a simple provider with terminal IO delegation', async () => {
+    const provider = await resolvePlatformProvider({
       platform: 'simple',
       terminal: { txPort: 4 },
       simple: { entry: 0x1234, extraListings: ['rom.lst'] },
@@ -64,7 +71,7 @@ describe('platform providers', () => {
       romRanges: provider.simpleConfig?.romRanges ?? [],
     });
 
-    provider.buildIoHandlers({
+    await provider.buildIoHandlers({
       terminal: { txPort: 4 },
       onTec1Update: () => undefined,
       onTec1Serial: () => undefined,
@@ -81,8 +88,8 @@ describe('platform providers', () => {
     );
   });
 
-  it('registers TEC-1 commands through the platform registry', () => {
-    const provider = resolvePlatformProvider({
+  it('registers TEC-1 commands through the platform registry', async () => {
+    const provider = await resolvePlatformProvider({
       platform: 'tec1',
       tec1: { entry: 0x4567, extraListings: ['tec1.rom.lst'] },
     });
@@ -117,8 +124,8 @@ describe('platform providers', () => {
     expect(context.sessionState.tec1Runtime?.resetState).toHaveBeenCalledTimes(1);
   });
 
-  it('finalizes TEC-1G runtime setup through the provider hook', () => {
-    const provider = resolvePlatformProvider({
+  it('finalizes TEC-1G runtime setup through the provider hook', async () => {
+    const provider = await resolvePlatformProvider({
       platform: 'tec1g',
       tec1g: {
         entry: 0x2000,


### PR DESCRIPTION
## Summary
- add a lazy platform manifest that resolves built-in providers through dynamic imports
- make provider resolution, runtime construction, and launch session assembly async end-to-end
- remove eager TEC-1 and TEC-1G runtime imports from the platform host and update tests for the async seam

Closes #174
Closes #175