### PR TITLE
feat: expose Debug80 extension API

### DIFF
--- a/src/debug/launch-args.ts
+++ b/src/debug/launch-args.ts
@@ -24,9 +24,6 @@ export function normalizePlatformName(args: LaunchRequestArguments): PlatformKin
   if (name === '') {
     return 'simple';
   }
-  if (name !== 'simple' && name !== 'tec1' && name !== 'tec1g') {
-    throw new Error(`Unsupported platform "${raw}".`);
-  }
   return name;
 }
 

--- a/src/debug/program-loader.ts
+++ b/src/debug/program-loader.ts
@@ -9,7 +9,8 @@ import { Tec1PlatformConfigNormalized, Tec1gPlatformConfigNormalized } from '../
 import { Z80_ADDRESS_SPACE, TEC1_ROM_LOAD_ADDR } from '../platforms/tec-common';
 import { Logger } from '../util/logger';
 
-export type PlatformKind = 'simple' | 'tec1' | 'tec1g';
+export type BuiltInPlatformKind = 'simple' | 'tec1' | 'tec1g';
+export type PlatformKind = BuiltInPlatformKind | (string & Record<never, never>);
 
 export interface ProgramLoaderOptions {
   platform: PlatformKind;

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -13,11 +13,21 @@ import { SourceColumnController } from './source-columns';
 import { TerminalPanelController } from './terminal-panel';
 import { WorkspaceSelectionController } from './workspace-selection';
 import { OutputChannelLogger } from '../util/logger';
+import {
+  listPlatforms,
+  registerPlatform,
+  type PlatformManifestEntry,
+} from '../platforms/provider';
+
+export interface Debug80Api {
+  registerPlatform: (entry: PlatformManifestEntry) => void;
+  listPlatforms: () => PlatformManifestEntry[];
+}
 
 /**
  * Activates the Debug80 extension and registers commands/providers.
  */
-export function activate(context: vscode.ExtensionContext): void {
+export function activate(context: vscode.ExtensionContext): Debug80Api {
   const sessionState = new SessionStateManager();
   const output = vscode.window.createOutputChannel('Debug80');
   const logger = new OutputChannelLogger(output);
@@ -61,6 +71,11 @@ export function activate(context: vscode.ExtensionContext): void {
     terminalPanel,
     workspaceSelection,
   });
+
+  return {
+    registerPlatform,
+    listPlatforms,
+  };
 }
 
 /**

--- a/src/platforms/manifest.ts
+++ b/src/platforms/manifest.ts
@@ -11,48 +11,63 @@ type PlatformProviderLoader = (
   args: LaunchRequestArguments
 ) => Promise<ResolvedPlatformProvider>;
 
-const platformLoaders = new Map<PlatformKind, PlatformProviderLoader>([
+export interface PlatformManifestEntry {
+  id: PlatformKind;
+  displayName: string;
+  loadProvider: PlatformProviderLoader;
+}
+
+const platformEntries = new Map<PlatformKind, PlatformManifestEntry>([
   [
     'simple',
-    async (args): Promise<ResolvedPlatformProvider> => {
-      const { createSimplePlatformProvider } = await import('./simple/provider.js');
-      return createSimplePlatformProvider(args);
+    {
+      id: 'simple',
+      displayName: 'Simple',
+      loadProvider: async (args): Promise<ResolvedPlatformProvider> => {
+        const { createSimplePlatformProvider } = await import('./simple/provider.js');
+        return createSimplePlatformProvider(args);
+      },
     },
   ],
   [
     'tec1',
-    async (args): Promise<ResolvedPlatformProvider> => {
-      const { createTec1PlatformProvider } = await import('./tec1/provider.js');
-      return createTec1PlatformProvider(args);
+    {
+      id: 'tec1',
+      displayName: 'TEC-1',
+      loadProvider: async (args): Promise<ResolvedPlatformProvider> => {
+        const { createTec1PlatformProvider } = await import('./tec1/provider.js');
+        return createTec1PlatformProvider(args);
+      },
     },
   ],
   [
     'tec1g',
-    async (args): Promise<ResolvedPlatformProvider> => {
-      const { createTec1gPlatformProvider } = await import('./tec1g/provider.js');
-      return createTec1gPlatformProvider(args);
+    {
+      id: 'tec1g',
+      displayName: 'TEC-1G',
+      loadProvider: async (args): Promise<ResolvedPlatformProvider> => {
+        const { createTec1gPlatformProvider } = await import('./tec1g/provider.js');
+        return createTec1gPlatformProvider(args);
+      },
     },
   ],
 ]);
 
-export function registerPlatform(
-  platform: PlatformKind,
-  loadProvider: PlatformProviderLoader
-): void {
-  platformLoaders.set(platform, loadProvider);
+export function registerPlatform(entry: PlatformManifestEntry): void {
+  platformEntries.set(entry.id, entry);
 }
 
-export function listPlatforms(): PlatformKind[] {
-  return Array.from(platformLoaders.keys());
+export function listPlatforms(): PlatformManifestEntry[] {
+  return Array.from(platformEntries.values());
 }
 
 export async function resolvePlatformProvider(
   args: LaunchRequestArguments
 ): Promise<ResolvedPlatformProvider> {
   const platform = normalizePlatformName(args);
-  const loadProvider = platformLoaders.get(platform);
-  if (loadProvider === undefined) {
+  const entry = platformEntries.get(platform);
+  if (entry === undefined) {
     throw new Error(`Unsupported platform: ${platform}`);
   }
-  return loadProvider(args);
+  return entry.loadProvider(args);
 }

--- a/src/platforms/provider.ts
+++ b/src/platforms/provider.ts
@@ -65,4 +65,9 @@ export interface ResolvedPlatformProvider {
   finalizeRuntime?: (context: PlatformRuntimeFinalizeContext) => void;
 }
 
-export { listPlatforms, registerPlatform, resolvePlatformProvider } from './manifest';
+export {
+  listPlatforms,
+  registerPlatform,
+  resolvePlatformProvider,
+  type PlatformManifestEntry,
+} from './manifest';

--- a/tests/debug/launch-args.test.ts
+++ b/tests/debug/launch-args.test.ts
@@ -25,9 +25,9 @@ describe('launch-args', () => {
     expect(normalizePlatformName({ platform: 'TEC1' } as LaunchRequestArguments)).toBe('tec1');
     expect(normalizePlatformName({ platform: 'simple' } as LaunchRequestArguments)).toBe('simple');
     expect(normalizePlatformName({ platform: '' } as LaunchRequestArguments)).toBe('simple');
-    expect(() =>
-      normalizePlatformName({ platform: 'unknown' } as LaunchRequestArguments)
-    ).toThrow('Unsupported platform');
+    expect(normalizePlatformName({ platform: 'MicroBee' } as LaunchRequestArguments)).toBe(
+      'microbee'
+    );
   });
 
   it('resolves artifacts from asm path', () => {

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -81,14 +81,17 @@ describe('extension activation', () => {
 
   it('registers commands and adapter factory', async () => {
     const extension = (await import('../../src/extension/extension')) as {
-      activate: (context: { subscriptions: Array<{ dispose: () => void }> }) => void;
+      activate: (context: { subscriptions: Array<{ dispose: () => void }> }) => {
+        registerPlatform: (entry: { id: string; displayName: string }) => void;
+        listPlatforms: () => Array<{ id: string; displayName: string }>;
+      };
     };
     const context = {
       subscriptions: [] as Array<{ dispose: () => void }>,
       workspaceState: { get: vi.fn(), update: vi.fn() },
       extensionUri: { fsPath: '/tmp/debug80' },
     };
-    extension.activate(context);
+    const api = extension.activate(context);
 
     expect(registerDebugAdapterDescriptorFactory).toHaveBeenCalledWith('z80', expect.anything());
     expect(registerCommand).toHaveBeenCalledWith('debug80.createProject', expect.anything());
@@ -99,6 +102,11 @@ describe('extension activation', () => {
     expect(registerCommand).toHaveBeenCalledWith('debug80.openTec1Memory', expect.anything());
     expect(registerCommand).toHaveBeenCalledWith('debug80.openRomSource', expect.anything());
     expect(context.subscriptions.length).toBeGreaterThan(0);
+    expect(api.listPlatforms()).toEqual([
+      expect.objectContaining({ id: 'simple', displayName: 'Simple' }),
+      expect.objectContaining({ id: 'tec1', displayName: 'TEC-1' }),
+      expect.objectContaining({ id: 'tec1g', displayName: 'TEC-1G' }),
+    ]);
   }, 20000);
 
   it('forces asm documents to z80-asm when available', async () => {

--- a/tests/platforms/provider.test.ts
+++ b/tests/platforms/provider.test.ts
@@ -30,7 +30,9 @@ vi.mock('../../src/platforms/tec1g/tec1g-memory', () => ({
 
 import {
   listPlatforms,
+  registerPlatform,
   resolvePlatformProvider,
+  type PlatformManifestEntry,
 } from '../../src/platforms/provider';
 import { PlatformRegistry } from '../../src/debug/platform-registry';
 import { createSessionState } from '../../src/debug/session-state';
@@ -53,7 +55,40 @@ describe('platform providers', () => {
   });
 
   it('lists the built-in platform manifest entries', () => {
-    expect(listPlatforms()).toEqual(['simple', 'tec1', 'tec1g']);
+    expect(listPlatforms()).toEqual([
+      expect.objectContaining({ id: 'simple', displayName: 'Simple' }),
+      expect.objectContaining({ id: 'tec1', displayName: 'TEC-1' }),
+      expect.objectContaining({ id: 'tec1g', displayName: 'TEC-1G' }),
+    ]);
+  });
+
+  it('resolves a registered external platform provider', async () => {
+    const customProvider = {
+      id: 'microbee',
+      payload: { id: 'microbee' },
+      extraListings: [],
+      registerCommands: vi.fn(),
+      buildIoHandlers: vi.fn(() => Promise.resolve({ ioHandlers: undefined })),
+      resolveEntry: vi.fn(() => 0x4000),
+    };
+    const entry: PlatformManifestEntry = {
+      id: 'microbee',
+      displayName: 'MicroBee',
+      loadProvider: vi.fn(() => Promise.resolve(customProvider)),
+    };
+
+    registerPlatform(entry);
+
+    expect(listPlatforms()).toContainEqual(expect.objectContaining({ id: 'microbee' }));
+
+    const provider = await resolvePlatformProvider({
+      platform: 'microbee',
+    });
+
+    expect(entry.loadProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: 'microbee' })
+    );
+    expect(provider).toBe(customProvider);
   });
 
   it('builds a simple provider with terminal IO delegation', async () => {


### PR DESCRIPTION
## Summary
- return a typed Debug80Api from activate() with platform registration and discovery methods
- export PlatformManifestEntry and reshape the platform manifest around public entries with display names and async loaders
- allow externally registered platform ids through launch argument normalization and add tests for custom provider registration

Closes #176