### PR TITLE
feat: lazy-load platform view modules

### DIFF
--- a/src/extension/debug-session-events.ts
+++ b/src/extension/debug-session-events.ts
@@ -84,19 +84,13 @@ export function registerDebugSessionHandlers({
           sessionState.sessionPlatforms.set(evt.session.id, id);
         }
         workspaceSelection.rememberWorkspace(evt.session.workspaceFolder);
-        if (id === 'tec1') {
-          platformViewProvider.setPlatform('tec1', evt.session, {
+        if (id !== undefined && id.length > 0 && id !== 'simple') {
+          platformViewProvider.setPlatform(id, evt.session, {
             focus: false,
             reveal: true,
             tab: 'ui',
           });
-        } else if (id === 'tec1g') {
-          platformViewProvider.setPlatform('tec1g', evt.session, {
-            focus: false,
-            reveal: true,
-            tab: 'ui',
-          });
-          if (body?.uiVisibility) {
+          if (id === 'tec1g' && body?.uiVisibility) {
             platformViewProvider.setTec1gUiVisibility(body.uiVisibility, false);
           }
         } else {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -18,6 +18,11 @@ import {
   registerPlatform,
   type PlatformManifestEntry,
 } from '../platforms/provider';
+import {
+  registerPlatformUi,
+  type PlatformUiEntry,
+  type PlatformUiModules,
+} from './platform-view-manifest';
 
 export interface Debug80Api {
   registerPlatform: (entry: PlatformManifestEntry) => void;
@@ -25,9 +30,145 @@ export interface Debug80Api {
 }
 
 /**
+ *
+ */
+function registerBuiltInPlatformUis(): void {
+  registerPlatformUi(createTec1PlatformUiEntry());
+  registerPlatformUi(createTec1gPlatformUiEntry());
+}
+
+/**
+ *
+ */
+function createTec1PlatformUiEntry(): PlatformUiEntry {
+  return {
+    id: 'tec1',
+    loadUiModules: async (): Promise<PlatformUiModules> => {
+      const [html, memory, messages, state] = await Promise.all([
+        import('../platforms/tec1/ui-panel-html.js'),
+        import('../platforms/tec1/ui-panel-memory.js'),
+        import('../platforms/tec1/ui-panel-messages.js'),
+        import('../platforms/tec1/ui-panel-state.js'),
+      ]);
+      type Tec1UiState = ReturnType<typeof state.createTec1UiState>;
+      const serializeState = (uiState: Tec1UiState): Record<string, unknown> => ({
+        digits: uiState.digits,
+        matrix: uiState.matrix,
+        speaker: uiState.speaker,
+        speedMode: uiState.speedMode,
+        lcd: uiState.lcd,
+      });
+      return {
+        getHtml: html.getTec1Html,
+        createUiState: state.createTec1UiState,
+        resetUiState: (uiState): void => state.resetTec1UiState(uiState as Tec1UiState),
+        applyUpdate: (uiState, payload): Record<string, unknown> => {
+          const tec1State = uiState as Tec1UiState;
+          const tec1Payload = payload as Parameters<typeof state.applyTec1Update>[1];
+          state.applyTec1Update(tec1State, tec1Payload);
+          return {
+            ...serializeState(tec1State),
+            ...(tec1Payload.speakerHz !== undefined ? { speakerHz: tec1Payload.speakerHz } : {}),
+          };
+        },
+        createMemoryViewState: memory.createMemoryViewState,
+        handleMessage: (message, context): Promise<void> => messages.handleTec1Message(message, context),
+        buildUpdateMessage: (uiState, uiRevision): Record<string, unknown> => ({
+          type: 'update',
+          uiRevision,
+          ...serializeState(uiState as Tec1UiState),
+        }),
+        buildClearMessage: (uiState, uiRevision): Record<string, unknown> => {
+          const tec1State = uiState as Tec1UiState;
+          return {
+            type: 'update',
+            uiRevision,
+            digits: tec1State.digits,
+            matrix: tec1State.matrix,
+            speaker: false,
+            speedMode: tec1State.speedMode,
+            lcd: tec1State.lcd,
+          };
+        },
+        snapshotCommand: 'debug80/tec1MemorySnapshot',
+      };
+    },
+  };
+}
+
+/**
+ *
+ */
+function createTec1gPlatformUiEntry(): PlatformUiEntry {
+  return {
+    id: 'tec1g',
+    loadUiModules: async (): Promise<PlatformUiModules> => {
+      const [html, memory, messages, state] = await Promise.all([
+        import('../platforms/tec1g/ui-panel-html.js'),
+        import('../platforms/tec1g/ui-panel-memory.js'),
+        import('../platforms/tec1g/ui-panel-messages.js'),
+        import('../platforms/tec1g/ui-panel-state.js'),
+      ]);
+      type Tec1gUiState = ReturnType<typeof state.createTec1gUiState>;
+      const serializeState = (uiState: Tec1gUiState): Record<string, unknown> => ({
+        digits: uiState.digits,
+        matrix: uiState.matrix,
+        glcd: uiState.glcd,
+        glcdDdram: uiState.glcdDdram,
+        glcdState: uiState.glcdState,
+        speaker: uiState.speaker,
+        speedMode: uiState.speedMode,
+        sysCtrl: uiState.sysCtrlValue,
+        bankA14: uiState.bankA14,
+        capsLock: uiState.capsLock,
+        lcdState: uiState.lcdState,
+        lcdCgram: uiState.lcdCgram,
+        lcd: uiState.lcd,
+      });
+      return {
+        getHtml: html.getTec1gHtml,
+        createUiState: state.createTec1gUiState,
+        resetUiState: (uiState): void => state.resetTec1gUiState(uiState as Tec1gUiState),
+        applyUpdate: (uiState, payload): Record<string, unknown> => {
+          const tec1gState = uiState as Tec1gUiState;
+          const tec1gPayload = payload as Parameters<typeof state.applyTec1gUpdate>[1];
+          state.applyTec1gUpdate(tec1gState, tec1gPayload);
+          return {
+            ...serializeState(tec1gState),
+            ...(tec1gPayload.speakerHz !== undefined ? { speakerHz: tec1gPayload.speakerHz } : {}),
+          };
+        },
+        createMemoryViewState: memory.createMemoryViewState,
+        handleMessage: (message, context): Promise<void> => messages.handleTec1gMessage(message, context),
+        buildUpdateMessage: (uiState, uiRevision): Record<string, unknown> => ({
+          type: 'update',
+          uiRevision,
+          ...serializeState(uiState as Tec1gUiState),
+        }),
+        buildClearMessage: (uiState, uiRevision): Record<string, unknown> => {
+          const tec1gState = uiState as Tec1gUiState;
+          return {
+            type: 'update',
+            uiRevision,
+            digits: tec1gState.digits,
+            matrix: tec1gState.matrix,
+            glcd: tec1gState.glcd,
+            speaker: false,
+            speedMode: tec1gState.speedMode,
+            lcd: tec1gState.lcd,
+          };
+        },
+        snapshotCommand: 'debug80/tec1gMemorySnapshot',
+      };
+    },
+  };
+}
+
+/**
  * Activates the Debug80 extension and registers commands/providers.
  */
 export function activate(context: vscode.ExtensionContext): Debug80Api {
+  registerBuiltInPlatformUis();
   const sessionState = new SessionStateManager();
   const output = vscode.window.createOutputChannel('Debug80');
   const logger = new OutputChannelLogger(output);

--- a/src/extension/platform-view-manifest.ts
+++ b/src/extension/platform-view-manifest.ts
@@ -1,0 +1,59 @@
+/**
+ * @file Lazy platform UI manifest for the Debug80 platform sidebar.
+ */
+
+import type * as vscode from 'vscode';
+import type { PanelTab } from '../platforms/panel-html';
+import type { MemoryViewState } from '../platforms/panel-memory';
+import type {
+  RefreshController,
+} from '../platforms/panel-refresh';
+import type { PlatformViewMessage } from './platform-view-messages';
+
+export interface PlatformUiMessageContext {
+  getSession: () => vscode.DebugSession | undefined;
+  refreshController: RefreshController;
+  autoRefreshMs: number;
+  setActiveTab: (tab: PanelTab) => void;
+  getActiveTab: () => PanelTab;
+  isPanelVisible: () => boolean;
+  memoryViews: MemoryViewState;
+}
+
+export interface PlatformUiModules<TUiState = unknown> {
+  getHtml: (tab: PanelTab, webview: vscode.Webview, extensionUri: vscode.Uri) => string;
+  createUiState: () => TUiState;
+  resetUiState: (state: TUiState) => void;
+  applyUpdate: (state: TUiState, payload: unknown) => Record<string, unknown>;
+  createMemoryViewState: () => MemoryViewState;
+  handleMessage: (
+    message: PlatformViewMessage,
+    context: PlatformUiMessageContext
+  ) => Promise<void>;
+  buildUpdateMessage: (state: TUiState, uiRevision: number) => Record<string, unknown>;
+  buildClearMessage: (state: TUiState, uiRevision: number) => Record<string, unknown>;
+  snapshotCommand: 'debug80/tec1MemorySnapshot' | 'debug80/tec1gMemorySnapshot';
+}
+
+export interface PlatformUiEntry {
+  id: string;
+  loadUiModules: () => Promise<PlatformUiModules>;
+}
+
+const uiRegistry = new Map<string, PlatformUiEntry>();
+
+export function registerPlatformUi(entry: PlatformUiEntry): void {
+  uiRegistry.set(entry.id, entry);
+}
+
+export function listPlatformUis(): PlatformUiEntry[] {
+  return Array.from(uiRegistry.values());
+}
+
+export async function loadPlatformUi(id: string): Promise<PlatformUiModules> {
+  const entry = uiRegistry.get(id);
+  if (entry === undefined) {
+    throw new Error(`No UI registered for platform: ${id}`);
+  }
+  return entry.loadUiModules();
+}

--- a/src/extension/platform-view-messages.ts
+++ b/src/extension/platform-view-messages.ts
@@ -2,21 +2,24 @@
  * @file Message routing helpers for the Debug80 platform view webview.
  */
 
-import type { Tec1Message } from '../platforms/tec1/ui-panel-messages';
-import type { Tec1gMessage } from '../platforms/tec1g/ui-panel-messages';
+export type PlatformViewPlatform = string;
 
-export type PlatformViewPlatform = 'tec1' | 'tec1g' | 'simple';
-
-export type PlatformViewMessage = Tec1Message | Tec1gMessage | { type?: string; text?: string };
+export type PlatformViewMessage = {
+  type?: string;
+  text?: string;
+  [key: string]: unknown;
+};
 
 export interface PlatformViewMessageDependencies {
   currentPlatform: () => PlatformViewPlatform | undefined;
   handleStartDebug: () => PromiseLike<void>;
   handleSerialSendFile: () => PromiseLike<void>;
   handleSerialSave: (text: string) => PromiseLike<void>;
-  clearSerialBuffer: (platform: Exclude<PlatformViewPlatform, 'simple'>) => void;
-  handleTec1Message: (msg: Tec1Message) => PromiseLike<void>;
-  handleTec1gMessage: (msg: Tec1gMessage) => PromiseLike<void>;
+  clearSerialBuffer: (platform: PlatformViewPlatform) => void;
+  handlePlatformMessage: (
+    platform: PlatformViewPlatform,
+    msg: PlatformViewMessage
+  ) => PromiseLike<void>;
 }
 
 export async function handlePlatformViewMessage(
@@ -37,18 +40,14 @@ export async function handlePlatformViewMessage(
   }
   if (msg?.type === 'serialClear') {
     const platform = deps.currentPlatform();
-    if (platform === 'tec1' || platform === 'tec1g') {
+    if (platform !== undefined && platform !== 'simple') {
       deps.clearSerialBuffer(platform);
     }
     return;
   }
 
   const platform = deps.currentPlatform();
-  if (platform === 'tec1') {
-    await deps.handleTec1Message(msg as Tec1Message);
-    return;
-  }
-  if (platform === 'tec1g') {
-    await deps.handleTec1gMessage(msg as Tec1gMessage);
+  if (platform !== undefined && platform !== 'simple') {
+    await deps.handlePlatformMessage(platform, msg);
   }
 }

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -3,33 +3,11 @@
  */
 
 import * as vscode from 'vscode';
-import { getTec1Html } from '../platforms/tec1/ui-panel-html';
-import {
-  createMemoryViewState as createTec1MemoryViewState,
-} from '../platforms/tec1/ui-panel-memory';
-import { handleTec1Message } from '../platforms/tec1/ui-panel-messages';
 import {
   createRefreshController,
 } from '../platforms/panel-refresh';
-import {
-  type Tec1UiState,
-  applyTec1Update,
-  createTec1UiState,
-  resetTec1UiState,
-} from '../platforms/tec1/ui-panel-state';
 import { appendSerialText, clearSerialBuffer, createSerialBuffer } from '../platforms/panel-serial';
 import type { Tec1UpdatePayload } from '../platforms/tec1/types';
-import { getTec1gHtml } from '../platforms/tec1g/ui-panel-html';
-import {
-  createMemoryViewState as createTec1gMemoryViewState,
-} from '../platforms/tec1g/ui-panel-memory';
-import { handleTec1gMessage } from '../platforms/tec1g/ui-panel-messages';
-import {
-  type Tec1gUiState,
-  applyTec1gUpdate,
-  createTec1gUiState,
-  resetTec1gUiState,
-} from '../platforms/tec1g/ui-panel-state';
 import type { Tec1gUpdatePayload } from '../platforms/tec1g/types';
 import type { PanelTab } from '../platforms/panel-html';
 import {
@@ -49,6 +27,11 @@ import {
   stopPlatformRefresh,
   syncPlatformMemoryRefresh,
 } from './platform-view-state';
+import {
+  loadPlatformUi,
+  type PlatformUiMessageContext,
+  type PlatformUiModules,
+} from './platform-view-manifest';
 
 export class PlatformViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'debug80.platformView';
@@ -61,113 +44,90 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   private selectedWorkspace: vscode.WorkspaceFolder | undefined;
   private hasProject = false;
   private readonly extensionUri: vscode.Uri;
+  private readonly platformStates = new Map<PlatformViewPlatform, PlatformViewState<unknown>>();
+  private readonly platformStateLoads = new Map<
+    PlatformViewPlatform,
+    Promise<PlatformViewState<unknown> | undefined>
+  >();
 
   constructor(extensionUri: vscode.Uri) {
     this.extensionUri = extensionUri;
   }
 
-  private tec1 = this.initTec1Platform();
-  private tec1g = this.initTec1gPlatform();
   private tec1gUiVisibilityOverride: Record<string, boolean> | undefined;
 
-  private platformStateFor(
+  private getPlatformState(
     platform: PlatformViewPlatform | undefined,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): PlatformViewState<any> | undefined {
-    if (platform === 'tec1') {return this.tec1;}
-    if (platform === 'tec1g') {return this.tec1g;}
-    return undefined;
+  ): PlatformViewState<unknown> | undefined {
+    if (platform === undefined || platform === 'simple') {
+      return undefined;
+    }
+    return this.platformStates.get(platform);
   }
 
-  private initTec1Platform(): PlatformViewState<Tec1UiState> {
-    const ps: PlatformViewState<Tec1UiState> = {
+  private async ensurePlatformState(
+    platform: PlatformViewPlatform | undefined,
+  ): Promise<PlatformViewState<unknown> | undefined> {
+    if (platform === undefined || platform === 'simple') {
+      return undefined;
+    }
+    const existing = this.platformStates.get(platform);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const pending = this.platformStateLoads.get(platform);
+    if (pending !== undefined) {
+      return pending;
+    }
+    const load = this.loadPlatformState(platform);
+    this.platformStateLoads.set(platform, load);
+    try {
+      const state = await load;
+      if (state !== undefined) {
+        this.platformStates.set(platform, state);
+      }
+      return state;
+    } finally {
+      this.platformStateLoads.delete(platform);
+    }
+  }
+
+  private async loadPlatformState(
+    platform: PlatformViewPlatform,
+  ): Promise<PlatformViewState<unknown>> {
+    const modules = await loadPlatformUi(platform);
+    return this.buildPlatformState(modules);
+  }
+
+  private buildPlatformState<TUiState>(
+    modules: PlatformUiModules<TUiState>,
+  ): PlatformViewState<TUiState> {
+    const platformState: PlatformViewState<TUiState> = {
       activeTab: 'ui',
-      uiState: createTec1UiState(),
+      uiState: modules.createUiState(),
       serialBuffer: createSerialBuffer(),
-      memoryViews: createTec1MemoryViewState(),
-      snapshotCommand: 'debug80/tec1MemorySnapshot',
-      resetUiState: resetTec1UiState,
+      memoryViews: modules.createMemoryViewState(),
+      snapshotCommand: modules.snapshotCommand,
+      getHtml: modules.getHtml,
+      applyUpdate: modules.applyUpdate,
+      handleMessage: modules.handleMessage,
+      resetUiState: modules.resetUiState,
       clearSerialBuffer: clearSerialBuffer,
-      createMemoryViewState: createTec1MemoryViewState,
-      buildUpdateMessage: (state, uiRevision) => ({
-        type: 'update',
-        uiRevision,
-        digits: state.digits,
-        matrix: state.matrix,
-        speaker: state.speaker,
-        speedMode: state.speedMode,
-        lcd: state.lcd,
-      }),
-      buildClearMessage: (state, uiRevision) => ({
-        type: 'update',
-        uiRevision,
-        digits: state.digits,
-        matrix: state.matrix,
-        speaker: false,
-        speedMode: state.speedMode,
-        lcd: state.lcd,
-      }),
-      refreshController: undefined!,
+      createMemoryViewState: modules.createMemoryViewState,
+      buildUpdateMessage: modules.buildUpdateMessage,
+      buildClearMessage: modules.buildClearMessage,
+      refreshController: undefined as never,
     };
-    ps.refreshController = createRefreshController(
-      () => buildSnapshotPayload(ps.memoryViews),
+    const refreshController = createRefreshController(
+      () => buildSnapshotPayload(platformState.memoryViews),
       {
-        postSnapshot: async (payload) => this.postSnapshot(ps.snapshotCommand, payload),
+        postSnapshot: async (payload) => this.postSnapshot(modules.snapshotCommand, payload),
         onSnapshotPosted: () => undefined,
         onSnapshotFailed: (allowErrors) => this.onSnapshotFailed(allowErrors),
       },
     );
-    return ps;
-  }
-
-  private initTec1gPlatform(): PlatformViewState<Tec1gUiState> {
-    const ps: PlatformViewState<Tec1gUiState> = {
-      activeTab: 'ui',
-      uiState: createTec1gUiState(),
-      serialBuffer: createSerialBuffer(),
-      memoryViews: createTec1gMemoryViewState(),
-      snapshotCommand: 'debug80/tec1gMemorySnapshot',
-      resetUiState: resetTec1gUiState,
-      clearSerialBuffer: clearSerialBuffer,
-      createMemoryViewState: createTec1gMemoryViewState,
-      buildUpdateMessage: (state, uiRevision) => ({
-        type: 'update',
-        uiRevision,
-        digits: state.digits,
-        matrix: state.matrix,
-        glcd: state.glcd,
-        glcdDdram: state.glcdDdram,
-        glcdState: state.glcdState,
-        speaker: state.speaker,
-        speedMode: state.speedMode,
-        sysCtrl: state.sysCtrlValue,
-        bankA14: state.bankA14,
-        capsLock: state.capsLock,
-        lcdState: state.lcdState,
-        lcdCgram: state.lcdCgram,
-        lcd: state.lcd,
-      }),
-      buildClearMessage: (state, uiRevision) => ({
-        type: 'update',
-        uiRevision,
-        digits: state.digits,
-        matrix: state.matrix,
-        glcd: state.glcd,
-        speaker: false,
-        speedMode: state.speedMode,
-        lcd: state.lcd,
-      }),
-      refreshController: undefined!,
-    };
-    ps.refreshController = createRefreshController(
-      () => buildSnapshotPayload(ps.memoryViews),
-      {
-        postSnapshot: async (payload) => this.postSnapshot(ps.snapshotCommand, payload),
-        onSnapshotPosted: () => undefined,
-        onSnapshotFailed: (allowErrors) => this.onSnapshotFailed(allowErrors),
-      },
-    );
-    return ps;
+    platformState.refreshController = refreshController;
+    return platformState;
   }
 
   reveal(focus = false): void {
@@ -180,14 +140,14 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
 
   setSelectedWorkspace(folder: vscode.WorkspaceFolder | undefined): void {
     this.selectedWorkspace = folder;
-    if (!this.currentPlatform) {
+    if (this.currentPlatform === undefined) {
       this.renderCurrentView(true);
     }
   }
 
   setHasProject(value: boolean): void {
     this.hasProject = value;
-    if (!this.currentPlatform) {
+    if (this.currentPlatform === undefined) {
       this.renderCurrentView(true);
     }
   }
@@ -202,14 +162,25 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       this.currentSession = session;
       this.currentSessionId = session.id;
     }
-    const ps = this.platformStateFor(platform);
-    if (ps && (options?.tab === 'ui' || options?.tab === 'memory')) {
-      ps.activeTab = options.tab;
+    void this.applyPlatformSelection(platform, options);
+  }
+
+  private async applyPlatformSelection(
+    platform: PlatformViewPlatform,
+    options?: { focus?: boolean; reveal?: boolean; tab?: PanelTab }
+  ): Promise<void> {
+    try {
+      const ps = await this.ensurePlatformState(platform);
+      if (ps && (options?.tab === 'ui' || options?.tab === 'memory')) {
+        ps.activeTab = options.tab;
+      }
+      if (options?.reveal !== false) {
+        this.reveal(options?.focus ?? false);
+      }
+      this.renderCurrentView(true);
+    } catch (err) {
+      void vscode.window.showErrorMessage(`Debug80: Failed to load ${platform} UI: ${String(err)}`);
     }
-    if (options?.reveal !== false) {
-      this.reveal(options?.focus ?? false);
-    }
-    this.renderCurrentView(true);
   }
 
   setTec1gUiVisibility(visibility: Record<string, boolean> | undefined, persist = false): void {
@@ -227,83 +198,70 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   }
 
   updateTec1(payload: Tec1UpdatePayload, sessionId?: string): void {
-    if (!this.shouldAcceptSession(sessionId)) {
-      return;
-    }
-    applyTec1Update(this.tec1.uiState, payload);
-    if (this.currentPlatform !== 'tec1') {
-      return;
-    }
-    this.postMessage({
-      type: 'update',
-      uiRevision: this.nextUiRevision(),
-      digits: this.tec1.uiState.digits,
-      matrix: this.tec1.uiState.matrix,
-      speaker: this.tec1.uiState.speaker,
-      speedMode: this.tec1.uiState.speedMode,
-      lcd: this.tec1.uiState.lcd,
-      speakerHz: payload.speakerHz,
-    });
+    void this.applyPlatformUpdate('tec1', payload, sessionId);
   }
 
   updateTec1g(payload: Tec1gUpdatePayload, sessionId?: string): void {
+    void this.applyPlatformUpdate('tec1g', payload, sessionId);
+  }
+
+  private async applyPlatformUpdate(
+    platform: PlatformViewPlatform,
+    payload: unknown,
+    sessionId?: string,
+  ): Promise<void> {
     if (!this.shouldAcceptSession(sessionId)) {
       return;
     }
-    applyTec1gUpdate(this.tec1g.uiState, payload);
-    if (this.currentPlatform !== 'tec1g') {
+    const ps = await this.ensurePlatformState(platform);
+    if (!ps) {
+      return;
+    }
+    const updateMessage = ps.applyUpdate(ps.uiState, payload);
+    if (this.currentPlatform !== platform) {
       return;
     }
     this.postMessage({
       type: 'update',
       uiRevision: this.nextUiRevision(),
-      digits: this.tec1g.uiState.digits,
-      matrix: this.tec1g.uiState.matrix,
-      glcd: this.tec1g.uiState.glcd,
-      glcdDdram: this.tec1g.uiState.glcdDdram,
-      glcdState: this.tec1g.uiState.glcdState,
-      speaker: this.tec1g.uiState.speaker,
-      speedMode: this.tec1g.uiState.speedMode,
-      sysCtrl: this.tec1g.uiState.sysCtrlValue,
-      bankA14: this.tec1g.uiState.bankA14,
-      capsLock: this.tec1g.uiState.capsLock,
-      lcdState: this.tec1g.uiState.lcdState,
-      lcdCgram: this.tec1g.uiState.lcdCgram,
-      lcd: this.tec1g.uiState.lcd,
-      speakerHz: payload.speakerHz,
+      ...updateMessage,
     });
   }
 
   appendTec1Serial(text: string, sessionId?: string): void {
-    if (!this.shouldAcceptSession(sessionId)) {
-      return;
-    }
-    if (text.length === 0) {
-      return;
-    }
-    appendSerialText(this.tec1.serialBuffer, text);
-    if (this.currentPlatform === 'tec1') {
-      this.postMessage({ type: 'serial', text });
-    }
+    void this.appendPlatformSerial('tec1', text, sessionId);
   }
 
   appendTec1gSerial(text: string, sessionId?: string): void {
+    void this.appendPlatformSerial('tec1g', text, sessionId);
+  }
+
+  private async appendPlatformSerial(
+    platform: PlatformViewPlatform,
+    text: string,
+    sessionId?: string,
+  ): Promise<void> {
     if (!this.shouldAcceptSession(sessionId)) {
       return;
     }
     if (text.length === 0) {
       return;
     }
-    appendSerialText(this.tec1g.serialBuffer, text);
-    if (this.currentPlatform === 'tec1g') {
+    const ps = await this.ensurePlatformState(platform);
+    if (!ps) {
+      return;
+    }
+    appendSerialText(ps.serialBuffer, text);
+    if (this.currentPlatform === platform) {
       this.postMessage({ type: 'serial', text });
     }
   }
 
   clear(): void {
-    clearPlatformState(this.tec1);
-    clearPlatformState(this.tec1g);
-    const ps = this.platformStateFor(this.currentPlatform);
+    for (const ps of this.platformStates.values()) {
+      clearPlatformState(ps);
+    }
+    const ps = this.getPlatformState(this.currentPlatform);
     if (ps) {
       this.postMessage(ps.buildClearMessage(ps.uiState, this.nextUiRevision()));
       this.postMessage({ type: 'serialClear' });
@@ -316,8 +274,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     }
     this.currentSession = undefined;
     this.currentSessionId = undefined;
-    stopPlatformRefresh(this.tec1);
-    stopPlatformRefresh(this.tec1g);
+    this.stopAllPlatformRefresh();
     this.clear();
   }
 
@@ -344,40 +301,17 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
           }),
         handleSerialSave: (text) => handlePlatformSerialSave(text),
         clearSerialBuffer: (platform) => {
-          const ps = this.platformStateFor(platform);
+          const ps = this.getPlatformState(platform);
           if (ps) {clearSerialBuffer(ps.serialBuffer);}
         },
-        handleTec1Message: async (message) =>
-          handleTec1Message(message, {
-            getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
-            refreshController: this.tec1.refreshController,
-            autoRefreshMs: 150,
-            setActiveTab: (tab) => {
-              this.tec1.activeTab = tab;
-            },
-            getActiveTab: () => this.tec1.activeTab,
-            isPanelVisible: () => this.view?.visible === true,
-            memoryViews: this.tec1.memoryViews,
-          }),
-        handleTec1gMessage: async (message) =>
-          handleTec1gMessage(message, {
-            getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
-            refreshController: this.tec1g.refreshController,
-            autoRefreshMs: 150,
-            setActiveTab: (tab) => {
-              this.tec1g.activeTab = tab;
-            },
-            getActiveTab: () => this.tec1g.activeTab,
-            isPanelVisible: () => this.view?.visible === true,
-            memoryViews: this.tec1g.memoryViews,
-          }),
+        handlePlatformMessage: (platform, message) =>
+          this.handlePlatformMessage(platform, message),
       });
     });
 
     webviewView.onDidDispose(() => {
       this.view = undefined;
-      stopPlatformRefresh(this.tec1);
-      stopPlatformRefresh(this.tec1g);
+      this.stopAllPlatformRefresh();
     });
 
     webviewView.onDidChangeVisibility(() => {
@@ -385,37 +319,75 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
         this.renderCurrentView(true);
         return;
       }
-      stopPlatformRefresh(this.tec1);
-      stopPlatformRefresh(this.tec1g);
+      this.stopAllPlatformRefresh();
     });
 
     this.renderCurrentView(false);
   }
 
+  private async handlePlatformMessage(
+    platform: PlatformViewPlatform,
+    message: PlatformViewMessage,
+  ): Promise<void> {
+    const ps = await this.ensurePlatformState(platform);
+    if (!ps) {
+      return;
+    }
+    const context: PlatformUiMessageContext = {
+      getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
+      refreshController: ps.refreshController,
+      autoRefreshMs: 150,
+      setActiveTab: (tab) => {
+        ps.activeTab = tab;
+      },
+      getActiveTab: () => ps.activeTab,
+      isPanelVisible: () => this.view?.visible === true,
+      memoryViews: ps.memoryViews,
+    };
+    await ps.handleMessage(message, context);
+  }
+
+  private stopAllPlatformRefresh(): void {
+    for (const ps of this.platformStates.values()) {
+      stopPlatformRefresh(ps);
+    }
+  }
+
   private renderCurrentView(rehydrate: boolean): void {
+    void this.renderCurrentViewAsync(rehydrate);
+  }
+
+  private async renderCurrentViewAsync(rehydrate: boolean): Promise<void> {
     if (!this.view) {
       return;
     }
-    const ps = this.platformStateFor(this.currentPlatform);
-    if (ps) {
-      this.view.webview.html =
-        this.currentPlatform === 'tec1'
-          ? getTec1Html(ps.activeTab, this.view.webview, this.extensionUri)
-          : getTec1gHtml(ps.activeTab, this.view.webview, this.extensionUri);
-      this.postMessage(ps.buildUpdateMessage(ps.uiState, this.nextUiRevision()));
-      if (this.currentPlatform === 'tec1g' && this.tec1gUiVisibilityOverride) {
-        this.postMessage({
-          type: 'uiVisibility',
-          visibility: this.tec1gUiVisibilityOverride,
-          persist: false,
-        });
+    const platform = this.currentPlatform;
+    try {
+      const ps = await this.ensurePlatformState(platform);
+      if (this.view === undefined || this.currentPlatform !== platform) {
+        return;
       }
-      if (ps.serialBuffer.text.length > 0) {
-        this.postMessage({ type: 'serialInit', text: ps.serialBuffer.text });
+      if (ps !== undefined) {
+        this.view.webview.html = ps.getHtml(ps.activeTab, this.view.webview, this.extensionUri);
+        this.postMessage(ps.buildUpdateMessage(ps.uiState, this.nextUiRevision()));
+        if (platform === 'tec1g' && this.tec1gUiVisibilityOverride !== undefined) {
+          this.postMessage({
+            type: 'uiVisibility',
+            visibility: this.tec1gUiVisibilityOverride,
+            persist: false,
+          });
+        }
+        if (ps.serialBuffer.text.length > 0) {
+          this.postMessage({ type: 'serialInit', text: ps.serialBuffer.text });
+        }
+        this.postMessage({ type: 'selectTab', tab: ps.activeTab });
+        syncPlatformMemoryRefresh(ps, this.view.visible, rehydrate);
+        return;
       }
-      this.postMessage({ type: 'selectTab', tab: ps.activeTab });
-      syncPlatformMemoryRefresh(ps, this.view.visible, rehydrate);
-      return;
+    } catch (err) {
+      if (platform !== undefined && platform !== 'simple') {
+        void vscode.window.showErrorMessage(`Debug80: Failed to load ${platform} UI: ${String(err)}`);
+      }
     }
     if (rehydrate || this.view.webview.html.length === 0) {
       const idleHtmlOptions = {

--- a/src/extension/platform-view-state.ts
+++ b/src/extension/platform-view-state.ts
@@ -6,6 +6,7 @@
  * operations can be written once.
  */
 
+import type * as vscode from 'vscode';
 import { type PanelTab } from '../platforms/panel-html';
 import { type MemoryViewState } from '../platforms/panel-memory';
 import {
@@ -16,6 +17,10 @@ import {
   refreshSnapshot,
 } from '../platforms/panel-refresh';
 import { type SerialBuffer } from '../platforms/panel-serial';
+import type {
+  PlatformUiMessageContext,
+} from './platform-view-manifest';
+import type { PlatformViewMessage } from './platform-view-messages';
 
 /**
  * Bundles one platform's worth of view state alongside the
@@ -29,6 +34,12 @@ export interface PlatformViewState<TUiState> {
   memoryViews: MemoryViewState;
   refreshController: RefreshController;
   snapshotCommand: 'debug80/tec1MemorySnapshot' | 'debug80/tec1gMemorySnapshot';
+  getHtml: (tab: PanelTab, webview: vscode.Webview, extensionUri: vscode.Uri) => string;
+  applyUpdate: (state: TUiState, payload: unknown) => Record<string, unknown>;
+  handleMessage: (
+    message: PlatformViewMessage,
+    context: PlatformUiMessageContext
+  ) => Promise<void>;
 
   resetUiState: (state: TUiState) => void;
   clearSerialBuffer: (buffer: SerialBuffer) => void;
@@ -40,8 +51,7 @@ export interface PlatformViewState<TUiState> {
 /**
  * Stop auto-refresh for this platform.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-export function stopPlatformRefresh(ps: PlatformViewState<any>): void {
+export function stopPlatformRefresh<TUiState>(ps: PlatformViewState<TUiState>): void {
   stopAutoRefresh(ps.refreshController.state);
 }
 
@@ -49,7 +59,7 @@ export function stopPlatformRefresh(ps: PlatformViewState<any>): void {
  * Synchronise the memory auto-refresh timer for a platform.
  */
 export function syncPlatformMemoryRefresh(
-  ps: PlatformViewState<any>,
+  ps: PlatformViewState<unknown>,
   visible: boolean,
   rehydrate: boolean,
 ): void {

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -86,6 +86,7 @@ describe('extension activation', () => {
         listPlatforms: () => Array<{ id: string; displayName: string }>;
       };
     };
+    const uiManifest = (await import('../../src/extension/platform-view-manifest')) as typeof import('../../src/extension/platform-view-manifest');
     const context = {
       subscriptions: [] as Array<{ dispose: () => void }>,
       workspaceState: { get: vi.fn(), update: vi.fn() },
@@ -106,6 +107,10 @@ describe('extension activation', () => {
       expect.objectContaining({ id: 'simple', displayName: 'Simple' }),
       expect.objectContaining({ id: 'tec1', displayName: 'TEC-1' }),
       expect.objectContaining({ id: 'tec1g', displayName: 'TEC-1G' }),
+    ]);
+    expect(uiManifest.listPlatformUis()).toEqual([
+      expect.objectContaining({ id: 'tec1' }),
+      expect.objectContaining({ id: 'tec1g' }),
     ]);
   }, 20000);
 

--- a/tests/extension/platform-view-messages.test.ts
+++ b/tests/extension/platform-view-messages.test.ts
@@ -4,8 +4,6 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import { handlePlatformViewMessage } from '../../src/extension/platform-view-messages';
-import type { Tec1Message } from '../../src/platforms/tec1/ui-panel-messages';
-import type { Tec1gMessage } from '../../src/platforms/tec1g/ui-panel-messages';
 
 function createDependencies(platform: 'simple' | 'tec1' | 'tec1g' | undefined) {
   return {
@@ -14,8 +12,7 @@ function createDependencies(platform: 'simple' | 'tec1' | 'tec1g' | undefined) {
     handleSerialSendFile: vi.fn(() => undefined),
     handleSerialSave: vi.fn(() => undefined),
     clearSerialBuffer: vi.fn(() => undefined),
-    handleTec1Message: vi.fn(() => undefined),
-    handleTec1gMessage: vi.fn(() => undefined),
+    handlePlatformMessage: vi.fn(() => undefined),
   };
 }
 
@@ -47,14 +44,14 @@ describe('platform-view message routing', () => {
     const tec1Deps = createDependencies('tec1');
     const tec1gDeps = createDependencies('tec1g');
 
-    const tec1Message = { type: 'update' } as Tec1Message;
-    const tec1gMessage = { type: 'update' } as Tec1gMessage;
+    const tec1Message = { type: 'update' };
+    const tec1gMessage = { type: 'update' };
 
     await handlePlatformViewMessage(tec1Message, tec1Deps);
     await handlePlatformViewMessage(tec1gMessage, tec1gDeps);
 
-    expect(tec1Deps.handleTec1Message).toHaveBeenCalledWith(tec1Message);
-    expect(tec1gDeps.handleTec1gMessage).toHaveBeenCalledWith(tec1gMessage);
+    expect(tec1Deps.handlePlatformMessage).toHaveBeenCalledWith('tec1', tec1Message);
+    expect(tec1gDeps.handlePlatformMessage).toHaveBeenCalledWith('tec1g', tec1gMessage);
   });
 
   it('ignores serialClear for idle simple view state', async () => {

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @file PlatformViewProvider lazy-loading tests.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { executeCommand, showErrorMessage, loadPlatformUi } = vi.hoisted(() => ({
+  executeCommand: vi.fn(() => Promise.resolve()),
+  showErrorMessage: vi.fn(),
+  loadPlatformUi: vi.fn(),
+}));
+
+vi.mock('vscode', () => {
+  return {
+    commands: { executeCommand },
+    debug: { activeDebugSession: undefined },
+    workspace: { workspaceFolders: undefined },
+    window: { showErrorMessage },
+  };
+});
+
+vi.mock('../../src/extension/platform-view-manifest', () => {
+  return {
+    loadPlatformUi,
+  };
+});
+
+import { PlatformViewProvider } from '../../src/extension/platform-view-provider';
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createModules() {
+  return {
+    getHtml: vi.fn(() => '<html></html>'),
+    createUiState: vi.fn(() => ({ digits: [] })),
+    resetUiState: vi.fn(),
+    applyUpdate: vi.fn(() => ({ digits: [] })),
+    createMemoryViewState: vi.fn(() => ({
+      viewModes: { a: 'pc', b: 'sp', c: 'hl', d: 'de' },
+      viewAfter: { a: 16, b: 16, c: 16, d: 16 },
+      viewAddress: { a: undefined, b: undefined, c: undefined, d: undefined },
+    })),
+    handleMessage: vi.fn(() => Promise.resolve(undefined)),
+    buildUpdateMessage: vi.fn(() => ({ type: 'update' })),
+    buildClearMessage: vi.fn(() => ({ type: 'update' })),
+    snapshotCommand: 'debug80/tec1MemorySnapshot' as const,
+  };
+}
+
+describe('PlatformViewProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lazy-loads platform ui state on first selection', async () => {
+    const modules = createModules();
+    loadPlatformUi.mockResolvedValue(modules);
+
+    const provider = new PlatformViewProvider({ fsPath: '/tmp/debug80' } as never);
+
+    expect(loadPlatformUi).not.toHaveBeenCalled();
+    expect(modules.createUiState).not.toHaveBeenCalled();
+
+    provider.setPlatform('tec1', undefined, { reveal: false, tab: 'ui' });
+    await flushPromises();
+    await flushPromises();
+
+    expect(loadPlatformUi).toHaveBeenCalledWith('tec1');
+    expect(modules.createUiState).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses loaded platform state across repeated selections', async () => {
+    const modules = createModules();
+    loadPlatformUi.mockResolvedValue(modules);
+
+    const provider = new PlatformViewProvider({ fsPath: '/tmp/debug80' } as never);
+
+    provider.setPlatform('tec1', undefined, { reveal: false, tab: 'ui' });
+    await flushPromises();
+    await flushPromises();
+    provider.setPlatform('tec1', undefined, { reveal: false, tab: 'memory' });
+    await flushPromises();
+    await flushPromises();
+
+    expect(loadPlatformUi).toHaveBeenCalledTimes(1);
+    expect(modules.createUiState).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a lazy platform UI manifest and register the built-in TEC-1 and TEC-1G panel modules during activation
- replace PlatformViewProvider's eager per-platform fields with a map-backed lazy state loader
- route any non-simple platform event through the platform view and add extension tests for lazy UI loading

Closes #177