### PR TITLE
Add home tab and root-oriented project selection

### DIFF
--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -196,7 +196,40 @@ export function registerExtensionCommands({
 
   context.subscriptions.push(
     vscode.commands.registerCommand('debug80.selectWorkspaceFolder', async () => {
-      await workspaceSelection.selectWorkspaceFolder();
+      const folder = await workspaceSelection.selectWorkspaceFolder();
+      if (!folder) {
+        return undefined;
+      }
+
+      platformViewProvider.refreshIdleView();
+
+      const projectConfig = findProjectConfigPath(folder);
+      if (projectConfig === undefined) {
+        void vscode.window.showInformationMessage(
+          `Debug80: Selected root ${folder.name}. This root does not contain a Debug80 project config.`
+        );
+        return folder;
+      }
+
+      const activeSession = vscode.debug.activeDebugSession;
+      if (activeSession?.type === 'z80') {
+        await vscode.debug.stopDebugging(activeSession);
+        const restarted = await startCurrentProjectDebugging(folder, workspaceSelection);
+        if (restarted) {
+          void vscode.window.showInformationMessage(
+            `Debug80: Switched to root ${folder.name} and restarted debugging.`
+          );
+        }
+        return folder;
+      }
+
+      const started = await startCurrentProjectDebugging(folder, workspaceSelection);
+      if (started) {
+        void vscode.window.showInformationMessage(
+          `Debug80: Selected root ${folder.name} and started debugging.`
+        );
+      }
+      return folder;
     })
   );
 
@@ -246,6 +279,16 @@ export function registerExtensionCommands({
         if (restarted) {
           void vscode.window.showInformationMessage(
             `Debug80: Switched target to ${target} and restarted debugging.`
+          );
+          return target;
+        }
+      }
+
+      if (activeSession?.type !== 'z80') {
+        const started = await startCurrentProjectDebugging(folder, workspaceSelection);
+        if (started) {
+          void vscode.window.showInformationMessage(
+            `Debug80: Selected target ${target} and started debugging.`
           );
           return target;
         }

--- a/src/extension/platform-view-idle-html.ts
+++ b/src/extension/platform-view-idle-html.ts
@@ -39,19 +39,24 @@ export function getPlatformViewIdleHtml(options: {
 </head>
 <body style="padding: 16px; font-family: var(--vscode-font-family); color: var(--vscode-foreground);">
   <p>Debug80</p>
-  <p style="opacity: 0.7;">Create a Debug80 project to get started.</p>
-  <button id="createProject" style="margin-top: 8px; padding: 6px 10px; font-size: 12px;">
-    Create Project
-  </button>
+  <p style="opacity: 0.7;">Create a Debug80 root project to get started.</p>
+  <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px;">
+    <button id="createProject" style="padding: 6px 10px; font-size: 12px;">Create Project</button>
+    <button id="selectProject" style="padding: 6px 10px; font-size: 12px;">Select Root</button>
+  </div>
   <script nonce="${nonce}">
     (function () {
       const vscode = acquireVsCodeApi();
-      const button = document.getElementById('createProject');
-      if (button) {
-        button.addEventListener('click', () => {
-          vscode.postMessage({ type: 'createProject' });
-        });
-      }
+      const bind = (id, type) => {
+        const button = document.getElementById(id);
+        if (button) {
+          button.addEventListener('click', () => {
+            vscode.postMessage({ type });
+          });
+        }
+      };
+      bind('createProject', 'createProject');
+      bind('selectProject', 'selectProject');
     }());
   </script>
 </body>
@@ -62,10 +67,10 @@ export function getPlatformViewIdleHtml(options: {
   const selectionHint =
     options.multiRoot &&
     (options.selectedWorkspaceName === undefined || options.selectedWorkspaceName === '')
-      ? 'Select a workspace folder with “Debug80: Select Workspace Folder”.'
+      ? 'Select a workspace root with “Debug80: Select Workspace Folder”.'
       : '';
   const statusRows = [
-    options.projectName !== undefined ? `<p style="margin: 6px 0 0; opacity: 0.85;">Project: ${options.projectName}</p>` : '',
+    options.projectName !== undefined ? `<p style="margin: 6px 0 0; opacity: 0.85;">Root: ${options.projectName}</p>` : '',
     options.targetName !== undefined ? `<p style="margin: 4px 0 0; opacity: 0.85;">Target: ${options.targetName}</p>` : '',
     options.entrySource !== undefined ? `<p style="margin: 4px 0 0; opacity: 0.85;">Entry: ${options.entrySource}</p>` : '',
   ]
@@ -82,11 +87,11 @@ export function getPlatformViewIdleHtml(options: {
 </head>
 <body style="padding: 16px; font-family: var(--vscode-font-family); color: var(--vscode-foreground);">
   <p>Debug80</p>
-  <p style="opacity: 0.7;">Project detected (${selectedLabel}). Start a debug session to see the platform UI.</p>
+  <p style="opacity: 0.7;">Configured root detected (${selectedLabel}). Select a root or target to start debugging, or use F5.</p>
   ${statusRows}
   <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px;">
     <button id="startDebug" style="padding: 6px 10px; font-size: 12px;">Start Debugging</button>
-    <button id="selectProject" style="padding: 6px 10px; font-size: 12px;">Select Open Project</button>
+    <button id="selectProject" style="padding: 6px 10px; font-size: 12px;">Select Root</button>
     <button id="selectTarget" style="padding: 6px 10px; font-size: 12px;">Select Target</button>
     <button id="setEntrySource" style="padding: 6px 10px; font-size: 12px;">Set Entry Source</button>
   </div>

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -106,7 +106,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     modules: PlatformUiModules<TUiState>,
   ): PlatformViewState<TUiState> {
     const platformState: PlatformViewState<TUiState> = {
-      activeTab: 'ui',
+      activeTab: 'home',
       uiState: modules.createUiState(),
       serialBuffer: createSerialBuffer(),
       memoryViews: modules.createMemoryViewState(),
@@ -145,7 +145,9 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     this.selectedWorkspace = folder;
     if (this.currentPlatform === undefined) {
       this.renderCurrentView(true);
+      return;
     }
+    this.postProjectStatus();
   }
 
   setHasProject(value: boolean): void {
@@ -180,7 +182,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   ): Promise<void> {
     try {
       const ps = await this.ensurePlatformState(platform);
-      if (ps && (options?.tab === 'ui' || options?.tab === 'memory')) {
+      if (ps && (options?.tab === 'home' || options?.tab === 'ui' || options?.tab === 'memory')) {
         ps.activeTab = options.tab;
       }
       if (options?.reveal !== false) {
@@ -397,6 +399,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
           this.postMessage({ type: 'serialInit', text: ps.serialBuffer.text });
         }
         this.postMessage({ type: 'selectTab', tab: ps.activeTab });
+        this.postProjectStatus();
         syncPlatformMemoryRefresh(ps, this.view.visible, rehydrate);
         return;
       }
@@ -436,6 +439,18 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       return;
     }
     void this.view.webview.postMessage(payload);
+  }
+
+  private postProjectStatus(): void {
+    const summary = resolveProjectStatusSummary(this.workspaceState, this.selectedWorkspace);
+    this.postMessage({
+      type: 'projectStatus',
+      rootName: this.selectedWorkspace?.name,
+      hasProject: summary !== undefined,
+      projectName: summary?.projectName,
+      targetName: summary?.targetName,
+      entrySource: summary?.entrySource,
+    });
   }
 
   private shouldAcceptSession(sessionId?: string): boolean {

--- a/src/extension/workspace-selection.ts
+++ b/src/extension/workspace-selection.ts
@@ -2,12 +2,12 @@
  * @file Workspace selection and project-detection state for Debug80.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { PlatformViewProvider } from './platform-view-provider';
+import { findProjectConfigPath } from './project-config';
 
 const WORKSPACE_KEY = 'debug80.selectedWorkspace';
+const PROJECT_CONFIG_WATCH_GLOBS = ['**/.vscode/debug80.json', '**/debug80.json', '**/.debug80.json'];
 
 export type ResolveWorkspaceFolderOptions = {
   prompt?: boolean;
@@ -25,10 +25,12 @@ export class WorkspaceSelectionController {
     this.updateHasProject();
     this.applySelectedWorkspace();
 
-    const configWatcher = vscode.workspace.createFileSystemWatcher('**/.vscode/debug80.json');
-    configWatcher.onDidCreate(this.updateHasProject);
-    configWatcher.onDidDelete(this.updateHasProject);
-    this.context.subscriptions.push(configWatcher);
+    PROJECT_CONFIG_WATCH_GLOBS.forEach((pattern) => {
+      const configWatcher = vscode.workspace.createFileSystemWatcher(pattern);
+      configWatcher.onDidCreate(this.updateHasProject);
+      configWatcher.onDidDelete(this.updateHasProject);
+      this.context.subscriptions.push(configWatcher);
+    });
 
     this.context.subscriptions.push(
       vscode.workspace.onDidChangeWorkspaceFolders(() => {
@@ -90,35 +92,41 @@ export class WorkspaceSelectionController {
     return picked.folder;
   }
 
-  async selectWorkspaceFolder(): Promise<void> {
+  async selectWorkspaceFolder(): Promise<vscode.WorkspaceFolder | undefined> {
     const folders = this.getCandidateFolders(false);
     if (folders.length === 0) {
       void vscode.window.showInformationMessage('Debug80: No workspace folders to select.');
-      return;
+      return undefined;
     }
     if (folders.length === 1) {
       this.rememberWorkspace(folders[0]);
-      return;
+      return folders[0];
     }
     const picked = await vscode.window.showQuickPick(
-      folders.map((folder) => ({
-        label: folder.name,
-        description: folder.uri.fsPath,
-        folder,
-      })),
-      { placeHolder: 'Select workspace folder for Debug80' }
+      folders.map((folder) => {
+        const projectConfig = findProjectConfigPath(folder);
+        return {
+          label: folder.name,
+          description: folder.uri.fsPath,
+          detail:
+            projectConfig !== undefined
+              ? `Configured Debug80 root (${projectConfig.split('/').slice(-2).join('/')})`
+              : 'No Debug80 project config in this root',
+          folder,
+        };
+      }),
+      { placeHolder: 'Select workspace root for Debug80' }
     );
     if (!picked) {
-      return;
+      return undefined;
     }
     this.rememberWorkspace(picked.folder);
+    return picked.folder;
   }
 
   private readonly updateHasProject = (): void => {
     const folders = vscode.workspace.workspaceFolders ?? [];
-    const hasProject = folders.some((folder) =>
-      fs.existsSync(path.join(folder.uri.fsPath, '.vscode', 'debug80.json'))
-    );
+    const hasProject = folders.some((folder) => this.hasProject(folder));
     void vscode.commands.executeCommand('setContext', 'debug80.hasProject', hasProject);
     this.platformViewProvider.setHasProject(hasProject);
   };
@@ -133,7 +141,7 @@ export class WorkspaceSelectionController {
   }
 
   private hasProject(folder: vscode.WorkspaceFolder): boolean {
-    return fs.existsSync(path.join(folder.uri.fsPath, '.vscode', 'debug80.json'));
+    return findProjectConfigPath(folder) !== undefined;
   }
 
   private getCandidateFolders(requireProject: boolean): vscode.WorkspaceFolder[] {

--- a/src/platforms/panel-html.ts
+++ b/src/platforms/panel-html.ts
@@ -5,7 +5,7 @@
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 
-export type PanelTab = 'ui' | 'memory';
+export type PanelTab = 'home' | 'ui' | 'memory';
 export type PanelPlatform = 'tec1' | 'tec1g';
 
 /** Generates a CSP nonce for inline script tags. */

--- a/src/platforms/panel-messages.ts
+++ b/src/platforms/panel-messages.ts
@@ -63,7 +63,7 @@ export async function handleCommonPanelMessage<TTab extends string>(
   ctx: PanelMessageContext<TTab>,
   commands: PanelCommands
 ): Promise<boolean> {
-  if (msg.type === 'tab' && (msg.tab === 'ui' || msg.tab === 'memory')) {
+  if (msg.type === 'tab' && (msg.tab === 'home' || msg.tab === 'ui' || msg.tab === 'memory')) {
     ctx.setActiveTab(msg.tab as TTab);
     if (ctx.isPanelVisible() && ctx.getActiveTab() === 'memory') {
       startAutoRefresh(ctx.refreshController.state, ctx.autoRefreshMs, () => {

--- a/src/platforms/tec1/ui-panel-messages.ts
+++ b/src/platforms/tec1/ui-panel-messages.ts
@@ -9,7 +9,7 @@ export type Tec1Message = PanelMessage;
 /**
  * Context required for TEC-1 message handling.
  */
-export type MessageContext = PanelMessageContext<'ui' | 'memory'>;
+export type MessageContext = PanelMessageContext<'home' | 'ui' | 'memory'>;
 
 /**
  * Handles inbound webview messages for the TEC-1 panel.

--- a/src/platforms/tec1g/ui-panel-messages.ts
+++ b/src/platforms/tec1g/ui-panel-messages.ts
@@ -16,7 +16,7 @@ export type Tec1gMessage = PanelMessage & {
 /**
  * Context required for TEC-1G message handling.
  */
-export type MessageContext = PanelMessageContext<'ui' | 'memory'>;
+export type MessageContext = PanelMessageContext<'home' | 'ui' | 'memory'>;
 
 /**
  * Handles inbound webview messages for the TEC-1G panel.

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -135,6 +135,47 @@ describe('registerExtensionCommands', () => {
     });
   });
 
+  it('selects a configured root and starts debugging immediately', async () => {
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    const folder = {
+      name: 'tec1g-mon3',
+      uri: { fsPath: '/workspace/tec1g-mon3' },
+      index: 0,
+    };
+    const selectWorkspaceFolder = vi.fn().mockResolvedValue(folder);
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder: vi.fn(),
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder,
+      } as never,
+      targetSelection: {} as never,
+    });
+
+    const selectRoot = registeredCommands.get('debug80.selectWorkspaceFolder');
+    expect(selectRoot).toBeTypeOf('function');
+
+    startDebugging.mockResolvedValueOnce(true);
+    const result = await selectRoot?.();
+
+    expect(result).toEqual(folder);
+    expect(startDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: { fsPath: '/workspace/tec1g-mon3' } }),
+      expect.objectContaining({
+        type: 'z80',
+        request: 'launch',
+        projectConfig: projectConfigPath,
+        stopOnEntry: false,
+      })
+    );
+  });
+
   it('auto-restarts an active z80 session after changing target', async () => {
     const vscode = await import('vscode');
     const { registerExtensionCommands } = await import('../../src/extension/commands');

--- a/tests/extension/platform-view-idle-html.test.ts
+++ b/tests/extension/platform-view-idle-html.test.ts
@@ -17,8 +17,9 @@ describe('platform-view idle html', () => {
       multiRoot: false,
     });
 
-    expect(html).toContain('Create a Debug80 project to get started.');
+    expect(html).toContain('Create a Debug80 root project to get started.');
     expect(html).toContain('Create Project');
+    expect(html).toContain('Select Root');
     expect(html).toContain("script-src 'nonce-abc123'");
     expect(html).not.toContain('Start Debugging');
   });
@@ -33,16 +34,16 @@ describe('platform-view idle html', () => {
       entrySource: 'src/main.asm',
     });
 
-    expect(html).toContain('Project detected (Workspace).');
-    expect(html).toContain('Project: caverns80');
+    expect(html).toContain('Configured root detected (Workspace).');
+    expect(html).toContain('Root: caverns80');
     expect(html).toContain('Target: app');
     expect(html).toContain('Entry: src/main.asm');
     expect(html).toContain('Start Debugging');
-    expect(html).toContain('Select Open Project');
+    expect(html).toContain('Select Root');
     expect(html).toContain('Select Target');
     expect(html).toContain('Set Entry Source');
     expect(html).toContain("script-src 'nonce-xyz789'");
-    expect(html).toContain('Select a workspace folder with');
+    expect(html).toContain('Select a workspace root with');
   });
 
   it('creates a 32-character nonce', () => {

--- a/tests/platforms/tec1/ui-panel-html.test.ts
+++ b/tests/platforms/tec1/ui-panel-html.test.ts
@@ -26,18 +26,21 @@ vi.mock('vscode', () => {
 });
 
 describe('tec1 ui-panel-html', () => {
-  const extensionUri = { fsPath: process.cwd() };
+  const extensionUri = { fsPath: process.cwd() } as never;
   const webview = {
     cspSource: 'vscode-resource://test',
     asWebviewUri: (uri: { fsPath: string }) => ({
       toString: () => uri.fsPath,
     }),
-  };
+  } as never;
 
   it('includes key UI sections', () => {
-    const html = getTec1Html('ui', webview, extensionUri);
-    expect(html).toContain('Select Open Project');
+    const html = getTec1Html('home', webview, extensionUri);
+    expect(html).toContain('Home');
+    expect(html).toContain('panel-home');
+    expect(html).toContain('Select Root');
     expect(html).toContain('Select Target');
+    expect(html).toContain('Set Entry Source');
     expect(html).toContain('panel-ui');
     expect(html).toContain('panel-memory');
     expect(html).toContain('LCD (HD44780 A00)');
@@ -46,7 +49,7 @@ describe('tec1 ui-panel-html', () => {
   });
 
   it('embeds the active tab', () => {
-    const html = getTec1Html('memory', webview, extensionUri);
-    expect(html).toContain('data-active-tab="memory"');
+    const html = getTec1Html('home', webview, extensionUri);
+    expect(html).toContain('data-active-tab="home"');
   });
 });

--- a/tests/platforms/tec1/ui-panel-messages.test.ts
+++ b/tests/platforms/tec1/ui-panel-messages.test.ts
@@ -24,12 +24,12 @@ describe('tec1 ui-panel-messages', () => {
       onSnapshotFailed: vi.fn(),
     };
     const refreshController = createRefreshController(() => ({ views: [] }), handlers);
-    let activeTab: 'ui' | 'memory' = 'ui';
+    let activeTab: 'home' | 'ui' | 'memory' = 'ui';
     const ctx = {
       getSession: () => undefined as { type: string; customRequest: (c: string, p: unknown) => Promise<unknown> } | undefined,
       refreshController,
       autoRefreshMs: 250,
-      setActiveTab: (tab: 'ui' | 'memory') => {
+      setActiveTab: (tab: 'home' | 'ui' | 'memory') => {
         activeTab = tab;
       },
       getActiveTab: () => activeTab,
@@ -50,7 +50,7 @@ describe('tec1 ui-panel-messages', () => {
   it('stops refresh when panel not visible', async () => {
     const { ctx } = createContext();
     ctx.isPanelVisible = () => false;
-    await handleTec1Message({ type: 'tab', tab: 'ui' }, ctx);
+    await handleTec1Message({ type: 'tab', tab: 'home' }, ctx);
     expect(ctx.refreshController.state.timer).toBeUndefined();
   });
 

--- a/tests/platforms/tec1g/ui-panel-html.test.ts
+++ b/tests/platforms/tec1g/ui-panel-html.test.ts
@@ -26,18 +26,21 @@ vi.mock('vscode', () => {
 });
 
 describe('tec1g ui-panel-html', () => {
-  const extensionUri = { fsPath: process.cwd() };
+  const extensionUri = { fsPath: process.cwd() } as never;
   const webview = {
     cspSource: 'vscode-resource://test',
     asWebviewUri: (uri: { fsPath: string }) => ({
       toString: () => uri.fsPath,
     }),
-  };
+  } as never;
 
   it('includes key UI sections', () => {
-    const html = getTec1gHtml('ui', webview, extensionUri);
-    expect(html).toContain('Select Open Project');
+    const html = getTec1gHtml('home', webview, extensionUri);
+    expect(html).toContain('Home');
+    expect(html).toContain('panel-home');
+    expect(html).toContain('Select Root');
     expect(html).toContain('Select Target');
+    expect(html).toContain('Set Entry Source');
     expect(html).toContain('panel-ui');
     expect(html).toContain('panel-memory');
     expect(html).toContain('LCD (HD44780 A00)');
@@ -46,7 +49,7 @@ describe('tec1g ui-panel-html', () => {
   });
 
   it('embeds the active tab', () => {
-    const html = getTec1gHtml('memory', webview, extensionUri);
-    expect(html).toContain('data-active-tab="memory"');
+    const html = getTec1gHtml('home', webview, extensionUri);
+    expect(html).toContain('data-active-tab="home"');
   });
 });

--- a/tests/platforms/tec1g/ui-panel-messages.test.ts
+++ b/tests/platforms/tec1g/ui-panel-messages.test.ts
@@ -24,12 +24,12 @@ describe('tec1g ui-panel-messages', () => {
       onSnapshotFailed: vi.fn(),
     };
     const refreshController = createRefreshController(() => ({ views: [] }), handlers);
-    let activeTab: 'ui' | 'memory' = 'ui';
+    let activeTab: 'home' | 'ui' | 'memory' = 'ui';
     const ctx = {
       getSession: () => undefined as { type: string; customRequest: (c: string, p: unknown) => Promise<unknown> } | undefined,
       refreshController,
       autoRefreshMs: 250,
-      setActiveTab: (tab: 'ui' | 'memory') => {
+      setActiveTab: (tab: 'home' | 'ui' | 'memory') => {
         activeTab = tab;
       },
       getActiveTab: () => activeTab,
@@ -50,7 +50,7 @@ describe('tec1g ui-panel-messages', () => {
   it('stops refresh when panel not visible', async () => {
     const { ctx } = createContext();
     ctx.isPanelVisible = () => false;
-    await handleTec1gMessage({ type: 'tab', tab: 'ui' }, ctx);
+    await handleTec1gMessage({ type: 'tab', tab: 'home' }, ctx);
     expect(ctx.refreshController.state.timer).toBeUndefined();
   });
 

--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -8,26 +8,52 @@ body {
     #app {
       outline: none;
     }
-    .session-controls {
+    .home-panel {
       display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 12px;
-      margin-bottom: 12px;
-      padding: 10px 12px;
-      border: 1px solid #333;
-      border-radius: 10px;
-      background: #141414;
+      flex-direction: column;
+      gap: 8px;
     }
-    .session-controls-title {
+    .home-card {
+      padding: 14px;
+      border: 1px solid #333;
+      border-radius: 12px;
+      background: linear-gradient(180deg, #141414 0%, #101010 100%);
+    }
+    .home-kicker {
+      margin-bottom: 10px;
       font-size: 11px;
       letter-spacing: 0.14em;
       color: #bcbcbc;
     }
-    .session-controls-buttons {
+    .home-status {
+      display: grid;
+      gap: 8px;
+    }
+    .home-status-row {
+      display: grid;
+      grid-template-columns: minmax(88px, 120px) 1fr;
+      gap: 12px;
+      align-items: baseline;
+    }
+    .home-label {
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #9a9a9a;
+    }
+    .home-value {
+      color: #f0f0f0;
+      word-break: break-word;
+    }
+    .home-actions {
       display: flex;
       gap: 8px;
       flex-wrap: wrap;
+    }
+    .home-note {
+      margin: 0;
+      color: #bcbcbc;
+      line-height: 1.4;
     }
     .session-button {
       appearance: none;
@@ -51,9 +77,9 @@ body {
       background: #465924;
     }
     @media (max-width: 640px) {
-      .session-controls {
-        align-items: flex-start;
-        flex-direction: column;
+      .home-status-row {
+        grid-template-columns: 1fr;
+        gap: 4px;
       }
     }
     .layout {

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -9,16 +9,43 @@
 </head>
 <body data-active-tab="{{activeTab}}">
 <div id="app" tabindex="0">
-    <div class="session-controls" id="sessionControls">
-      <div class="session-controls-title">DEBUG80</div>
-      <div class="session-controls-buttons">
-        <button class="session-button" id="selectProject">Select Open Project</button>
-        <button class="session-button" id="selectTarget">Select Target</button>
-      </div>
-    </div>
     <div class="tabs">
+      <button class="tab" data-tab="home">Home</button>
       <button class="tab" data-tab="ui">UI</button>
       <button class="tab" data-tab="memory">CPU</button>
+    </div>
+    <div class="panel panel-home" id="panel-home">
+      <div class="home-panel">
+        <div class="home-card">
+          <div class="home-kicker">DEBUG80 HOME</div>
+          <div class="home-status">
+            <div class="home-status-row">
+              <span class="home-label">Root</span>
+              <span class="home-value" id="homeRootName">No root selected</span>
+            </div>
+            <div class="home-status-row">
+              <span class="home-label">Project State</span>
+              <span class="home-value" id="homeProjectState">No Debug80 project in this root</span>
+            </div>
+            <div class="home-status-row">
+              <span class="home-label">Target</span>
+              <span class="home-value" id="homeTargetName">No target selected</span>
+            </div>
+            <div class="home-status-row">
+              <span class="home-label">Entry</span>
+              <span class="home-value" id="homeEntrySource">No entry source selected</span>
+            </div>
+          </div>
+        </div>
+        <div class="home-actions">
+          <button class="session-button" id="selectProject">Select Root</button>
+          <button class="session-button" id="selectTarget">Select Target</button>
+          <button class="session-button" id="setEntrySource">Set Entry Source</button>
+        </div>
+        <p class="home-note">
+          Debug80 follows workspace roots. Select a configured root and target here, then use the UI and CPU tabs while the session runs.
+        </p>
+      </div>
     </div>
     <div class="panel panel-ui" id="panel-ui">
       <div class="layout">

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -8,9 +8,19 @@ import { createPanelLayoutController, type PanelTab } from './panel-layout';
 import { wireTec1SerialUi } from './serial-ui';
 
 const vscode = acquireVscodeApi();
-const DEFAULT_TAB: PanelTab = document.body.dataset.activeTab === 'memory' ? 'memory' : 'ui';
+const DEFAULT_TAB: PanelTab =
+  document.body.dataset.activeTab === 'memory'
+    ? 'memory'
+    : document.body.dataset.activeTab === 'ui'
+      ? 'ui'
+      : 'home';
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
 const selectTargetButton = document.getElementById('selectTarget') as HTMLButtonElement | null;
+const setEntrySourceButton = document.getElementById('setEntrySource') as HTMLButtonElement | null;
+const homeRootName = document.getElementById('homeRootName') as HTMLElement | null;
+const homeProjectState = document.getElementById('homeProjectState') as HTMLElement | null;
+const homeTargetName = document.getElementById('homeTargetName') as HTMLElement | null;
+const homeEntrySource = document.getElementById('homeEntrySource') as HTMLElement | null;
 const displayEl = document.getElementById('display') as HTMLElement;
 const keypadEl = document.getElementById('keypad') as HTMLElement;
 const speakerEl = document.getElementById('speaker') as HTMLElement;
@@ -18,6 +28,7 @@ const speakerHzEl = document.getElementById('speakerHz') as HTMLElement;
 const speedEl = document.getElementById('speed') as HTMLElement;
 const muteEl = document.getElementById('mute') as HTMLElement;
 const tabButtons = Array.from(document.querySelectorAll<HTMLElement>('[data-tab]'));
+const panelHome = document.getElementById('panel-home') as HTMLElement;
 const panelUi = document.getElementById('panel-ui') as HTMLElement;
 const panelMemory = document.getElementById('panel-memory') as HTMLElement;
 const registerStrip = document.getElementById('registerStrip') as HTMLElement;
@@ -34,6 +45,7 @@ for (let i = 0; i < DIGITS; i++) {
 let memoryPanelController: MemoryPanel | null = null;
 const panelLayout = createPanelLayoutController({
   defaultTab: DEFAULT_TAB,
+  panelHome,
   memoryPanel,
   panelMemory,
   panelUi,
@@ -72,6 +84,35 @@ selectProjectButton?.addEventListener('click', () => {
 selectTargetButton?.addEventListener('click', () => {
   vscode.postMessage({ type: 'selectTarget' });
 });
+
+setEntrySourceButton?.addEventListener('click', () => {
+  vscode.postMessage({ type: 'setEntrySource' });
+});
+
+function setHomeValue(node: HTMLElement | null, value: string | undefined, fallback: string): void {
+  if (!node) {
+    return;
+  }
+  node.textContent = value !== undefined && value !== '' ? value : fallback;
+}
+
+function applyProjectStatus(payload: {
+  rootName?: string;
+  hasProject?: boolean;
+  targetName?: string;
+  entrySource?: string;
+}): void {
+  setHomeValue(homeRootName, payload.rootName, 'No root selected');
+  setHomeValue(
+    homeProjectState,
+    payload.hasProject ? 'Configured Debug80 project' : undefined,
+    payload.rootName ? 'No Debug80 project in this root' : 'No root selected'
+  );
+  setHomeValue(homeTargetName, payload.targetName, 'No target selected');
+  setHomeValue(homeEntrySource, payload.entrySource, 'No entry source selected');
+}
+
+applyProjectStatus({});
 
 function applySpeed(mode: string): void {
   speedMode = mode;
@@ -232,6 +273,10 @@ const serialUi = wireTec1SerialUi(vscode);
 
 window.addEventListener('message', event => {
   if (!event.data) return;
+  if (event.data.type === 'projectStatus') {
+    applyProjectStatus(event.data);
+    return;
+  }
   if (event.data.type === 'selectTab') {
     panelLayout.setTab(event.data.tab, false);
     return;

--- a/webview/tec1/panel-layout.ts
+++ b/webview/tec1/panel-layout.ts
@@ -1,4 +1,4 @@
-export type PanelTab = 'ui' | 'memory';
+export type PanelTab = 'home' | 'ui' | 'memory';
 
 const MEMORY_NARROW_MAX = 480;
 const MEMORY_WIDE_MIN = 520;
@@ -14,6 +14,7 @@ export interface PanelLayoutController {
 
 type PanelLayoutOptions = {
   defaultTab: PanelTab;
+  panelHome: HTMLElement | null;
   memoryPanel: HTMLElement | null;
   panelMemory: HTMLElement | null;
   panelUi: HTMLElement | null;
@@ -36,7 +37,12 @@ function resolveMemoryRowSize(width: number, currentSize: number): number {
 }
 
 export function createPanelLayoutController(options: PanelLayoutOptions): PanelLayoutController {
-  let activeTab: PanelTab = options.defaultTab === 'memory' ? 'memory' : 'ui';
+  let activeTab: PanelTab =
+    options.defaultTab === 'memory'
+      ? 'memory'
+      : options.defaultTab === 'ui'
+        ? 'ui'
+        : 'home';
   let memoryRowSize = 16;
   let resizeTimer: number | null = null;
 
@@ -56,7 +62,8 @@ export function createPanelLayoutController(options: PanelLayoutOptions): PanelL
   };
 
   const setTab = (tab: string, notify: boolean): void => {
-    activeTab = tab === 'memory' ? 'memory' : 'ui';
+    activeTab = tab === 'memory' ? 'memory' : tab === 'ui' ? 'ui' : 'home';
+    options.panelHome?.classList.toggle('active', activeTab === 'home');
     options.panelUi?.classList.toggle('active', activeTab === 'ui');
     options.panelMemory?.classList.toggle('active', activeTab === 'memory');
     options.tabButtons.forEach((button) => {

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -9,16 +9,43 @@
 </head>
 <body data-active-tab="{{activeTab}}">
 <div id="app" tabindex="0">
-    <div class="session-controls" id="sessionControls">
-      <div class="session-controls-title">DEBUG80</div>
-      <div class="session-controls-buttons">
-        <button class="session-button" id="selectProject">Select Open Project</button>
-        <button class="session-button" id="selectTarget">Select Target</button>
-      </div>
-    </div>
     <div class="tabs">
+      <button class="tab" data-tab="home">Home</button>
       <button class="tab" data-tab="ui">UI</button>
       <button class="tab" data-tab="memory">CPU</button>
+    </div>
+    <div class="panel panel-home" id="panel-home">
+      <div class="home-panel">
+        <div class="home-card">
+          <div class="home-kicker">DEBUG80 HOME</div>
+          <div class="home-status">
+            <div class="home-status-row">
+              <span class="home-label">Root</span>
+              <span class="home-value" id="homeRootName">No root selected</span>
+            </div>
+            <div class="home-status-row">
+              <span class="home-label">Project State</span>
+              <span class="home-value" id="homeProjectState">No Debug80 project in this root</span>
+            </div>
+            <div class="home-status-row">
+              <span class="home-label">Target</span>
+              <span class="home-value" id="homeTargetName">No target selected</span>
+            </div>
+            <div class="home-status-row">
+              <span class="home-label">Entry</span>
+              <span class="home-value" id="homeEntrySource">No entry source selected</span>
+            </div>
+          </div>
+        </div>
+        <div class="home-actions">
+          <button class="session-button" id="selectProject">Select Root</button>
+          <button class="session-button" id="selectTarget">Select Target</button>
+          <button class="session-button" id="setEntrySource">Set Entry Source</button>
+        </div>
+        <p class="home-note">
+          Debug80 follows workspace roots. Select a configured root and target here, then use the UI and CPU tabs while the session runs.
+        </p>
+      </div>
     </div>
     <div class="panel panel-ui" id="panel-ui">
       <div class="ui-controls" id="uiControls">

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -7,7 +7,7 @@ import { createMatrixUiController } from './matrix-ui';
 import { wireTec1gSerialUi } from './serial-ui';
 import { createVisibilityController } from './visibility-controller';
 
-type PanelTab = 'ui' | 'memory';
+type PanelTab = 'home' | 'ui' | 'memory';
 type SpeedMode = 'slow' | 'fast';
 type AudioContextCtor = typeof AudioContext;
 
@@ -63,15 +63,32 @@ type MemorySnapshotPayload = {
 
 type IncomingMessage =
   | { type: 'selectTab'; tab: string }
+  | {
+      type: 'projectStatus';
+      rootName?: string;
+      hasProject?: boolean;
+      targetName?: string;
+      entrySource?: string;
+    }
   | { type: 'uiVisibility'; visibility: Record<string, boolean>; persist?: boolean }
   | ({ type: 'update'; uiRevision?: number } & Tec1gUpdatePayload)
   | ({ type: 'snapshot' } & MemorySnapshotPayload)
   | { type: 'snapshotError'; message?: string };
 
 const vscode = acquireVscodeApi();
-const DEFAULT_TAB: PanelTab = document.body.dataset.activeTab === 'memory' ? 'memory' : 'ui';
+const DEFAULT_TAB: PanelTab =
+  document.body.dataset.activeTab === 'memory'
+    ? 'memory'
+    : document.body.dataset.activeTab === 'ui'
+      ? 'ui'
+      : 'home';
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
 const selectTargetButton = document.getElementById('selectTarget') as HTMLButtonElement | null;
+const setEntrySourceButton = document.getElementById('setEntrySource') as HTMLButtonElement | null;
+const homeRootName = document.getElementById('homeRootName') as HTMLElement | null;
+const homeProjectState = document.getElementById('homeProjectState') as HTMLElement | null;
+const homeTargetName = document.getElementById('homeTargetName') as HTMLElement | null;
+const homeEntrySource = document.getElementById('homeEntrySource') as HTMLElement | null;
 const displayEl = document.getElementById('display') as HTMLElement;
 const keypadEl = document.getElementById('keypad') as HTMLElement;
 const speakerEl = document.getElementById('speaker') as HTMLElement;
@@ -83,6 +100,7 @@ const statusProtect = document.getElementById('statusProtect') as HTMLElement;
 const statusExpand = document.getElementById('statusExpand') as HTMLElement;
 const statusCaps = document.getElementById('statusCaps') as HTMLElement;
 const tabButtons = Array.from(document.querySelectorAll<HTMLElement>('[data-tab]'));
+const panelHome = document.getElementById('panel-home') as HTMLElement;
 const panelUi = document.getElementById('panel-ui') as HTMLElement;
 const panelMemory = document.getElementById('panel-memory') as HTMLElement;
 const registerStrip = document.getElementById('registerStrip') as HTMLElement;
@@ -98,7 +116,8 @@ for (let i = 0; i < DIGITS; i++) {
   displayEl.appendChild(digit);
 }
 
-let activeTab: PanelTab = DEFAULT_TAB === 'memory' ? 'memory' : 'ui';
+let activeTab: PanelTab =
+  DEFAULT_TAB === 'memory' ? 'memory' : DEFAULT_TAB === 'ui' ? 'ui' : 'home';
 const glcdRenderer = createGlcdRenderer();
 const lcdRenderer = createLcdRenderer();
 const matrixUi = createMatrixUiController(vscode, () => activeTab === 'ui');
@@ -151,7 +170,10 @@ function scheduleMemoryResize(): void {
 }
 
 function setTab(tab: string, notify: boolean): void {
-  activeTab = tab === 'memory' ? 'memory' : 'ui';
+  activeTab = tab === 'memory' ? 'memory' : tab === 'ui' ? 'ui' : 'home';
+  if (panelHome) {
+    panelHome.classList.toggle('active', activeTab === 'home');
+  }
   if (panelUi) {
     panelUi.classList.toggle('active', activeTab === 'ui');
   }
@@ -218,6 +240,35 @@ selectProjectButton?.addEventListener('click', () => {
 selectTargetButton?.addEventListener('click', () => {
   vscode.postMessage({ type: 'selectTarget' });
 });
+
+setEntrySourceButton?.addEventListener('click', () => {
+  vscode.postMessage({ type: 'setEntrySource' });
+});
+
+function setHomeValue(node: HTMLElement | null, value: string | undefined, fallback: string): void {
+  if (!node) {
+    return;
+  }
+  node.textContent = value !== undefined && value !== '' ? value : fallback;
+}
+
+function applyProjectStatus(payload: {
+  rootName?: string;
+  hasProject?: boolean;
+  targetName?: string;
+  entrySource?: string;
+}): void {
+  setHomeValue(homeRootName, payload.rootName, 'No root selected');
+  setHomeValue(
+    homeProjectState,
+    payload.hasProject ? 'Configured Debug80 project' : undefined,
+    payload.rootName ? 'No Debug80 project in this root' : 'No root selected'
+  );
+  setHomeValue(homeTargetName, payload.targetName, 'No target selected');
+  setHomeValue(homeEntrySource, payload.entrySource, 'No entry source selected');
+}
+
+applyProjectStatus({});
 
 function applySpeed(mode: SpeedMode): void {
   speedMode = mode;
@@ -498,6 +549,10 @@ memoryPanelController.wire();
 window.addEventListener('message', (event: MessageEvent<IncomingMessage | undefined>): void => {
   const message = event.data;
   if (!message) {
+    return;
+  }
+  if (message.type === 'projectStatus') {
+    applyProjectStatus(message);
     return;
   }
   if (message.type === 'selectTab') {


### PR DESCRIPTION
## Summary
- add a Home tab as the first live-panel tab for TEC-1 and TEC-1G, moving root/target/entry controls out of the UI tab
- make workspace selection explicitly root-oriented, broaden project detection to all supported config locations, and auto-start or restart debugging when selecting a configured root or target
- update idle-view wording and regression coverage for the new root-selection and Home-tab workflow

## Validation
- npm run lint
- npm test

## Notes
- created local top-level directories beside the repo for future root projects: debug80-tec1-mon1, debug80-tec1-mon2, debug80-tec1g-mon1, debug80-tec1g-mon3
- those new directories are outside this repository, so they are not part of the PR diff
