### PR TITLE
fix: TEC-1G launch config merge (romHex, source roots, asm80)

### DIFF
--- a/src/debug/launch-args.ts
+++ b/src/debug/launch-args.ts
@@ -6,8 +6,58 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { LaunchRequestArguments } from './types';
 import type { PlatformKind } from './program-loader';
+import type { Tec1gPlatformConfig } from '../platforms/types';
 import { isPathWithin } from './path-utils';
 import { D8_DEBUG_MAP_EXT } from './d8-map-paths';
+
+/**
+ * Shallow-merge nested platform blocks so a target can override e.g. `tec1g.appStart`
+ * without replacing the entire root `tec1g` object (which would drop `romHex` and break MON-3).
+ */
+function mergeNestedPlatformBlock<T extends object>(
+  ...parts: Array<Partial<T> | undefined>
+): T | undefined {
+  const out: Record<string, unknown> = {};
+  for (const p of parts) {
+    if (p === undefined || typeof p !== 'object' || Array.isArray(p)) {
+      continue;
+    }
+    Object.assign(out, p as Record<string, unknown>);
+  }
+  return Object.keys(out).length > 0 ? (out as T) : undefined;
+}
+
+/**
+ * When `romHex` lives only under another target's `tec1g` block (common for MON-3),
+ * the active target's partial `tec1g` would otherwise drop it after merge.
+ * If root and merged base have no non-empty `romHex`, inherit from the first target
+ * (alphabetically) that defines `romHex`, then apply root overrides.
+ */
+function resolveTec1gBaseForMerge(cfg: {
+  tec1g?: Tec1gPlatformConfig;
+  targets?: Record<
+    string,
+    Partial<LaunchRequestArguments> & { sourceFile?: string; source?: string }
+  >;
+}): Tec1gPlatformConfig | undefined {
+  const root = cfg.tec1g;
+  if (root !== undefined && typeof root.romHex === 'string' && root.romHex.trim() !== '') {
+    return root;
+  }
+  let inherited: Tec1gPlatformConfig | undefined;
+  const names = Object.keys(cfg.targets ?? {}).sort((a, b) => a.localeCompare(b));
+  for (const name of names) {
+    const t = cfg.targets?.[name]?.tec1g;
+    if (t !== undefined && typeof t.romHex === 'string' && t.romHex.trim() !== '') {
+      inherited = { ...t };
+      break;
+    }
+  }
+  if (inherited === undefined) {
+    return root;
+  }
+  return { ...inherited, ...(root ?? {}) };
+}
 
 export interface LaunchArgsHelpers {
   resolveBaseDir: (args: LaunchRequestArguments) => string;
@@ -120,6 +170,29 @@ export function populateFromConfig(
       ...targetCfg,
       ...args,
     };
+
+    const mergedSimple = mergeNestedPlatformBlock(cfg.simple, targetCfg?.simple, args.simple);
+    if (mergedSimple !== undefined) {
+      merged.simple = mergedSimple;
+    } else {
+      delete merged.simple;
+    }
+    const mergedTec1 = mergeNestedPlatformBlock(cfg.tec1, targetCfg?.tec1, args.tec1);
+    if (mergedTec1 !== undefined) {
+      merged.tec1 = mergedTec1;
+    } else {
+      delete merged.tec1;
+    }
+    const mergedTec1g = mergeNestedPlatformBlock(
+      resolveTec1gBaseForMerge(cfg),
+      targetCfg?.tec1g,
+      args.tec1g,
+    );
+    if (mergedTec1g !== undefined) {
+      merged.tec1g = mergedTec1g;
+    } else {
+      delete merged.tec1g;
+    }
 
     const asmResolved =
       args.asm ??

--- a/src/debug/launch-sequence.ts
+++ b/src/debug/launch-sequence.ts
@@ -3,6 +3,7 @@
  */
 
 import * as fs from 'fs';
+import * as path from 'path';
 import type { DebugProtocol } from '@vscode/debugprotocol';
 import { resolveBundledTec1Rom } from './assembler';
 import { emitConsoleOutput } from './adapter-ui';
@@ -266,6 +267,16 @@ export async function buildLaunchSession(
   });
 
   context.sessionState.listingPath = listingPath;
+  const preSourceRoots: string[] = [];
+  for (const r of merged.sourceRoots ?? []) {
+    preSourceRoots.push(resolveRelative(r, baseDir));
+  }
+  if (asmPath !== undefined && asmPath.length > 0) {
+    preSourceRoots.push(path.dirname(resolveRelative(asmPath, baseDir)));
+  }
+  context.sessionState.sourceRoots = preSourceRoots;
+  const resolvedSourceRoots =
+    preSourceRoots.length > 0 ? preSourceRoots : merged.sourceRoots ?? [];
   const extraListings = platformProvider.extraListings;
   context.sourceState.setManager(
     new SourceManager({
@@ -296,7 +307,7 @@ export async function buildLaunchSession(
     ...(merged.sourceFile !== undefined && merged.sourceFile.length > 0
       ? { sourceFile: merged.sourceFile }
       : {}),
-    sourceRoots: merged.sourceRoots ?? [],
+    sourceRoots: resolvedSourceRoots,
     extraListings,
     mapArgs: {
       ...(merged.artifactBase !== undefined && merged.artifactBase.length > 0

--- a/src/debug/zax-backend.ts
+++ b/src/debug/zax-backend.ts
@@ -14,13 +14,13 @@ import type { AssembleOptions, AssemblerBackend } from './assembler-backend';
 const moduleRequire = createRequire(__filename);
 
 /**
- * Optional local development without publishing to npm:
- * - Prefer `npm link` in the ZAX repo, then `npm link @jhlagado/zax` in Debug80 (see README).
- * - `DEBUG80_ZAX_CLI`: absolute path to `cli.js` (e.g. `.../ZAX/dist/src/cli.js`)
- * - `DEBUG80_ZAX_ROOT`: path to ZAX repo root (uses `dist/src/cli.js` under it)
+ * Resolution order:
+ * 1) Optional env overrides (one-off debugging; see README).
+ * 2) `require.resolve('@jhlagado/zax/dist/src/cli.js')` / package layout.
+ * 3) Walk parents for `node_modules/@jhlagado/zax` (e.g. workspace with hoisted deps).
  *
- * Env vars are checked before `node_modules` resolution so Extension Host can override
- * a registry install when needed.
+ * Normal local ZAX development: keep `package.json` on the published semver
+ * (`@jhlagado/zax`) and use `npm link` — no committed `file:` dependency.
  */
 function resolveZaxCliFromEnv(): string | undefined {
   const cli = process.env.DEBUG80_ZAX_CLI?.trim();
@@ -85,9 +85,9 @@ function resolveZaxCliPath(startDir: string): string | undefined {
 
 function zaxNotFoundMessage(): string {
   return (
-    'zax not found. Install with "npm install -D @jhlagado/zax", use a local checkout ' +
-    '("cd ZAX && npm link" then "cd debug80 && npm link @jhlagado/zax"), "npm install file:../ZAX", ' +
-    'or set DEBUG80_ZAX_ROOT / DEBUG80_ZAX_CLI (see Debug80 README).'
+    'zax not found. Install with "npm install -D @jhlagado/zax", or link a local ZAX build ' +
+    '("cd ZAX && npm run build && npm link" then "cd debug80 && npm link @jhlagado/zax"). ' +
+    'Optional: DEBUG80_ZAX_ROOT / DEBUG80_ZAX_CLI (see Debug80 README).'
   );
 }
 
@@ -110,7 +110,8 @@ export class ZaxBackend implements AssemblerBackend {
     }
 
     const outArg = toPortablePath(path.relative(asmDir, options.hexPath));
-    const args = [cliPath, '--nobin', '-o', outArg, path.basename(options.asmPath)];
+    // ZAX --asm80: emit ASM80-compatible lowered source (.z80) beside the HEX for inspection.
+    const args = [cliPath, '--nobin', '--asm80', '-o', outArg, path.basename(options.asmPath)];
     const result = cp.spawnSync(process.execPath, args, {
       cwd: asmDir,
       encoding: 'utf-8',

--- a/src/platforms/tec1g/README.md
+++ b/src/platforms/tec1g/README.md
@@ -102,6 +102,13 @@ The TEC-1G DIAG ROM exercises several device behaviors directly:
 Debug80 does not bundle MON-3 ROM images. Provide `romHex` in the platform
 config (and optionally ROM listings via `extraListings`).
 
+**Shared MON-3 settings (recommended):** Put `romHex`, `entry`, and any other
+fields that are the same for every build under **`debug80.json` root** `tec1g`,
+not only under each `targets.<name>` entry. That way every target (ASM, ZAX,
+different demos) loads the same monitor ROM without duplicating paths or
+depending on merge order. Use per-target `tec1g` only for overrides (for example
+`appStart`, `matrixMode`, or `extraListings`).
+
 ```json
 {
   "platform": "tec1g",

--- a/tests/debug/launch-args.test.ts
+++ b/tests/debug/launch-args.test.ts
@@ -109,6 +109,83 @@ describe('launch-args', () => {
     expect(merged.outputDir).toBe('build');
   });
 
+  it('deep-merges tec1g so target overrides do not drop root romHex', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-tec1g-merge-'));
+    const configPath = path.join(dir, 'debug80.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        platform: 'tec1g',
+        defaultTarget: 'matrix',
+        tec1g: {
+          romHex: 'roms/mon-3.hex',
+          entry: 0,
+          appStart: 16384,
+        },
+        targets: {
+          matrix: {
+            asm: 'src/matrix.zax',
+            tec1g: {
+              appStart: 16384,
+            },
+          },
+          asmDemo: {
+            asm: 'src/matrix-demo.asm',
+          },
+        },
+      })
+    );
+    const mergedMatrix = populateFromConfig(
+      { projectConfig: configPath, target: 'matrix' } as LaunchRequestArguments,
+      { resolveBaseDir: () => dir }
+    );
+    expect(mergedMatrix.tec1g?.romHex).toBe('roms/mon-3.hex');
+    expect(mergedMatrix.tec1g?.entry).toBe(0);
+    expect(mergedMatrix.tec1g?.appStart).toBe(16384);
+
+    const mergedAsm = populateFromConfig(
+      { projectConfig: configPath, target: 'asmDemo' } as LaunchRequestArguments,
+      { resolveBaseDir: () => dir }
+    );
+    expect(mergedAsm.tec1g?.romHex).toBe('roms/mon-3.hex');
+    expect(mergedAsm.asm).toBe('src/matrix-demo.asm');
+  });
+
+  it('inherits tec1g.romHex from another target when root has no romHex', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-tec1g-inherit-'));
+    const configPath = path.join(dir, 'debug80.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        platform: 'tec1g',
+        defaultTarget: 'matrix',
+        targets: {
+          'matrix-demo': {
+            asm: 'src/matrix-demo.asm',
+            tec1g: {
+              romHex: 'roms/mon-3.hex',
+              entry: 0,
+            },
+          },
+          matrix: {
+            asm: 'src/matrix.zax',
+            assembler: 'zax',
+            tec1g: {
+              appStart: 16384,
+            },
+          },
+        },
+      })
+    );
+    const merged = populateFromConfig(
+      { projectConfig: configPath, target: 'matrix' } as LaunchRequestArguments,
+      { resolveBaseDir: () => dir }
+    );
+    expect(merged.tec1g?.romHex).toBe('roms/mon-3.hex');
+    expect(merged.tec1g?.appStart).toBe(16384);
+    expect(merged.tec1g?.entry).toBe(0);
+  });
+
   it('returns args when config is missing or unreadable', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-missing-'));
     const args = { asm: path.join(dir, 'main.asm') } as LaunchRequestArguments;

--- a/tests/debug/zax-backend.test.ts
+++ b/tests/debug/zax-backend.test.ts
@@ -99,6 +99,7 @@ describe('zax-backend', () => {
     const [command, args, spawnOptions] = firstCall;
     expect(command).toBe(process.execPath);
     expect(args).toContain('--nobin');
+    expect(args).toContain('--asm80');
     expect(args).toContain('-o');
     expect(args).toContain(path.join('build', 'prog.hex').replace(/\\/g, '/'));
     expect(args).toContain(path.basename(asmPath));


### PR DESCRIPTION
## Summary
- Deep-merge `tec1g` / `tec1` / `simple` so per-target blocks extend the root instead of replacing the whole object (fixes MON-3 `romHex` being dropped when a target only overrides e.g. `appStart`).
- If root has no `romHex`, inherit from the first target (alphabetically) that defines `tec1g.romHex`.
- Resolve `sourceRoots` with the asm file directory for ZAX; pass the same list to `SourceManager.build`.
- `ZaxBackend`: pass `--asm80` for lowered listing output; update tests.
- Document shared root `tec1g` in the TEC-1G platform README.

## Test plan
- [x] `npx vitest run tests/debug/launch-args.test.ts`
- [x] `tsc --noEmit` (pre-commit hook)

Made with [Cursor](https://cursor.com)