### PR TITLE
feat: ZAX entry picker, map overlap resolution, .zax rebuild on save

### DIFF
--- a/src/extension/auto-rebuild.ts
+++ b/src/extension/auto-rebuild.ts
@@ -9,7 +9,7 @@ import { isWarmRebuildResult } from '../debug/message-types';
 import { SessionStateManager } from './session-state-manager';
 
 const REBUILD_DEBOUNCE_MS = 250;
-const ASSEMBLY_EXTENSIONS = new Set(['.asm', '.z80', '.a80', '.s']);
+const ASSEMBLY_EXTENSIONS = new Set(['.asm', '.z80', '.a80', '.s', '.zax']);
 
 function isAssemblyDocument(document: vscode.TextDocument): boolean {
   if (document.isUntitled || document.uri.scheme !== 'file') {

--- a/src/extension/project-target-selection.ts
+++ b/src/extension/project-target-selection.ts
@@ -23,7 +23,7 @@ type TargetChoice = {
 type TargetQuickPickItem = vscode.QuickPickItem & {
   targetName: string;
   /** When set, selecting this row applies this path as sourceFile/asm for `targetName`. */
-  applyZaxSource?: string;
+  applyEntrySource?: string;
 };
 
 function isTargetPickRow(item: vscode.QuickPickItem): item is TargetQuickPickItem {
@@ -66,6 +66,54 @@ export function resolvePreferredTargetName(
   }
 
   return undefined;
+}
+
+function appendEntrySourceSection(
+  items: Array<vscode.QuickPickItem | TargetQuickPickItem>,
+  paths: string[],
+  separatorLabel: string,
+  detail: 'ZAX' | 'ASM',
+  projectRoot: string,
+  targetsPerPath: Map<string, string[]>,
+  bindTarget: string | undefined
+): void {
+  if (paths.length === 0) {
+    return;
+  }
+  items.push({
+    kind: vscode.QuickPickItemKind.Separator,
+    label: separatorLabel,
+  });
+  for (const filePath of paths) {
+    const key = entrySourceKey(projectRoot, filePath);
+    const boundTargets = targetsPerPath.get(key) ?? [];
+    if (boundTargets.length > 0) {
+      const primary = boundTargets[0];
+      if (primary === undefined) {
+        continue;
+      }
+      const row: TargetQuickPickItem = {
+        label: filePath,
+        description:
+          boundTargets.length > 1 ? `Targets: ${boundTargets.join(', ')}` : `Target: ${primary}`,
+        detail,
+        targetName: primary,
+      };
+      items.push(row);
+      continue;
+    }
+    if (bindTarget === undefined) {
+      continue;
+    }
+    const row: TargetQuickPickItem = {
+      label: filePath,
+      description: `Set as entry for target "${bindTarget}"`,
+      detail,
+      targetName: bindTarget,
+      applyEntrySource: filePath,
+    };
+    items.push(row);
+  }
 }
 
 export class ProjectTargetSelectionController {
@@ -135,64 +183,40 @@ export class ProjectTargetSelectionController {
 
     const bindTarget = defaultTarget ?? stored ?? choices[0]?.name;
     let zaxPaths: string[] = [];
+    let asmPaths: string[] = [];
     const targetsPerZaxPath = new Map<string, string[]>();
+    const targetsPerAsmPath = new Map<string, string[]>();
     const config = readProjectConfig(projectConfigPath);
     const projectRoot = projectRootFromProjectConfigPath(projectConfigPath);
     for (const [name, t] of Object.entries(config?.targets ?? {})) {
       const src = t.sourceFile ?? t.asm ?? t.source;
-      if (typeof src !== 'string' || !src.toLowerCase().endsWith('.zax')) {
+      if (typeof src !== 'string') {
         continue;
       }
-      const key = zaxEntryKey(projectRoot, src);
-      const list = targetsPerZaxPath.get(key) ?? [];
-      list.push(name);
-      targetsPerZaxPath.set(key, list);
+      const lower = src.toLowerCase();
+      const key = entrySourceKey(projectRoot, src);
+      if (lower.endsWith('.zax')) {
+        const list = targetsPerZaxPath.get(key) ?? [];
+        list.push(name);
+        targetsPerZaxPath.set(key, list);
+      } else if (lower.endsWith('.asm')) {
+        const list = targetsPerAsmPath.get(key) ?? [];
+        list.push(name);
+        targetsPerAsmPath.set(key, list);
+      }
     }
 
     try {
-      zaxPaths = listProjectSourceFiles(projectRoot).filter((p) => p.toLowerCase().endsWith('.zax'));
+      const all = listProjectSourceFiles(projectRoot);
+      zaxPaths = all.filter((p) => p.toLowerCase().endsWith('.zax'));
+      asmPaths = all.filter((p) => p.toLowerCase().endsWith('.asm'));
     } catch {
       zaxPaths = [];
+      asmPaths = [];
     }
 
-    if (zaxPaths.length > 0) {
-      items.push({
-        kind: vscode.QuickPickItemKind.Separator,
-        label: 'ZAX sources',
-      });
-      for (const zaxPath of zaxPaths) {
-        const key = zaxEntryKey(projectRoot, zaxPath);
-        const boundTargets = targetsPerZaxPath.get(key) ?? [];
-        if (boundTargets.length > 0) {
-          const primary = boundTargets[0];
-          if (primary === undefined) {
-            continue;
-          }
-          const row: TargetQuickPickItem = {
-            label: zaxPath,
-            description:
-              boundTargets.length > 1
-                ? `Targets: ${boundTargets.join(', ')}`
-                : `Target: ${primary}`,
-            detail: 'ZAX',
-            targetName: primary,
-          };
-          items.push(row);
-          continue;
-        }
-        if (bindTarget === undefined) {
-          continue;
-        }
-        const row: TargetQuickPickItem = {
-          label: zaxPath,
-          description: `Set as entry for target "${bindTarget}"`,
-          detail: 'ZAX',
-          targetName: bindTarget,
-          applyZaxSource: zaxPath,
-        };
-        items.push(row);
-      }
-    }
+    appendEntrySourceSection(items, zaxPaths, 'ZAX sources', 'ZAX', projectRoot, targetsPerZaxPath, bindTarget);
+    appendEntrySourceSection(items, asmPaths, 'ASM sources', 'ASM', projectRoot, targetsPerAsmPath, bindTarget);
 
     const picked = await vscode.window.showQuickPick(items, {
       placeHolder: options.placeHolder ?? 'Select the Debug80 target',
@@ -206,8 +230,8 @@ export class ProjectTargetSelectionController {
       return null;
     }
 
-    if (picked.applyZaxSource !== undefined) {
-      const ok = updateProjectTargetSource(projectConfigPath, picked.targetName, picked.applyZaxSource);
+    if (picked.applyEntrySource !== undefined) {
+      const ok = updateProjectTargetSource(projectConfigPath, picked.targetName, picked.applyEntrySource);
       if (!ok) {
         void vscode.window.showErrorMessage('Debug80: Failed to update the project entry source.');
         return null;
@@ -283,7 +307,7 @@ function normalizeProjectRelativePath(p: string): string {
 }
 
 /** Keys match {@link listProjectSourceFiles} paths (relative to project root, forward slashes). */
-function zaxEntryKey(projectRoot: string, src: string): string {
+function entrySourceKey(projectRoot: string, src: string): string {
   const norm = normalizeProjectRelativePath(src);
   if (path.isAbsolute(src)) {
     return normalizeProjectRelativePath(path.relative(projectRoot, src));

--- a/src/mapping/source-map.ts
+++ b/src/mapping/source-map.ts
@@ -3,8 +3,30 @@
  * Provides efficient address-to-source and source-to-address resolution.
  */
 
-import { MappingParseResult, SourceMapAnchor, SourceMapSegment } from './parser';
+import { Confidence, MappingParseResult, SourceMapAnchor, SourceMapSegment } from './parser';
 import { normalizePathForKey } from '../debug/path-utils';
+
+const CONFIDENCE_RANK: Record<Confidence, number> = {
+  HIGH: 0,
+  MEDIUM: 1,
+  LOW: 2,
+};
+
+function segmentWidth(segment: SourceMapSegment): number {
+  return Math.max(0, segment.end - segment.start);
+}
+
+/** Prefer the narrowest span; then higher mapping confidence (ZAX may emit overlapping unknown spans). */
+function compareSegmentForAddress(
+  a: SourceMapSegment,
+  b: SourceMapSegment
+): number {
+  const w = segmentWidth(a) - segmentWidth(b);
+  if (w !== 0) {
+    return w;
+  }
+  return CONFIDENCE_RANK[a.confidence] - CONFIDENCE_RANK[b.confidence];
+}
 
 /**
  * Indexed source map for efficient lookups.
@@ -49,7 +71,7 @@ export function buildSourceMapIndex(
   resolvePath: ResolvePathFn
 ): SourceMapIndex {
   const segmentsByAddress = [...mapping.segments].sort(
-    (a, b) => a.start - b.start || a.lst.line - b.lst.line
+    (a, b) => a.start - b.start || segmentWidth(a) - segmentWidth(b) || a.lst.line - b.lst.line
   );
 
   const segmentsByFileLine = new Map<string, Map<number, SourceMapSegment[]>>();
@@ -98,8 +120,9 @@ export function buildSourceMapIndex(
 /**
  * Finds the source map segment containing a given address.
  *
- * Performs a linear search through segments sorted by address.
- * Returns the first segment where start <= address < end.
+ * Native D8 maps (e.g. ZAX) may emit overlapping segments: a coarse `unknown` span and
+ * precise `code` rows sharing the same address range. Breakpoints still resolve via
+ * file+line; PC→line must pick the **most specific** span, not the first in sort order.
  *
  * @param index - Source map index
  * @param address - Memory address to look up
@@ -109,15 +132,16 @@ export function findSegmentForAddress(
   index: SourceMapIndex,
   address: number
 ): SourceMapSegment | undefined {
+  let best: SourceMapSegment | undefined;
   for (const segment of index.segmentsByAddress) {
-    if (address < segment.start) {
-      break;
+    if (address < segment.start || address >= segment.end) {
+      continue;
     }
-    if (address >= segment.start && address < segment.end) {
-      return segment;
+    if (best === undefined || compareSegmentForAddress(segment, best) < 0) {
+      best = segment;
     }
   }
-  return undefined;
+  return best;
 }
 
 /**

--- a/tests/mapping/source-map.test.ts
+++ b/tests/mapping/source-map.test.ts
@@ -78,4 +78,32 @@ describe('source-map', () => {
     assert.equal(findAnchorLine(index, asmPath, 0x0002), 1);
     assert.equal(findAnchorLine(index, asmPath, 0xffff), 5);
   });
+
+  it('prefers the narrowest segment when ZAX-style D8 maps overlap (wide unknown + code)', () => {
+    const mapping: MappingParseResult = {
+      segments: [
+        {
+          start: 0x4000,
+          end: 0x4002,
+          loc: { file: 'app.zax', line: 21 },
+          lst: { line: 21, text: 'ld a,1' },
+          confidence: 'HIGH',
+        },
+        {
+          start: 0x4000,
+          end: 0x4040,
+          loc: { file: 'app.zax', line: null },
+          lst: { line: 0, text: '' },
+          confidence: 'LOW',
+        },
+      ],
+      anchors: [],
+    };
+    const resolve = (f: string): string | undefined => (f === 'app.zax' ? '/x/app.zax' : undefined);
+    const idx = buildSourceMapIndex(mapping, resolve);
+    const seg = findSegmentForAddress(idx, 0x4001);
+    assert.ok(seg);
+    assert.equal(seg?.loc.line, 21);
+    assert.equal(seg?.confidence, 'HIGH');
+  });
 });


### PR DESCRIPTION
## Summary

This PR cleans up remaining ZAX / MON-3 workbench work that was sitting unstaged on `main`:

- **Target quick pick** — Lists both `.zax` and `.asm` entry sources, renames `applyZaxSource` → `applyEntrySource`, and factors a shared `appendEntrySourceSection` helper.
- **Source maps** — ZAX native D8 maps can emit overlapping segments (e.g. coarse `unknown` vs precise `code`). `findSegmentForAddress` now picks the **narrowest** span, then higher **confidence**, so PC→line resolution matches the intended instruction row.
- **Auto-rebuild** — Adds `.zax` to the assembly extension set so warm rebuild-on-save applies during debug sessions (same as `.asm` / `.z80`).

## Testing

- `npm run typecheck`
- `vitest run tests/mapping/source-map.test.ts`
- `vitest run tests/extension/project-config.test.ts`

## Related

Complements recent `main` work: TEC-1G matrix latch/visit-mask display, `@jhlagado/zax/cli` resolution.

Made with [Cursor](https://cursor.com)