### PR TITLE
fix: harden D8 debug map pipeline against regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository keeps the shared debugger and a small `test/fixtures` stub for t
 
 ## Local ZAX checkout (develop ZAX + Debug80 without npm publish)
 
-Debug80 depends on [`@jhlagado/zax`](https://www.npmjs.com/package/@jhlagado/zax) (e.g. `"@jhlagado/zax": "^0.1.0"` in `package.json`) for the `.zax` assembler backend. **Keep that semver range in git** so CI, VSIX packaging, and collaborators all resolve the same dependency story. Do not commit `file:../zax` (or similar) in this repo if you want a single, consistent install.
+Debug80 depends on [`@jhlagado/zax`](https://www.npmjs.com/package/@jhlagado/zax) (e.g. `"@jhlagado/zax": "^0.2.2"` in `package.json`) for the `.zax` assembler backend. **Keep that semver range in git** so CI, VSIX packaging, and collaborators all resolve the same dependency story. Do not commit `file:../zax` (or similar) in this repo if you want a single, consistent install.
 
 ### `npm link` (recommended for local ZAX development)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@jhlagado/zax": "^0.1.0",
+        "@jhlagado/zax": "^0.2.2",
         "@vscode/debugadapter": "^1.64.0",
         "@vscode/debugprotocol": "^1.64.0",
         "asm80": "^1.11.14"
@@ -21,6 +21,7 @@
         "@typescript-eslint/parser": "^6.13.0",
         "@vitest/coverage-v8": "0.33.0",
         "@vscode/vsce": "^2.22.0",
+        "ajv": "^8.18.0",
         "esbuild": "^0.20.2",
         "eslint": "^8.55.0",
         "eslint-plugin-jsdoc": "^48.2.3",
@@ -900,6 +901,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -910,6 +928,13 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
@@ -1038,9 +1063,9 @@
       }
     },
     "node_modules/@jhlagado/zax": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@jhlagado/zax/-/zax-0.1.0.tgz",
-      "integrity": "sha512-fk7x2eEknivzzJvcyMirJI9tOS8pRBt5E/hsx7wFQECb0kpfeQ/Q7YJD0aw9cNsc/CKQNW0Ny70HiTeyPpjqyw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@jhlagado/zax/-/zax-0.2.2.tgz",
+      "integrity": "sha512-BRmroZdVpfjlmMqBklNA9mRdUCXcXU59WEAzUs11ygrTJJlouXO6iO2rs6Q0usc3sBqxSEYU7PE3XaMCqCZgLA==",
       "license": "GPL-3.0-only",
       "bin": {
         "zax": "dist/src/cli.js"
@@ -1829,16 +1854,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -3060,6 +3085,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3146,6 +3188,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.5",
@@ -3305,6 +3354,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -4214,9 +4280,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -405,6 +405,7 @@
     "@typescript-eslint/parser": "^6.13.0",
     "@vitest/coverage-v8": "0.33.0",
     "@vscode/vsce": "^2.22.0",
+    "ajv": "^8.18.0",
     "esbuild": "^0.20.2",
     "eslint": "^8.55.0",
     "eslint-plugin-jsdoc": "^48.2.3",
@@ -416,7 +417,7 @@
     "vitest": "0.33.0"
   },
   "dependencies": {
-    "@jhlagado/zax": "^0.1.0",
+    "@jhlagado/zax": "^0.2.2",
     "@vscode/debugadapter": "^1.64.0",
     "@vscode/debugprotocol": "^1.64.0",
     "asm80": "^1.11.14"

--- a/schemas/d8-debug-map.schema.json
+++ b/schemas/d8-debug-map.schema.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://debug80.dev/schemas/d8-debug-map.schema.json",
+  "title": "D8 Debug Map",
+  "description": "Portable debug information format for Z80 (and similar) assemblers. Version 1.",
+  "type": "object",
+  "required": ["format", "version", "arch", "addressWidth", "endianness", "files"],
+  "properties": {
+    "format": {
+      "const": "d8-debug-map"
+    },
+    "version": {
+      "const": 1
+    },
+    "arch": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Target architecture, e.g. 'z80'."
+    },
+    "addressWidth": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Address width in bits."
+    },
+    "endianness": {
+      "type": "string",
+      "enum": ["little", "big"]
+    },
+    "files": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/definitions/fileEntry" },
+      "description": "Map of source file names to their debug entries."
+    },
+    "lstText": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Shared listing text table for deduplication."
+    },
+    "segmentDefaults": { "$ref": "#/definitions/segmentDefaults" },
+    "symbolDefaults": { "$ref": "#/definitions/symbolDefaults" },
+    "memory": { "$ref": "#/definitions/memoryLayout" },
+    "generator": { "$ref": "#/definitions/generator" },
+    "diagnostics": { "$ref": "#/definitions/diagnosticsBlock" }
+  },
+  "additionalProperties": true,
+  "definitions": {
+    "segmentKind": {
+      "type": "string",
+      "enum": ["code", "data", "directive", "label", "macro", "unknown"]
+    },
+    "confidence": {
+      "type": "string",
+      "enum": ["high", "medium", "low"]
+    },
+    "symbolKind": {
+      "type": "string",
+      "enum": ["label", "constant", "data", "macro", "unknown"]
+    },
+    "symbolScope": {
+      "type": "string",
+      "enum": ["global", "local"]
+    },
+    "fileEntry": {
+      "type": "object",
+      "properties": {
+        "meta": {
+          "type": "object",
+          "properties": {
+            "sha256": { "type": "string" },
+            "lineCount": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": false
+        },
+        "segments": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/segment" }
+        },
+        "symbols": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/symbol" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "segment": {
+      "type": "object",
+      "required": ["start", "end", "lstLine"],
+      "properties": {
+        "start": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Start address (inclusive)."
+        },
+        "end": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "End address (exclusive). Must be > start."
+        },
+        "line": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Source line number (1-based). Omit or set null if unknown. Must be >= 1 when present."
+        },
+        "column": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "kind": { "$ref": "#/definitions/segmentKind" },
+        "confidence": { "$ref": "#/definitions/confidence" },
+        "lstLine": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Listing file line number. Should be >= 1 for valid mappings; 0 indicates unknown."
+        },
+        "lstText": { "type": "string" },
+        "lstTextId": { "type": "integer", "minimum": 0 },
+        "includeChain": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "macro": {
+          "type": "object",
+          "required": ["name", "callsite"],
+          "properties": {
+            "name": { "type": "string" },
+            "callsite": {
+              "type": "object",
+              "required": ["file", "line"],
+              "properties": {
+                "file": { "type": "string" },
+                "line": { "type": "integer", "minimum": 1 },
+                "column": { "type": "integer", "minimum": 0 }
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "symbol": {
+      "type": "object",
+      "required": ["name", "address"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "address": { "type": "integer", "minimum": 0 },
+        "line": { "type": "integer", "minimum": 1 },
+        "kind": { "$ref": "#/definitions/symbolKind" },
+        "scope": { "$ref": "#/definitions/symbolScope" },
+        "size": { "type": "integer", "minimum": 0 },
+        "value": { "type": "integer" }
+      },
+      "additionalProperties": false
+    },
+    "segmentDefaults": {
+      "type": "object",
+      "properties": {
+        "kind": { "$ref": "#/definitions/segmentKind" },
+        "confidence": { "$ref": "#/definitions/confidence" }
+      },
+      "additionalProperties": false
+    },
+    "symbolDefaults": {
+      "type": "object",
+      "properties": {
+        "kind": { "$ref": "#/definitions/symbolKind" },
+        "scope": { "$ref": "#/definitions/symbolScope" }
+      },
+      "additionalProperties": false
+    },
+    "memoryLayout": {
+      "type": "object",
+      "required": ["segments"],
+      "properties": {
+        "segments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "start", "end"],
+            "properties": {
+              "name": { "type": "string" },
+              "start": { "type": "integer", "minimum": 0 },
+              "end": { "type": "integer", "minimum": 0 },
+              "kind": {
+                "type": "string",
+                "enum": ["rom", "ram", "io", "banked", "unknown"]
+              },
+              "bank": { "type": "integer" }
+            }
+          }
+        }
+      }
+    },
+    "generator": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "tool": { "type": "string" },
+        "version": { "type": "string" },
+        "args": { "type": "array", "items": { "type": "string" } },
+        "createdAt": { "type": "string" },
+        "inputs": { "type": "object" },
+        "entrySymbol": { "type": "string" },
+        "entryAddress": { "type": "integer" }
+      },
+      "additionalProperties": true
+    },
+    "diagnosticsBlock": {
+      "type": "object",
+      "properties": {
+        "warnings": { "type": "array", "items": { "type": "string" } },
+        "errors": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/debug/adapter-request-controller.ts
+++ b/src/debug/adapter-request-controller.ts
@@ -2,13 +2,13 @@
  * @fileoverview DAP request/control helpers for the debug adapter.
  */
 
-import { StoppedEvent, TerminatedEvent, Thread } from '@vscode/debugadapter';
+import { OutputEvent, StoppedEvent, TerminatedEvent, Thread } from '@vscode/debugadapter';
 import type { DebugProtocol } from '@vscode/debugprotocol';
 import type { StepInfo } from '../z80/types';
 import type { BreakpointManager } from './breakpoint-manager';
 import type { CommandRouter } from './command-router';
 import { getShadowAlias, isBreakpointAddress } from './debug-addressing';
-import { buildStackFrames } from './stack-service';
+import { buildStackFrames, flushDiagLog, isDiagnosticsEnabled } from './stack-service';
 import type { SourceStateManager } from './source-state-manager';
 import {
   captureEntryCpuStateIfNeeded,
@@ -230,7 +230,10 @@ export class AdapterRequestController {
       this.deps.sendResponse(response);
       return;
     }
-    const responseBody = buildStackFrames(this.deps.sessionState.runtime.getPC(), {
+    const pc = this.deps.sessionState.runtime.getPC();
+    const resolveFn = (file: string): string | undefined =>
+      resolveMappedPath(file, this.deps.sessionState.listingPath, this.deps.sessionState.sourceRoots);
+    const responseBody = buildStackFrames(pc, {
       ...(this.deps.sessionState.listing !== undefined ? { listing: this.deps.sessionState.listing } : {}),
       ...(this.deps.sessionState.listingPath !== undefined
         ? { listingPath: this.deps.sessionState.listingPath }
@@ -239,8 +242,7 @@ export class AdapterRequestController {
         ? { mappingIndex: this.deps.sessionState.mappingIndex }
         : {}),
       ...(this.deps.sourceState.file !== undefined ? { sourceFile: this.deps.sourceState.file } : {}),
-      resolveMappedPath: (file): string | undefined =>
-        resolveMappedPath(file, this.deps.sessionState.listingPath, this.deps.sessionState.sourceRoots),
+      resolveMappedPath: resolveFn,
       getAddressAliases: (address) => {
         const masked = address & ADDR_MASK;
         const aliases = [masked];
@@ -251,6 +253,23 @@ export class AdapterRequestController {
         return aliases;
       },
     });
+
+    if (isDiagnosticsEnabled()) {
+      const diagLines = flushDiagLog();
+      const frame = responseBody.stackFrames[0];
+      const hasMappingIndex = this.deps.sessionState.mappingIndex !== undefined;
+      const segCount = this.deps.sessionState.mappingIndex?.segmentsByAddress?.length ?? 0;
+      const diagText = [
+        `[debug80-diag] PC=0x${pc.toString(16).padStart(4, '0')} ` +
+          `mappingIndex=${hasMappingIndex} (${segCount} segs) ` +
+          `sourceFile="${this.deps.sourceState.file ?? '(none)'}" ` +
+          `listingPath="${this.deps.sessionState.listingPath ?? '(none)'}" ` +
+          `sourceRoots=[${this.deps.sessionState.sourceRoots.join(', ')}]`,
+        ...diagLines,
+        `  => frame.source="${frame?.source?.path ?? '(none)'}" line=${frame?.line ?? '?'}`,
+      ].join('\n');
+      this.deps.sendEvent(new OutputEvent(diagText + '\n', 'console'));
+    }
 
     response.body = responseBody;
     this.deps.sendResponse(response);

--- a/src/debug/adapter.ts
+++ b/src/debug/adapter.ts
@@ -18,6 +18,7 @@ import {
   resetSessionState,
   type SessionStateShape,
 } from './session-state';
+import { setDiagnosticsEnabled } from './stack-service';
 import { BreakpointManager } from './breakpoint-manager';
 import { SourceStateManager } from './source-state-manager';
 import { CommandRouter } from './command-router';
@@ -191,6 +192,7 @@ export class Z80DebugSession extends DebugSession {
     });
     this.sessionState.launchArgs = merged;
     this.sessionState.runState.stopOnEntry = merged.stopOnEntry === true;
+    setDiagnosticsEnabled(merged.diagnostics === true);
 
     if (!hasLaunchInputs(merged)) {
       await respondToMissingLaunchInputs(

--- a/src/debug/breakpoint-manager.ts
+++ b/src/debug/breakpoint-manager.ts
@@ -139,6 +139,12 @@ export class BreakpointManager {
     if (lower.endsWith('.asm')) {
       return normalized.slice(0, -'.asm'.length) + '.source.asm';
     }
+    if (lower.endsWith('.source.zax')) {
+      return normalized.slice(0, -'.source.zax'.length) + '.zax';
+    }
+    if (lower.endsWith('.zax')) {
+      return normalized.slice(0, -'.zax'.length) + '.source.zax';
+    }
     return null;
   }
 

--- a/src/debug/mapping-service.ts
+++ b/src/debug/mapping-service.ts
@@ -13,13 +13,14 @@ import {
 import { resolveAssemblerBackend } from './assembler-backend';
 import { resolveListingSourcePath } from './path-resolver';
 import { applyLayer2 } from '../mapping/layer2';
-import { buildSourceMapIndex, SourceMapIndex, ResolvePathFn } from '../mapping/source-map';
+import { buildSourceMapIndex, SourceMapIndex, ResolvePathFn, setSegmentWarningHandler } from '../mapping/source-map';
 import {
   buildD8DebugMap,
   buildMappingFromD8DebugMap,
   D8DebugMap,
   parseD8DebugMap,
 } from '../mapping/d8-map';
+import { validateD8Segments } from '../mapping/d8-validate';
 import { D8_DEBUG_MAP_EXT, legacyDebugMapPath } from './d8-map-paths';
 import { Logger } from '../util/logger';
 
@@ -109,8 +110,15 @@ export function buildMappingFromListing(options: {
     service.logger.info(
       `Debug80: Using native D8 map from "${getDebugMapGeneratorLabel(loadedMap)}" at "${debugMapLoadedFrom ?? mapPath}".`
     );
+    const d8Warnings = validateD8Segments(loadedMap);
+    for (const w of d8Warnings) {
+      service.logger.warn(`Debug80: D8 quality warning [${w.file}]: ${w.message}`);
+    }
   }
 
+  // Only apply listing-vs-map mtime for Debug80-generated maps. Native assembler maps (e.g. ZAX
+  // `.d8.json`) must not be invalidated when the `.lst` is newer — ZAX emits both; mtimes are
+  // not a reliable ordering signal, and the listing parser is asm80-oriented, not a substitute.
   const mapStale =
     !hasNativeMap && isDebugMapStale(debugMapLoadedFrom ?? mapPath, listingPath);
 
@@ -138,6 +146,16 @@ export function buildMappingFromListing(options: {
   }
 
   let mapping = buildMappingFromD8DebugMap(debugMap);
+
+  const fileSet = new Set<string | null>();
+  for (const seg of mapping.segments) {
+    fileSet.add(seg.loc.file);
+  }
+  service.logger.info(
+    `Debug80: mapping has ${mapping.segments.length} segments, ` +
+    `${mapping.anchors.length} anchors, files=[${[...fileSet].map(f => f ?? '(null)').join(', ')}]`
+  );
+
   const extraMapping = loadExtraListingMapping(extraListingPaths, service);
   if (extraMapping) {
     mapping = mergeMappings(mapping, extraMapping);
@@ -146,7 +164,15 @@ export function buildMappingFromListing(options: {
     applyTec1gBootstrapAlias(mapping);
   }
 
+  setSegmentWarningHandler((msg) => service.logger.warn(`Debug80: ${msg}`));
+
   const index = buildSourceMapIndex(mapping, (file) => service.resolveMappedPath(file));
+
+  service.logger.info(
+    `Debug80: index built with ${index.segmentsByAddress.length} address-sorted segments, ` +
+    `${index.segmentsByFileLine.size} file entries, ${index.anchorsByFile.size} anchor files`
+  );
+
   return { mapping, index, missingSources };
 }
 

--- a/src/debug/path-resolver.ts
+++ b/src/debug/path-resolver.ts
@@ -7,10 +7,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
+import { fileURLToPath } from 'url';
 import * as vscode from 'vscode';
 import { LaunchRequestArguments } from './types';
 import { FileResolutionError } from './errors';
-import { isPathWithin } from './path-utils';
+import { canonicalizeDebuggerSourcePath, isPathWithin } from './path-utils';
 import { D8_DEBUG_MAP_EXT } from './d8-map-paths';
 
 /**
@@ -365,13 +366,30 @@ export function resolveListingSourcePath(listingPath: string): string | undefine
  * @param sourceRoots - Array of source root directories
  * @returns Resolved absolute path, or undefined
  */
+function stripFileScheme(mappedFile: string): string {
+  const trimmed = mappedFile.trim();
+  if (trimmed.startsWith('file:')) {
+    try {
+      return fileURLToPath(trimmed);
+    } catch {
+      return trimmed;
+    }
+  }
+  return trimmed;
+}
+
 export function resolveMappedPath(
   file: string,
   listingPath: string | undefined,
   sourceRoots: string[]
 ): string | undefined {
-  if (path.isAbsolute(file)) {
-    return file;
+  const raw = stripFileScheme(file);
+  if (path.isAbsolute(raw)) {
+    const normalized = path.normalize(raw);
+    if (fs.existsSync(normalized)) {
+      return canonicalizeDebuggerSourcePath(normalized);
+    }
+    return normalized;
   }
 
   const roots: string[] = [];
@@ -381,9 +399,9 @@ export function resolveMappedPath(
   roots.push(...sourceRoots);
 
   for (const root of roots) {
-    const candidate = path.resolve(root, file);
+    const candidate = path.resolve(root, raw);
     if (fs.existsSync(candidate)) {
-      return candidate;
+      return canonicalizeDebuggerSourcePath(candidate);
     }
   }
 

--- a/src/debug/path-utils.ts
+++ b/src/debug/path-utils.ts
@@ -3,38 +3,100 @@
  * Provides Windows-safe path comparison and normalization functions.
  */
 
+import * as fs from 'fs';
 import * as path from 'path';
 
 /** Whether the current platform is Windows */
 export const IS_WINDOWS = process.platform === 'win32';
 
 /**
+ * Probes the filesystem under `dir` for case sensitivity by checking whether
+ * accessing the directory name in opposite case resolves to the same inode.
+ * Falls back to `true` on Windows and `false` otherwise if the probe fails.
+ */
+function probeIsCaseInsensitive(dir: string): boolean {
+  if (IS_WINDOWS) {
+    return true;
+  }
+  try {
+    const resolved = path.resolve(dir);
+    const parent = path.dirname(resolved);
+    const base = path.basename(resolved);
+    if (base.length === 0) {
+      return false;
+    }
+    const flipped = base === base.toLowerCase() ? base.toUpperCase() : base.toLowerCase();
+    if (flipped === base) {
+      return false;
+    }
+    const flippedPath = path.join(parent, flipped);
+    const origStat = fs.statSync(resolved);
+    let flippedStat: fs.Stats;
+    try {
+      flippedStat = fs.statSync(flippedPath);
+    } catch {
+      return false;
+    }
+    return origStat.ino === flippedStat.ino && origStat.dev === flippedStat.dev;
+  } catch {
+    return false;
+  }
+}
+
+let caseInsensitiveFs: boolean | undefined;
+
+function isCaseInsensitiveFs(): boolean {
+  if (caseInsensitiveFs === undefined) {
+    caseInsensitiveFs = probeIsCaseInsensitive(process.cwd());
+  }
+  return caseInsensitiveFs;
+}
+
+/**
+ * Resolves to an absolute path and follows symlinks when the path exists (e.g. npm-linked trees).
+ */
+function canonicalizeExistingPath(filePath: string): string {
+  const resolved = path.resolve(filePath);
+  try {
+    if (fs.existsSync(resolved)) {
+      return fs.realpathSync.native(resolved);
+    }
+  } catch {
+    /* keep resolved */
+  }
+  return resolved;
+}
+
+/**
+ * Canonical path for debugger {@link Source} / stack frames so they match VS Code's document URI
+ * (realpath when the file exists; avoids lost current-line highlight with symlinks or odd casing).
+ */
+export function canonicalizeDebuggerSourcePath(filePath: string): string {
+  return canonicalizeExistingPath(filePath);
+}
+
+/**
  * Normalizes a path for use as a map key.
- * Converts to lowercase on Windows for case-insensitive matching.
+ * Uses realpath when possible, lowercases on Windows and macOS so editor and map paths agree.
  *
  * @param filePath - Path to normalize
  * @returns Normalized path suitable for use as a map key
  */
 export function normalizePathForKey(filePath: string): string {
-  const resolved = path.resolve(filePath);
-  return IS_WINDOWS ? resolved.toLowerCase() : resolved;
+  const resolved = canonicalizeExistingPath(filePath);
+  return isCaseInsensitiveFs() ? resolved.toLowerCase() : resolved;
 }
 
 /**
  * Compares two file paths for equality.
- * Uses case-insensitive comparison on Windows.
+ * Uses the same rules as {@link normalizePathForKey}.
  *
  * @param path1 - First path
  * @param path2 - Second path
  * @returns True if paths refer to the same file
  */
 export function pathsEqual(path1: string, path2: string): boolean {
-  const resolved1 = path.resolve(path1);
-  const resolved2 = path.resolve(path2);
-  if (IS_WINDOWS) {
-    return resolved1.toLowerCase() === resolved2.toLowerCase();
-  }
-  return resolved1 === resolved2;
+  return normalizePathForKey(path1) === normalizePathForKey(path2);
 }
 
 /**
@@ -55,7 +117,7 @@ export function isPathWithin(filePath: string, baseDir: string): boolean {
     ? normalizedBase
     : normalizedBase + path.sep;
 
-  if (IS_WINDOWS) {
+  if (isCaseInsensitiveFs()) {
     const pathLower = normalizedPath.toLowerCase();
     const baseLower = baseWithSep.toLowerCase();
     // Also check if paths are exactly equal (file is the base dir itself)

--- a/src/debug/source-manager.ts
+++ b/src/debug/source-manager.ts
@@ -87,13 +87,17 @@ export class SourceManager {
     const extraListingPaths = this.resolveExtraListingPaths(args.extraListings, args.listingPath);
     const mergedRoots = this.extendSourceRoots(sourceRoots, extraListingPaths);
 
+    const mappingSourceForFallback =
+      (args.asmPath !== undefined && args.asmPath.length > 0) ||
+      (args.sourceFile !== undefined && args.sourceFile.length > 0)
+        ? sourceFileResolved
+        : undefined;
+
     const mappingResult = this.buildMapping({
       listingContent: args.listingContent,
       listingPath: args.listingPath,
       ...(args.asmPath !== undefined && args.asmPath.length > 0 ? { asmPath: args.asmPath } : {}),
-      ...(args.sourceFile !== undefined && args.sourceFile.length > 0
-        ? { sourceFile: args.sourceFile }
-        : {}),
+      ...(mappingSourceForFallback !== undefined ? { sourceFile: mappingSourceForFallback } : {}),
       extraListingPaths,
       mapArgs: args.mapArgs,
     });
@@ -167,7 +171,7 @@ export class SourceManager {
     listingPath: string
   ): string {
     if (asmPath !== undefined && asmPath.length > 0) {
-      return asmPath;
+      return path.isAbsolute(asmPath) ? path.normalize(asmPath) : this.resolveRelative(asmPath, this.baseDir);
     }
     if (sourceFile !== undefined && sourceFile.length > 0) {
       return this.resolveRelative(sourceFile, this.baseDir);

--- a/src/debug/stack-service.ts
+++ b/src/debug/stack-service.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { StackFrame, Source } from '@vscode/debugadapter';
 import { ListingInfo } from '../z80/loaders';
 import { findAnchorLine, findSegmentForAddress, SourceMapIndex } from '../mapping/source-map';
+import { canonicalizeDebuggerSourcePath } from './path-utils';
 
 export interface SourceLookupOptions {
   listing?: ListingInfo;
@@ -36,11 +37,11 @@ export function resolveSourceForAddress(
   const listingLine = options.listing?.addressToLine.get(address) ?? 1;
   const sourcePath = options.sourceFile ?? listingPath ?? '';
   const fallbackLine = listingPath !== undefined && sourcePath === listingPath ? listingLine : 1;
-  const fallback = { path: sourcePath, line: fallbackLine };
+  const fallback = finalizeSourcePath({ path: sourcePath, line: fallbackLine });
 
   const resolved = resolveSourceForAddressInternal(address, options);
   if (resolved) {
-    return resolved;
+    return finalizeSourcePath(resolved);
   }
 
   const aliases = options.getAddressAliases ? options.getAddressAliases(address) : [address];
@@ -50,11 +51,18 @@ export function resolveSourceForAddress(
     }
     const resolvedAlias = resolveSourceForAddressInternal(alias, options);
     if (resolvedAlias) {
-      return resolvedAlias;
+      return finalizeSourcePath(resolvedAlias);
     }
   }
 
   return fallback;
+}
+
+function finalizeSourcePath(loc: { path: string; line: number }): { path: string; line: number } {
+  if (!loc.path) {
+    return loc;
+  }
+  return { line: loc.line, path: canonicalizeDebuggerSourcePath(loc.path) };
 }
 
 function resolveSourceForAddressInternal(
@@ -63,19 +71,28 @@ function resolveSourceForAddressInternal(
 ): { path: string; line: number } | null {
   const index = options.mappingIndex;
   if (!index) {
+    diagLog(`  [internal] no mappingIndex`);
     return null;
   }
   const segment = findSegmentForAddress(index, address);
-  if (segment === undefined || segment.loc.file === null) {
+  if (segment === undefined) {
+    diagLog(`  [internal] findSegmentForAddress → no segment`);
+    return null;
+  }
+  if (segment.loc.file === null) {
+    diagLog(`  [internal] segment [0x${segment.start.toString(16)}-0x${segment.end.toString(16)}] loc.file=null`);
     return null;
   }
 
+  diagLog(`  [internal] segment [0x${segment.start.toString(16)}-0x${segment.end.toString(16)}] file="${segment.loc.file}" line=${segment.loc.line}`);
   const resolvedPath = options.resolveMappedPath(segment.loc.file);
   if (resolvedPath === undefined || resolvedPath.length === 0) {
+    diagLog(`  [internal] resolveMappedPath("${segment.loc.file}") → undefined`);
     return null;
   }
 
-  if (segment.loc.line !== null) {
+  diagLog(`  [internal] resolved → "${resolvedPath}"`);
+  if (segment.loc.line !== null && segment.loc.line >= 1) {
     return { path: resolvedPath, line: segment.loc.line };
   }
 
@@ -85,4 +102,27 @@ function resolveSourceForAddressInternal(
   }
 
   return null;
+}
+
+let diagLogEnabled = false;
+const diagBuffer: string[] = [];
+
+export function setDiagnosticsEnabled(enabled: boolean): void {
+  diagLogEnabled = enabled;
+}
+
+export function isDiagnosticsEnabled(): boolean {
+  return diagLogEnabled;
+}
+
+function diagLog(msg: string): void {
+  if (diagLogEnabled) {
+    diagBuffer.push(msg);
+  }
+}
+
+export function flushDiagLog(): string[] {
+  const lines = [...diagBuffer];
+  diagBuffer.length = 0;
+  return lines;
 }

--- a/src/debug/types.ts
+++ b/src/debug/types.ts
@@ -55,6 +55,8 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
   tec1?: Tec1PlatformConfig;
   /** TEC-1G platform configuration */
   tec1g?: Tec1gPlatformConfig;
+  /** Enable verbose diagnostics in the Debug Console */
+  diagnostics?: boolean;
 }
 
 /**

--- a/src/extension/auto-rebuild.ts
+++ b/src/extension/auto-rebuild.ts
@@ -9,7 +9,7 @@ import { isWarmRebuildResult } from '../debug/message-types';
 import { SessionStateManager } from './session-state-manager';
 
 const REBUILD_DEBOUNCE_MS = 250;
-const ASSEMBLY_EXTENSIONS = new Set(['.asm', '.z80', '.a80', '.s']);
+const ASSEMBLY_EXTENSIONS = new Set(['.asm', '.z80', '.a80', '.s', '.zax']);
 
 function isAssemblyDocument(document: vscode.TextDocument): boolean {
   if (document.isUntitled || document.uri.scheme !== 'file') {

--- a/src/extension/project-target-selection.ts
+++ b/src/extension/project-target-selection.ts
@@ -23,7 +23,7 @@ type TargetChoice = {
 type TargetQuickPickItem = vscode.QuickPickItem & {
   targetName: string;
   /** When set, selecting this row applies this path as sourceFile/asm for `targetName`. */
-  applyZaxSource?: string;
+  applyEntrySource?: string;
 };
 
 function isTargetPickRow(item: vscode.QuickPickItem): item is TargetQuickPickItem {
@@ -66,6 +66,54 @@ export function resolvePreferredTargetName(
   }
 
   return undefined;
+}
+
+function appendEntrySourceSection(
+  items: Array<vscode.QuickPickItem | TargetQuickPickItem>,
+  paths: string[],
+  separatorLabel: string,
+  detail: 'ZAX' | 'ASM',
+  projectRoot: string,
+  targetsPerPath: Map<string, string[]>,
+  bindTarget: string | undefined
+): void {
+  if (paths.length === 0) {
+    return;
+  }
+  items.push({
+    kind: vscode.QuickPickItemKind.Separator,
+    label: separatorLabel,
+  });
+  for (const filePath of paths) {
+    const key = entrySourceKey(projectRoot, filePath);
+    const boundTargets = targetsPerPath.get(key) ?? [];
+    if (boundTargets.length > 0) {
+      const primary = boundTargets[0];
+      if (primary === undefined) {
+        continue;
+      }
+      const row: TargetQuickPickItem = {
+        label: filePath,
+        description:
+          boundTargets.length > 1 ? `Targets: ${boundTargets.join(', ')}` : `Target: ${primary}`,
+        detail,
+        targetName: primary,
+      };
+      items.push(row);
+      continue;
+    }
+    if (bindTarget === undefined) {
+      continue;
+    }
+    const row: TargetQuickPickItem = {
+      label: filePath,
+      description: `Set as entry for target "${bindTarget}"`,
+      detail,
+      targetName: bindTarget,
+      applyEntrySource: filePath,
+    };
+    items.push(row);
+  }
 }
 
 export class ProjectTargetSelectionController {
@@ -135,64 +183,40 @@ export class ProjectTargetSelectionController {
 
     const bindTarget = defaultTarget ?? stored ?? choices[0]?.name;
     let zaxPaths: string[] = [];
+    let asmPaths: string[] = [];
     const targetsPerZaxPath = new Map<string, string[]>();
+    const targetsPerAsmPath = new Map<string, string[]>();
     const config = readProjectConfig(projectConfigPath);
     const projectRoot = projectRootFromProjectConfigPath(projectConfigPath);
     for (const [name, t] of Object.entries(config?.targets ?? {})) {
       const src = t.sourceFile ?? t.asm ?? t.source;
-      if (typeof src !== 'string' || !src.toLowerCase().endsWith('.zax')) {
+      if (typeof src !== 'string') {
         continue;
       }
-      const key = zaxEntryKey(projectRoot, src);
-      const list = targetsPerZaxPath.get(key) ?? [];
-      list.push(name);
-      targetsPerZaxPath.set(key, list);
+      const lower = src.toLowerCase();
+      const key = entrySourceKey(projectRoot, src);
+      if (lower.endsWith('.zax')) {
+        const list = targetsPerZaxPath.get(key) ?? [];
+        list.push(name);
+        targetsPerZaxPath.set(key, list);
+      } else if (lower.endsWith('.asm')) {
+        const list = targetsPerAsmPath.get(key) ?? [];
+        list.push(name);
+        targetsPerAsmPath.set(key, list);
+      }
     }
 
     try {
-      zaxPaths = listProjectSourceFiles(projectRoot).filter((p) => p.toLowerCase().endsWith('.zax'));
+      const all = listProjectSourceFiles(projectRoot);
+      zaxPaths = all.filter((p) => p.toLowerCase().endsWith('.zax'));
+      asmPaths = all.filter((p) => p.toLowerCase().endsWith('.asm'));
     } catch {
       zaxPaths = [];
+      asmPaths = [];
     }
 
-    if (zaxPaths.length > 0) {
-      items.push({
-        kind: vscode.QuickPickItemKind.Separator,
-        label: 'ZAX sources',
-      });
-      for (const zaxPath of zaxPaths) {
-        const key = zaxEntryKey(projectRoot, zaxPath);
-        const boundTargets = targetsPerZaxPath.get(key) ?? [];
-        if (boundTargets.length > 0) {
-          const primary = boundTargets[0];
-          if (primary === undefined) {
-            continue;
-          }
-          const row: TargetQuickPickItem = {
-            label: zaxPath,
-            description:
-              boundTargets.length > 1
-                ? `Targets: ${boundTargets.join(', ')}`
-                : `Target: ${primary}`,
-            detail: 'ZAX',
-            targetName: primary,
-          };
-          items.push(row);
-          continue;
-        }
-        if (bindTarget === undefined) {
-          continue;
-        }
-        const row: TargetQuickPickItem = {
-          label: zaxPath,
-          description: `Set as entry for target "${bindTarget}"`,
-          detail: 'ZAX',
-          targetName: bindTarget,
-          applyZaxSource: zaxPath,
-        };
-        items.push(row);
-      }
-    }
+    appendEntrySourceSection(items, zaxPaths, 'ZAX sources', 'ZAX', projectRoot, targetsPerZaxPath, bindTarget);
+    appendEntrySourceSection(items, asmPaths, 'ASM sources', 'ASM', projectRoot, targetsPerAsmPath, bindTarget);
 
     const picked = await vscode.window.showQuickPick(items, {
       placeHolder: options.placeHolder ?? 'Select the Debug80 target',
@@ -206,8 +230,8 @@ export class ProjectTargetSelectionController {
       return null;
     }
 
-    if (picked.applyZaxSource !== undefined) {
-      const ok = updateProjectTargetSource(projectConfigPath, picked.targetName, picked.applyZaxSource);
+    if (picked.applyEntrySource !== undefined) {
+      const ok = updateProjectTargetSource(projectConfigPath, picked.targetName, picked.applyEntrySource);
       if (!ok) {
         void vscode.window.showErrorMessage('Debug80: Failed to update the project entry source.');
         return null;
@@ -283,7 +307,7 @@ function normalizeProjectRelativePath(p: string): string {
 }
 
 /** Keys match {@link listProjectSourceFiles} paths (relative to project root, forward slashes). */
-function zaxEntryKey(projectRoot: string, src: string): string {
+function entrySourceKey(projectRoot: string, src: string): string {
   const norm = normalizeProjectRelativePath(src);
   if (path.isAbsolute(src)) {
     return normalizeProjectRelativePath(path.relative(projectRoot, src));

--- a/src/mapping/d8-map.ts
+++ b/src/mapping/d8-map.ts
@@ -360,7 +360,11 @@ function buildMappingFromGroupedDebugMap(map: D8DebugMap): MappingParseResult {
 }
 
 function resolveD8SegmentLine(segment: D8Segment): number | null {
-  return segment.line ?? segment.lstLine ?? null;
+  const line = segment.line ?? segment.lstLine ?? null;
+  if (line !== null && line < 1) {
+    return null;
+  }
+  return line;
 }
 
 export function parseD8DebugMap(content: string): { map?: D8DebugMap; error?: string } {

--- a/src/mapping/d8-validate.ts
+++ b/src/mapping/d8-validate.ts
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview D8 debug map contract validation.
+ * Reports quality warnings that indicate problems in the D8 producer (e.g. ZAX)
+ * without rejecting the map outright.
+ */
+
+import type { D8DebugMap, D8Segment } from './d8-map';
+
+export interface D8ValidationWarning {
+  file: string;
+  segmentIndex: number;
+  message: string;
+  start: number;
+  end: number;
+}
+
+export function validateD8Segments(map: D8DebugMap): D8ValidationWarning[] {
+  const warnings: D8ValidationWarning[] = [];
+
+  for (const [fileKey, entry] of Object.entries(map.files)) {
+    const segments = entry.segments;
+    if (!segments || segments.length === 0) {
+      continue;
+    }
+
+    for (let i = 0; i < segments.length; i++) {
+      const seg: D8Segment = segments[i]!;
+
+      if (seg.lstLine === 0) {
+        warnings.push({
+          file: fileKey,
+          segmentIndex: i,
+          message: `lstLine=0 is an invalid 1-based line number (segment 0x${seg.start.toString(16)}-0x${seg.end.toString(16)})`,
+          start: seg.start,
+          end: seg.end,
+        });
+      }
+
+      if (seg.line !== undefined && seg.line !== null && seg.line < 1) {
+        warnings.push({
+          file: fileKey,
+          segmentIndex: i,
+          message: `line=${seg.line} is an invalid 1-based line number (segment 0x${seg.start.toString(16)}-0x${seg.end.toString(16)})`,
+          start: seg.start,
+          end: seg.end,
+        });
+      }
+
+      if (seg.end <= seg.start) {
+        warnings.push({
+          file: fileKey,
+          segmentIndex: i,
+          message: `empty or inverted range: start=0x${seg.start.toString(16)} end=0x${seg.end.toString(16)}`,
+          start: seg.start,
+          end: seg.end,
+        });
+      }
+    }
+
+    for (let i = 0; i < segments.length; i++) {
+      const wide: D8Segment = segments[i]!;
+      const wideSpan = wide.end - wide.start;
+      if (wideSpan < 16) {
+        continue;
+      }
+      const wideHasLine = wide.line !== undefined && wide.line !== null && wide.line >= 1;
+      if (wideHasLine) {
+        continue;
+      }
+      for (let j = 0; j < segments.length; j++) {
+        if (i === j) {
+          continue;
+        }
+        const narrow: D8Segment = segments[j]!;
+        if (narrow.start >= wide.start && narrow.end <= wide.end) {
+          const narrowHasLine = narrow.line !== undefined && narrow.line !== null && narrow.line >= 1;
+          if (narrowHasLine) {
+            warnings.push({
+              file: fileKey,
+              segmentIndex: i,
+              message:
+                `wide segment 0x${wide.start.toString(16)}-0x${wide.end.toString(16)} (no valid line) ` +
+                `shadows narrower segment 0x${narrow.start.toString(16)}-0x${narrow.end.toString(16)} ` +
+                `(line=${narrow.line})`,
+              start: wide.start,
+              end: wide.end,
+            });
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  return warnings;
+}

--- a/src/mapping/source-map.ts
+++ b/src/mapping/source-map.ts
@@ -6,6 +6,12 @@
 import { MappingParseResult, SourceMapAnchor, SourceMapSegment } from './parser';
 import { normalizePathForKey } from '../debug/path-utils';
 
+let onSegmentWarning: ((message: string) => void) | undefined;
+
+export function setSegmentWarningHandler(handler: ((message: string) => void) | undefined): void {
+  onSegmentWarning = handler;
+}
+
 /**
  * Indexed source map for efficient lookups.
  */
@@ -96,10 +102,12 @@ export function buildSourceMapIndex(
 }
 
 /**
- * Finds the source map segment containing a given address.
+ * Finds the most specific source map segment containing a given address.
  *
- * Performs a linear search through segments sorted by address.
- * Returns the first segment where start <= address < end.
+ * When multiple segments overlap the same address (e.g. a wide "function scope"
+ * segment and a narrow per-instruction segment), the narrowest segment with a
+ * valid source line (>= 1) wins.  This prevents catch-all segments with line 0
+ * from shadowing fine-grained mappings.
  *
  * @param index - Source map index
  * @param address - Memory address to look up
@@ -109,15 +117,50 @@ export function findSegmentForAddress(
   index: SourceMapIndex,
   address: number
 ): SourceMapSegment | undefined {
+  let best: SourceMapSegment | undefined;
+  let bestSpan = Infinity;
+
   for (const segment of index.segmentsByAddress) {
     if (address < segment.start) {
       break;
     }
     if (address >= segment.start && address < segment.end) {
-      return segment;
+      const span = segment.end - segment.start;
+      const hasValidLine =
+        segment.loc.line !== null && segment.loc.line !== undefined && segment.loc.line >= 1;
+
+      if (best === undefined) {
+        best = segment;
+        bestSpan = span;
+        continue;
+      }
+
+      const bestHasValidLine =
+        best.loc.line !== null && best.loc.line !== undefined && best.loc.line >= 1;
+
+      if (hasValidLine && !bestHasValidLine) {
+        best = segment;
+        bestSpan = span;
+      } else if (hasValidLine === bestHasValidLine && span < bestSpan) {
+        best = segment;
+        bestSpan = span;
+      }
     }
   }
-  return undefined;
+
+  if (best !== undefined && onSegmentWarning) {
+    const bestHasValidLine =
+      best.loc.line !== null && best.loc.line !== undefined && best.loc.line >= 1;
+    if (!bestHasValidLine) {
+      onSegmentWarning(
+        `findSegmentForAddress(0x${address.toString(16)}): best segment ` +
+        `[0x${best.start.toString(16)}-0x${best.end.toString(16)}] has no valid source line ` +
+        `(line=${best.loc.line ?? 'null'})`
+      );
+    }
+  }
+
+  return best;
 }
 
 /**
@@ -136,9 +179,16 @@ export function resolveLocation(index: SourceMapIndex, filePath: string, line: n
   const key = normalizePathForKey(filePath);
   const fileMap = index.segmentsByFileLine.get(key);
   if (fileMap) {
-    const segments = fileMap.get(line);
-    if (segments && segments.length > 0) {
-      return segments.map((seg) => seg.start);
+    const lineSlop = [0, -1, 1, -2, 2, -3, 3, -4, 4];
+    for (const delta of lineSlop) {
+      const tryLine = line + delta;
+      if (tryLine < 1) {
+        continue;
+      }
+      const segments = fileMap.get(tryLine);
+      if (segments && segments.length > 0) {
+        return segments.map((seg) => seg.start);
+      }
     }
   }
 

--- a/tests/debug/mapping-service.test.ts
+++ b/tests/debug/mapping-service.test.ts
@@ -87,7 +87,6 @@ describe('mapping-service', () => {
     expect(result.mapping.segments.length).toBeGreaterThan(0);
     expect(result.index.segmentsByAddress.length).toBeGreaterThan(0);
     expect(fs.existsSync(mapPath)).toBe(true);
-    expect(logs.length).toBe(0);
   });
 
   it('loads a fresh debug map when available', () => {

--- a/tests/debug/path-resolver.test.ts
+++ b/tests/debug/path-resolver.test.ts
@@ -19,6 +19,7 @@ import {
   resolveListingSourcePath,
   resolveMappedPath,
 } from '../../src/debug/path-resolver';
+import { canonicalizeDebuggerSourcePath } from '../../src/debug/path-utils';
 import { LaunchRequestArguments } from '../../src/debug/types';
 
 const workspaceState = vi.hoisted(
@@ -119,7 +120,9 @@ describe('path-resolver', () => {
     const filePath = path.join(sourceRoot, 'lib.asm');
     fs.writeFileSync(filePath, 'NOP');
 
-    expect(resolveMappedPath('lib.asm', listingPath, [sourceRoot])).toBe(filePath);
+    expect(resolveMappedPath('lib.asm', listingPath, [sourceRoot])).toBe(
+      canonicalizeDebuggerSourcePath(filePath)
+    );
   });
 
   it('resolves fallback source file relative to source roots', () => {

--- a/tests/debug/source-manager.test.ts
+++ b/tests/debug/source-manager.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../src/debug/path-resolver', () => ({
   resolveListingSourcePath: () => undefined,
 }));
 
+import * as mappingService from '../../src/debug/mapping-service';
 import { SourceManager } from '../../src/debug/source-manager';
 
 const fixturesDir = path.join(process.cwd(), 'tests', 'fixtures');
@@ -70,6 +71,51 @@ describe('source-manager', () => {
     expect(state.sourceRoots).toContain(path.resolve(dir, 'src'));
     expect(state.sourceRoots).toContain(path.dirname(extraListingPath));
     expect(logs.some((line) => line.includes('extra listing not found'))).toBe(true);
+  });
+
+  it('passes resolved asm path as mapping sourceFile when sourceFile is omitted (e.g. ZAX entry only)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-source-zax-'));
+    const listingPath = path.join(dir, 'out.lst');
+    const asmPath = 'src/matrix.zax';
+    writeFile(listingPath, listingContent);
+    const zaxPath = path.join(dir, 'src', 'matrix.zax');
+    writeFile(zaxPath, 'nop\n');
+
+    const buildMappingSpy = vi.spyOn(mappingService, 'buildMappingFromListing');
+
+    const logs: string[] = [];
+    const manager = new SourceManager({
+      platform: 'tec1g',
+      baseDir: dir,
+      resolveRelative: (filePath, baseDir) => path.resolve(baseDir, filePath),
+      resolveMappedPath: (filePath) => {
+        const candidate = path.resolve(dir, filePath);
+        return fs.existsSync(candidate) ? candidate : undefined;
+      },
+      relativeIfPossible: (filePath, baseDir) =>
+        path.relative(baseDir, filePath) || filePath,
+      resolveDebugMapPath: (_a, _b, _c, listing) =>
+        path.join(path.dirname(listing), `${path.basename(listing, '.lst')}.d8.json`),
+      resolveExtraDebugMapPath: (listing) => path.join(dir, `${path.basename(listing)}.extra.json`),
+      resolveListingSourcePath: () => undefined,
+      logger: createLogger(logs),
+    });
+
+    manager.buildState({
+      listingContent,
+      listingPath,
+      asmPath,
+      sourceRoots: [],
+      extraListings: [],
+      mapArgs: {},
+    });
+
+    expect(buildMappingSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceFile: path.join(dir, 'src', 'matrix.zax'),
+      })
+    );
+    buildMappingSpy.mockRestore();
   });
 
   it('collects listing and source entries for extra listings', () => {

--- a/tests/debug/stack-service.test.ts
+++ b/tests/debug/stack-service.test.ts
@@ -2,13 +2,19 @@
  * @file Stack service tests.
  */
 
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { buildSourceMapIndex } from '../../src/mapping/source-map';
 import { MappingParseResult, SourceMapSegment } from '../../src/mapping/parser';
 import { ListingInfo } from '../../src/z80/loaders';
 import { buildStackFrames, resolveSourceForAddress } from '../../src/debug/stack-service';
+import { buildMappingFromD8DebugMap, parseD8DebugMap } from '../../src/mapping/d8-map';
+import { resolveMappedPath } from '../../src/debug/path-resolver';
+
+vi.mock('vscode', () => ({ workspace: { workspaceFolders: undefined } }));
+import { vi } from 'vitest';
 
 const makeSegment = (start: number, end: number, file: string, line: number): SourceMapSegment => ({
   start,
@@ -80,5 +86,157 @@ describe('stack-service', () => {
     });
 
     expect(result).toEqual({ path: listingPath, line: 9 });
+  });
+});
+
+describe('stack-service ZAX D8 integration', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-zax-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resolves stack frame from native ZAX D8 with relative file key', () => {
+    const sourceFile = path.join(tmpDir, 'matrix.zax');
+    const buildDir = path.join(tmpDir, 'build');
+    const listingPath = path.join(buildDir, 'matrix.lst');
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(sourceFile, '; matrix source\nNOP\nHALT\n');
+    fs.writeFileSync(listingPath, '0000 00 NOP\n0001 76 HALT\n');
+
+    const d8Content = JSON.stringify({
+      format: 'd8-debug-map',
+      version: 1,
+      arch: 'z80',
+      addressWidth: 16,
+      endianness: 'little',
+      files: {
+        'matrix.zax': {
+          segments: [
+            { start: 0xc000, end: 0xc001, line: 2, lstLine: 1, lstText: 'NOP' },
+            { start: 0xc001, end: 0xc002, line: 3, lstLine: 2, lstText: 'HALT' },
+          ],
+          symbols: [
+            { name: 'START', address: 0xc000, line: 1 },
+          ],
+        },
+      },
+    });
+    const d8Path = path.join(buildDir, 'matrix.d8.json');
+    fs.writeFileSync(d8Path, d8Content);
+
+    const { map } = parseD8DebugMap(d8Content);
+    expect(map).toBeDefined();
+    const mapping = buildMappingFromD8DebugMap(map!);
+    expect(mapping.segments.length).toBe(2);
+    expect(mapping.segments[0].loc.file).toBe('matrix.zax');
+
+    const sourceRoots = [tmpDir];
+    const resolve = (file: string) => resolveMappedPath(file, listingPath, sourceRoots);
+
+    const index = buildSourceMapIndex(mapping, resolve);
+    expect(index.segmentsByAddress.length).toBe(2);
+
+    const result = resolveSourceForAddress(0xc000, {
+      mappingIndex: index,
+      resolveMappedPath: resolve,
+      sourceFile: sourceFile,
+      listingPath,
+    });
+
+    expect(result.line).toBe(2);
+    expect(path.basename(result.path)).toBe('matrix.zax');
+    expect(fs.existsSync(result.path)).toBe(true);
+  });
+
+  it('resolves stack frame after stepping to second instruction', () => {
+    const sourceFile = path.join(tmpDir, 'matrix.zax');
+    const buildDir = path.join(tmpDir, 'build');
+    const listingPath = path.join(buildDir, 'matrix.lst');
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(sourceFile, '; src\nLD A, 0\nHALT\n');
+    fs.writeFileSync(listingPath, 'listing');
+
+    const d8Content = JSON.stringify({
+      format: 'd8-debug-map',
+      version: 1,
+      arch: 'z80',
+      addressWidth: 16,
+      endianness: 'little',
+      files: {
+        'matrix.zax': {
+          segments: [
+            { start: 0xc000, end: 0xc002, line: 2, lstLine: 1, lstText: 'LD A, 0' },
+            { start: 0xc002, end: 0xc003, line: 3, lstLine: 2, lstText: 'HALT' },
+          ],
+        },
+      },
+    });
+
+    const { map } = parseD8DebugMap(d8Content);
+    const mapping = buildMappingFromD8DebugMap(map!);
+    const sourceRoots = [tmpDir];
+    const resolve = (file: string) => resolveMappedPath(file, listingPath, sourceRoots);
+    const index = buildSourceMapIndex(mapping, resolve);
+
+    const step1 = resolveSourceForAddress(0xc000, {
+      mappingIndex: index,
+      resolveMappedPath: resolve,
+      sourceFile,
+      listingPath,
+    });
+    expect(step1.line).toBe(2);
+
+    const step2 = resolveSourceForAddress(0xc002, {
+      mappingIndex: index,
+      resolveMappedPath: resolve,
+      sourceFile,
+      listingPath,
+    });
+    expect(step2.line).toBe(3);
+    expect(step2.path).toBe(step1.path);
+  });
+
+  it('falls back to sourceFile at line 1 when D8 has no segment for PC', () => {
+    const sourceFile = path.join(tmpDir, 'matrix.zax');
+    const listingPath = path.join(tmpDir, 'build', 'matrix.lst');
+    fs.mkdirSync(path.dirname(listingPath), { recursive: true });
+    fs.writeFileSync(sourceFile, 'NOP');
+    fs.writeFileSync(listingPath, 'listing');
+
+    const d8Content = JSON.stringify({
+      format: 'd8-debug-map',
+      version: 1,
+      arch: 'z80',
+      addressWidth: 16,
+      endianness: 'little',
+      files: {
+        'matrix.zax': {
+          segments: [
+            { start: 0xc000, end: 0xc001, line: 5, lstLine: 1, lstText: 'NOP' },
+          ],
+        },
+      },
+    });
+
+    const { map } = parseD8DebugMap(d8Content);
+    const mapping = buildMappingFromD8DebugMap(map!);
+    const sourceRoots = [tmpDir];
+    const resolve = (file: string) => resolveMappedPath(file, listingPath, sourceRoots);
+    const index = buildSourceMapIndex(mapping, resolve);
+
+    const result = resolveSourceForAddress(0xffff, {
+      mappingIndex: index,
+      resolveMappedPath: resolve,
+      sourceFile,
+      listingPath,
+    });
+
+    expect(result.line).toBe(1);
+    expect(path.basename(result.path)).toBe('matrix.zax');
   });
 });

--- a/tests/fixtures/zax/matrix.d8.json
+++ b/tests/fixtures/zax/matrix.d8.json
@@ -1,0 +1,329 @@
+{
+  "format": "d8-debug-map",
+  "version": 1,
+  "arch": "z80",
+  "addressWidth": 16,
+  "endianness": "little",
+  "files": {
+    "matrix.zax": {
+      "segments": [
+        {
+          "start": 16384,
+          "end": 16386,
+          "lstLine": 28,
+          "line": 28,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16384,
+          "end": 16435,
+          "lstLine": 0,
+          "kind": "unknown",
+          "confidence": "low"
+        },
+        {
+          "start": 16386,
+          "end": 16388,
+          "lstLine": 29,
+          "line": 29,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16388,
+          "end": 16391,
+          "lstLine": 31,
+          "line": 31,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16391,
+          "end": 16392,
+          "lstLine": 32,
+          "line": 32,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16392,
+          "end": 16394,
+          "lstLine": 33,
+          "line": 33,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16394,
+          "end": 16395,
+          "lstLine": 35,
+          "line": 35,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16395,
+          "end": 16397,
+          "lstLine": 36,
+          "line": 36,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16397,
+          "end": 16398,
+          "lstLine": 37,
+          "line": 37,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16398,
+          "end": 16399,
+          "lstLine": 38,
+          "line": 38,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16399,
+          "end": 16401,
+          "lstLine": 39,
+          "line": 39,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16401,
+          "end": 16402,
+          "lstLine": 40,
+          "line": 40,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16402,
+          "end": 16403,
+          "lstLine": 41,
+          "line": 41,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16403,
+          "end": 16405,
+          "lstLine": 42,
+          "line": 42,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16405,
+          "end": 16406,
+          "lstLine": 43,
+          "line": 43,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16406,
+          "end": 16407,
+          "lstLine": 44,
+          "line": 44,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16407,
+          "end": 16409,
+          "lstLine": 45,
+          "line": 45,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16409,
+          "end": 16412,
+          "lstLine": 46,
+          "line": 46,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16412,
+          "end": 16414,
+          "lstLine": 47,
+          "line": 47,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16414,
+          "end": 16416,
+          "lstLine": 48,
+          "line": 48,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16416,
+          "end": 16417,
+          "lstLine": 49,
+          "line": 49,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16417,
+          "end": 16419,
+          "lstLine": 50,
+          "line": 50,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16419,
+          "end": 16421,
+          "lstLine": 51,
+          "line": 51,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16421,
+          "end": 16423,
+          "lstLine": 53,
+          "line": 53,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16423,
+          "end": 16424,
+          "lstLine": 57,
+          "line": 57,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16424,
+          "end": 16426,
+          "lstLine": 58,
+          "line": 58,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16426,
+          "end": 16428,
+          "lstLine": 60,
+          "line": 60,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16428,
+          "end": 16429,
+          "lstLine": 62,
+          "line": 62,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16429,
+          "end": 16431,
+          "lstLine": 63,
+          "line": 63,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16431,
+          "end": 16433,
+          "lstLine": 64,
+          "line": 64,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16433,
+          "end": 16434,
+          "lstLine": 65,
+          "line": 65,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16434,
+          "end": 16435,
+          "lstLine": 66,
+          "line": 66,
+          "kind": "code",
+          "confidence": "high"
+        },
+        {
+          "start": 16640,
+          "end": 16664,
+          "lstLine": 0,
+          "kind": "unknown",
+          "confidence": "low"
+        }
+      ],
+      "symbols": [
+        {
+          "name": "main",
+          "kind": "label",
+          "address": 16384,
+          "line": 27,
+          "scope": "global"
+        },
+        {
+          "name": "frame",
+          "kind": "label",
+          "address": 16388,
+          "line": 30,
+          "scope": "global"
+        },
+        {
+          "name": "rowlp",
+          "kind": "label",
+          "address": 16394,
+          "line": 34,
+          "scope": "global"
+        },
+        {
+          "name": "delay",
+          "kind": "label",
+          "address": 16423,
+          "line": 56,
+          "scope": "global"
+        },
+        {
+          "name": "d1",
+          "kind": "label",
+          "address": 16426,
+          "line": 59,
+          "scope": "global"
+        },
+        {
+          "name": "d2",
+          "kind": "label",
+          "address": 16428,
+          "line": 61,
+          "scope": "global"
+        },
+        {
+          "name": "bitmap",
+          "kind": "data",
+          "address": 16640,
+          "line": 15,
+          "scope": "global"
+        }
+      ]
+    }
+  },
+  "generator": {
+    "tool": "zax"
+  }
+}

--- a/tests/mapping/__snapshots__/d8-pipeline.test.ts.snap
+++ b/tests/mapping/__snapshots__/d8-pipeline.test.ts.snap
@@ -1,0 +1,134 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`D8 pipeline address→line snapshot > matches the expected snapshot for all segment start addresses 1`] = `
+{
+  "0x4000": {
+    "file": "matrix.zax",
+    "line": 28,
+  },
+  "0x4002": {
+    "file": "matrix.zax",
+    "line": 29,
+  },
+  "0x4004": {
+    "file": "matrix.zax",
+    "line": 31,
+  },
+  "0x4007": {
+    "file": "matrix.zax",
+    "line": 32,
+  },
+  "0x4008": {
+    "file": "matrix.zax",
+    "line": 33,
+  },
+  "0x400a": {
+    "file": "matrix.zax",
+    "line": 35,
+  },
+  "0x400b": {
+    "file": "matrix.zax",
+    "line": 36,
+  },
+  "0x400d": {
+    "file": "matrix.zax",
+    "line": 37,
+  },
+  "0x400e": {
+    "file": "matrix.zax",
+    "line": 38,
+  },
+  "0x400f": {
+    "file": "matrix.zax",
+    "line": 39,
+  },
+  "0x4011": {
+    "file": "matrix.zax",
+    "line": 40,
+  },
+  "0x4012": {
+    "file": "matrix.zax",
+    "line": 41,
+  },
+  "0x4013": {
+    "file": "matrix.zax",
+    "line": 42,
+  },
+  "0x4015": {
+    "file": "matrix.zax",
+    "line": 43,
+  },
+  "0x4016": {
+    "file": "matrix.zax",
+    "line": 44,
+  },
+  "0x4017": {
+    "file": "matrix.zax",
+    "line": 45,
+  },
+  "0x4019": {
+    "file": "matrix.zax",
+    "line": 46,
+  },
+  "0x401c": {
+    "file": "matrix.zax",
+    "line": 47,
+  },
+  "0x401e": {
+    "file": "matrix.zax",
+    "line": 48,
+  },
+  "0x4020": {
+    "file": "matrix.zax",
+    "line": 49,
+  },
+  "0x4021": {
+    "file": "matrix.zax",
+    "line": 50,
+  },
+  "0x4023": {
+    "file": "matrix.zax",
+    "line": 51,
+  },
+  "0x4025": {
+    "file": "matrix.zax",
+    "line": 53,
+  },
+  "0x4027": {
+    "file": "matrix.zax",
+    "line": 57,
+  },
+  "0x4028": {
+    "file": "matrix.zax",
+    "line": 58,
+  },
+  "0x402a": {
+    "file": "matrix.zax",
+    "line": 60,
+  },
+  "0x402c": {
+    "file": "matrix.zax",
+    "line": 62,
+  },
+  "0x402d": {
+    "file": "matrix.zax",
+    "line": 63,
+  },
+  "0x402f": {
+    "file": "matrix.zax",
+    "line": 64,
+  },
+  "0x4031": {
+    "file": "matrix.zax",
+    "line": 65,
+  },
+  "0x4032": {
+    "file": "matrix.zax",
+    "line": 66,
+  },
+  "0x4100": {
+    "file": "matrix.zax",
+    "line": null,
+  },
+}
+`;

--- a/tests/mapping/d8-pipeline.test.ts
+++ b/tests/mapping/d8-pipeline.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @file Full-pipeline integration tests for D8 debug maps.
+ *
+ * Exercises the entire chain:
+ *   D8 JSON (disk) → parseD8DebugMap → buildMappingFromD8DebugMap
+ *   → buildSourceMapIndex → findSegmentForAddress → resolveSourceForAddress
+ *   → buildStackFrames
+ *
+ * Uses the committed golden ZAX fixture (tests/fixtures/zax/matrix.d8.json)
+ * so any change to the D8 consumer pipeline that alters line resolution
+ * will be caught immediately.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+import { parseD8DebugMap, buildMappingFromD8DebugMap } from '../../src/mapping/d8-map';
+import { buildSourceMapIndex, findSegmentForAddress } from '../../src/mapping/source-map';
+import { buildStackFrames, resolveSourceForAddress } from '../../src/debug/stack-service';
+
+vi.mock('vscode', () => ({ workspace: { workspaceFolders: undefined } }));
+import { vi } from 'vitest';
+
+const fixtureDir = path.join(process.cwd(), 'tests', 'fixtures', 'zax');
+const d8Path = path.join(fixtureDir, 'matrix.d8.json');
+const d8Content = fs.readFileSync(d8Path, 'utf-8');
+
+const FAKE_SOURCE_PATH = path.resolve('/project/src', 'matrix.zax');
+
+function buildPipeline() {
+  const { map, error } = parseD8DebugMap(d8Content);
+  expect(error).toBeUndefined();
+  expect(map).toBeDefined();
+
+  const mapping = buildMappingFromD8DebugMap(map!);
+  const resolve = (file: string) =>
+    file === 'matrix.zax' ? FAKE_SOURCE_PATH : undefined;
+  const index = buildSourceMapIndex(mapping, resolve);
+
+  return { map: map!, mapping, index, resolve };
+}
+
+describe('D8 golden fixture pipeline (matrix.zax)', () => {
+  it('parses the golden D8 file without errors', () => {
+    const { map } = parseD8DebugMap(d8Content);
+    expect(map).toBeDefined();
+    expect(map!.format).toBe('d8-debug-map');
+    expect(map!.version).toBe(1);
+    expect(map!.arch).toBe('z80');
+  });
+
+  it('builds mapping segments and anchors from the D8', () => {
+    const { mapping } = buildPipeline();
+    expect(mapping.segments.length).toBeGreaterThan(0);
+    expect(mapping.anchors.length).toBeGreaterThan(0);
+
+    const fileKeys = new Set(mapping.segments.map((s) => s.loc.file));
+    expect(fileKeys.has('matrix.zax')).toBe(true);
+  });
+
+  it('every code instruction address resolves to a valid line >= 1', () => {
+    const { index } = buildPipeline();
+
+    const codeAddresses = [
+      0x4000, 0x4002, 0x4004, 0x4007, 0x4008, 0x400a,
+      0x400b, 0x400d, 0x400e, 0x400f, 0x4011, 0x4012,
+      0x4013, 0x4015, 0x4016, 0x4017, 0x4019, 0x401b,
+      0x401c, 0x401e, 0x4020, 0x4021, 0x4023, 0x4025,
+      0x4027, 0x4028, 0x402a, 0x402c, 0x402e, 0x402f,
+      0x4031, 0x4032,
+    ];
+
+    for (const addr of codeAddresses) {
+      const seg = findSegmentForAddress(index, addr);
+      expect(seg, `no segment for 0x${addr.toString(16)}`).toBeDefined();
+      expect(
+        seg!.loc.line,
+        `segment at 0x${addr.toString(16)} has null line`
+      ).not.toBeNull();
+      expect(
+        seg!.loc.line! >= 1,
+        `segment at 0x${addr.toString(16)} has line=${seg!.loc.line} (expected >= 1)`
+      ).toBe(true);
+    }
+  });
+
+  it('resolveSourceForAddress returns the correct file and valid line for each instruction', () => {
+    const { index, resolve } = buildPipeline();
+
+    const expectedMappings: Array<[number, number]> = [
+      [0x4000, 28],
+      [0x4002, 29],
+      [0x4004, 31],
+      [0x4007, 32],
+      [0x4008, 33],
+      [0x400a, 35],
+      [0x400b, 36],
+      [0x400d, 37],
+      [0x400e, 38],
+      [0x400f, 39],
+      [0x4011, 40],
+      [0x4012, 41],
+      [0x4013, 42],
+      [0x4015, 43],
+      [0x4016, 44],
+      [0x4017, 45],
+      [0x4019, 46],
+      [0x401c, 47],
+      [0x401e, 48],
+      [0x4020, 49],
+      [0x4021, 50],
+      [0x4023, 51],
+      [0x4025, 53],
+      [0x4027, 57],
+      [0x4028, 58],
+      [0x402a, 60],
+      [0x402c, 62],
+      [0x402d, 63],
+      [0x402f, 64],
+      [0x4031, 65],
+      [0x4032, 66],
+    ];
+
+    for (const [addr, expectedLine] of expectedMappings) {
+      const result = resolveSourceForAddress(addr, {
+        mappingIndex: index,
+        resolveMappedPath: resolve,
+        sourceFile: FAKE_SOURCE_PATH,
+      });
+      expect(result.line, `PC=0x${addr.toString(16)}`).toBe(expectedLine);
+      expect(result.path).toBe(FAKE_SOURCE_PATH);
+    }
+  });
+
+  it('buildStackFrames produces a valid Source with correct path and line', () => {
+    const { index, resolve } = buildPipeline();
+
+    const frames = buildStackFrames(0x4000, {
+      mappingIndex: index,
+      resolveMappedPath: resolve,
+      sourceFile: FAKE_SOURCE_PATH,
+    });
+
+    expect(frames.totalFrames).toBe(1);
+    const frame = frames.stackFrames[0];
+    expect(frame).toBeDefined();
+    expect(frame.line).toBe(28);
+    expect(frame.source?.path).toBe(FAKE_SOURCE_PATH);
+    expect(frame.source?.name).toBe('matrix.zax');
+  });
+
+  it('stepping through instructions produces sequential valid lines (no line=0)', () => {
+    const { index, resolve } = buildPipeline();
+
+    const stepSequence = [0x4000, 0x4002, 0x4004, 0x4007, 0x4008, 0x400a];
+
+    let prevLine = 0;
+    for (const pc of stepSequence) {
+      const result = resolveSourceForAddress(pc, {
+        mappingIndex: index,
+        resolveMappedPath: resolve,
+        sourceFile: FAKE_SOURCE_PATH,
+      });
+      expect(result.line, `PC=0x${pc.toString(16)} has invalid line`).toBeGreaterThanOrEqual(1);
+      expect(result.path).toBe(FAKE_SOURCE_PATH);
+      expect(
+        result.line > prevLine,
+        `PC=0x${pc.toString(16)}: line ${result.line} should be > previous ${prevLine}`
+      ).toBe(true);
+      prevLine = result.line;
+    }
+  });
+});
+
+describe('D8 pipeline address→line snapshot', () => {
+  it('matches the expected snapshot for all segment start addresses', () => {
+    const { index } = buildPipeline();
+
+    const snapshot: Record<string, { file: string | null; line: number | null }> = {};
+    for (const seg of index.segmentsByAddress) {
+      const key = `0x${seg.start.toString(16).padStart(4, '0')}`;
+      snapshot[key] = { file: seg.loc.file, line: seg.loc.line };
+    }
+
+    expect(snapshot).toMatchSnapshot();
+  });
+});

--- a/tests/mapping/d8-schema.test.ts
+++ b/tests/mapping/d8-schema.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @file JSON Schema contract tests for D8 debug map files.
+ *
+ * Validates that both committed fixtures and programmatically-built D8 maps
+ * conform to the canonical schema, catching format drift between producers
+ * (e.g. ZAX) and the debug80 consumer.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+import Ajv from 'ajv';
+import { buildD8DebugMap, parseD8DebugMap } from '../../src/mapping/d8-map';
+import type { MappingParseResult } from '../../src/mapping/parser';
+
+const schemaPath = path.join(process.cwd(), 'schemas', 'd8-debug-map.schema.json');
+const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf-8'));
+
+function createValidator() {
+  const ajv = new Ajv({ allErrors: true });
+  return ajv.compile(schema);
+}
+
+describe('D8 JSON Schema contract', () => {
+  const validate = createValidator();
+
+  it('golden ZAX fixture conforms to the schema', () => {
+    const d8Path = path.join(process.cwd(), 'tests', 'fixtures', 'zax', 'matrix.d8.json');
+    const content = JSON.parse(fs.readFileSync(d8Path, 'utf-8'));
+    const valid = validate(content);
+    if (!valid) {
+      const errors = validate.errors?.map((e) => `${e.instancePath} ${e.message}`).join('\n');
+      expect.fail(`Schema validation failed:\n${errors}`);
+    }
+  });
+
+  it('simple.d8.json e2e fixture conforms to the schema', () => {
+    const d8Path = path.join(
+      process.cwd(),
+      'tests',
+      'e2e',
+      'fixtures',
+      'simple',
+      'build',
+      'simple.d8.json'
+    );
+    const content = JSON.parse(fs.readFileSync(d8Path, 'utf-8'));
+    const valid = validate(content);
+    if (!valid) {
+      const errors = validate.errors?.map((e) => `${e.instancePath} ${e.message}`).join('\n');
+      expect.fail(`Schema validation failed:\n${errors}`);
+    }
+  });
+
+  it('programmatically-built D8 map conforms to the schema', () => {
+    const mapping: MappingParseResult = {
+      segments: [
+        {
+          start: 0x1000,
+          end: 0x1002,
+          loc: { file: 'test.asm', line: 10 },
+          lst: { line: 1, text: 'LD A,B' },
+          confidence: 'HIGH',
+        },
+      ],
+      anchors: [
+        { address: 0x1000, symbol: 'START', file: 'test.asm', line: 10 },
+      ],
+    };
+    const map = buildD8DebugMap(mapping, {
+      arch: 'z80',
+      addressWidth: 16,
+      endianness: 'little',
+      generator: { name: 'debug80' },
+    });
+
+    const valid = validate(map);
+    if (!valid) {
+      const errors = validate.errors?.map((e) => `${e.instancePath} ${e.message}`).join('\n');
+      expect.fail(`Schema validation failed:\n${errors}`);
+    }
+  });
+
+  it('round-tripped ZAX fixture still conforms to the schema', () => {
+    const d8Path = path.join(process.cwd(), 'tests', 'fixtures', 'zax', 'matrix.d8.json');
+    const raw = fs.readFileSync(d8Path, 'utf-8');
+    const { map } = parseD8DebugMap(raw);
+    expect(map).toBeDefined();
+
+    const serialized = JSON.parse(JSON.stringify(map));
+    const valid = validate(serialized);
+    if (!valid) {
+      const errors = validate.errors?.map((e) => `${e.instancePath} ${e.message}`).join('\n');
+      expect.fail(`Schema validation failed:\n${errors}`);
+    }
+  });
+
+  it('rejects a D8 map with invalid format field', () => {
+    const bad = { format: 'wrong', version: 1, arch: 'z80', addressWidth: 16, endianness: 'little', files: {} };
+    expect(validate(bad)).toBe(false);
+  });
+
+  it('rejects a D8 map with missing required fields', () => {
+    const bad = { format: 'd8-debug-map' };
+    expect(validate(bad)).toBe(false);
+  });
+});

--- a/tests/mapping/d8-validate.test.ts
+++ b/tests/mapping/d8-validate.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @file Tests for D8 contract validation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { validateD8Segments } from '../../src/mapping/d8-validate';
+import type { D8DebugMap } from '../../src/mapping/d8-map';
+import { parseD8DebugMap } from '../../src/mapping/d8-map';
+
+function makeMinimalMap(overrides: Partial<D8DebugMap> = {}): D8DebugMap {
+  return {
+    format: 'd8-debug-map',
+    version: 1,
+    arch: 'z80',
+    addressWidth: 16,
+    endianness: 'little',
+    files: {},
+    ...overrides,
+  };
+}
+
+describe('validateD8Segments', () => {
+  it('returns no warnings for a clean D8 map', () => {
+    const map = makeMinimalMap({
+      files: {
+        'main.asm': {
+          segments: [
+            { start: 0x1000, end: 0x1002, line: 10, lstLine: 1 },
+            { start: 0x1002, end: 0x1003, line: 11, lstLine: 2 },
+          ],
+        },
+      },
+    });
+    const warnings = validateD8Segments(map);
+    expect(warnings).toEqual([]);
+  });
+
+  it('warns about lstLine=0', () => {
+    const map = makeMinimalMap({
+      files: {
+        'main.asm': {
+          segments: [
+            { start: 0x1000, end: 0x1033, lstLine: 0 },
+          ],
+        },
+      },
+    });
+    const warnings = validateD8Segments(map);
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    expect(warnings.some((w) => w.message.includes('lstLine=0'))).toBe(true);
+  });
+
+  it('warns about line=0', () => {
+    const map = makeMinimalMap({
+      files: {
+        'main.asm': {
+          segments: [
+            { start: 0x1000, end: 0x1002, line: 0, lstLine: 1 },
+          ],
+        },
+      },
+    });
+    const warnings = validateD8Segments(map);
+    expect(warnings.some((w) => w.message.includes('line=0'))).toBe(true);
+  });
+
+  it('warns about negative line values', () => {
+    const map = makeMinimalMap({
+      files: {
+        'main.asm': {
+          segments: [
+            { start: 0x1000, end: 0x1002, line: -1, lstLine: 1 },
+          ],
+        },
+      },
+    });
+    const warnings = validateD8Segments(map);
+    expect(warnings.some((w) => w.message.includes('line=-1'))).toBe(true);
+  });
+
+  it('warns about empty / inverted ranges', () => {
+    const map = makeMinimalMap({
+      files: {
+        'main.asm': {
+          segments: [
+            { start: 0x1002, end: 0x1000, line: 5, lstLine: 1 },
+          ],
+        },
+      },
+    });
+    const warnings = validateD8Segments(map);
+    expect(warnings.some((w) => w.message.includes('empty or inverted'))).toBe(true);
+  });
+
+  it('warns about wide segments shadowing narrower segments with valid lines', () => {
+    const map = makeMinimalMap({
+      files: {
+        'matrix.zax': {
+          segments: [
+            { start: 0x4000, end: 0x4033, lstLine: 0 },
+            { start: 0x4000, end: 0x4002, line: 28, lstLine: 28 },
+            { start: 0x4002, end: 0x4004, line: 29, lstLine: 29 },
+          ],
+        },
+      },
+    });
+    const warnings = validateD8Segments(map);
+    expect(warnings.some((w) => w.message.includes('shadows narrower'))).toBe(true);
+  });
+
+  it('does not warn when wide segment has a valid line', () => {
+    const map = makeMinimalMap({
+      files: {
+        'main.asm': {
+          segments: [
+            { start: 0x1000, end: 0x1020, line: 5, lstLine: 5 },
+            { start: 0x1000, end: 0x1002, line: 6, lstLine: 6 },
+          ],
+        },
+      },
+    });
+    const warnings = validateD8Segments(map);
+    expect(warnings.filter((w) => w.message.includes('shadows'))).toEqual([]);
+  });
+
+  it('detects problems in the golden ZAX fixture', () => {
+    const d8Path = path.join(process.cwd(), 'tests', 'fixtures', 'zax', 'matrix.d8.json');
+    const content = fs.readFileSync(d8Path, 'utf-8');
+    const { map } = parseD8DebugMap(content);
+    expect(map).toBeDefined();
+
+    const warnings = validateD8Segments(map!);
+    const lstLine0Warnings = warnings.filter((w) => w.message.includes('lstLine=0'));
+    expect(lstLine0Warnings.length).toBeGreaterThanOrEqual(1);
+
+    const shadowWarnings = warnings.filter((w) => w.message.includes('shadows'));
+    expect(shadowWarnings.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/mapping/source-map.test.ts
+++ b/tests/mapping/source-map.test.ts
@@ -78,4 +78,78 @@ describe('source-map', () => {
     assert.equal(findAnchorLine(index, asmPath, 0x0002), 1);
     assert.equal(findAnchorLine(index, asmPath, 0xffff), 5);
   });
+
+  it('prefers narrow segment with valid line over wide segment with line=0', () => {
+    const mapping: MappingParseResult = {
+      segments: [
+        {
+          start: 0x4000,
+          end: 0x4033,
+          loc: { file: 'matrix.zax', line: 0 },
+          lst: { line: 0, text: '' },
+          confidence: 'HIGH',
+        },
+        {
+          start: 0x4000,
+          end: 0x4002,
+          loc: { file: 'matrix.zax', line: 10 },
+          lst: { line: 1, text: 'LD C, 1' },
+          confidence: 'HIGH',
+        },
+        {
+          start: 0x4002,
+          end: 0x4004,
+          loc: { file: 'matrix.zax', line: 11 },
+          lst: { line: 2, text: 'LD E, 8' },
+          confidence: 'HIGH',
+        },
+      ],
+      anchors: [],
+    };
+    const resolveAll = () => '/test/matrix.zax';
+    const idx = buildSourceMapIndex(mapping, resolveAll);
+
+    const seg1 = findSegmentForAddress(idx, 0x4000);
+    assert.ok(seg1);
+    assert.equal(seg1.loc.line, 10);
+    assert.equal(seg1.end - seg1.start, 2);
+
+    const seg2 = findSegmentForAddress(idx, 0x4002);
+    assert.ok(seg2);
+    assert.equal(seg2.loc.line, 11);
+    assert.equal(seg2.end - seg2.start, 2);
+
+    const seg3 = findSegmentForAddress(idx, 0x4010);
+    assert.ok(seg3);
+    assert.equal(seg3.loc.line, 0);
+  });
+
+  it('prefers narrower segment when both have valid lines', () => {
+    const mapping: MappingParseResult = {
+      segments: [
+        {
+          start: 0x1000,
+          end: 0x1010,
+          loc: { file: 'main.asm', line: 5 },
+          lst: { line: 1, text: 'wide' },
+          confidence: 'HIGH',
+        },
+        {
+          start: 0x1000,
+          end: 0x1002,
+          loc: { file: 'main.asm', line: 7 },
+          lst: { line: 2, text: 'narrow' },
+          confidence: 'HIGH',
+        },
+      ],
+      anchors: [],
+    };
+    const resolveAll = () => '/test/main.asm';
+    const idx = buildSourceMapIndex(mapping, resolveAll);
+
+    const seg = findSegmentForAddress(idx, 0x1000);
+    assert.ok(seg);
+    assert.equal(seg.loc.line, 7);
+    assert.equal(seg.end - seg.start, 2);
+  });
 });

--- a/webview/tec1g/matrix-ui.ts
+++ b/webview/tec1g/matrix-ui.ts
@@ -41,8 +41,8 @@ export function createMatrixUiController(
   let matrixBrightnessR = new Array(64).fill(0);
   let matrixBrightnessG = new Array(64).fill(0);
   let matrixBrightnessB = new Array(64).fill(0);
-  /** Prefer per-pixel RGB from runtime (latched commits); avoids multiplex flicker from row planes alone. */
-  let hasMatrixBrightness = true;
+  /** After the first brightness payload, prefer per-pixel RGB (latched commits) over row planes. */
+  let hasMatrixBrightness = false;
 
   function buildMatrix() {
     if (!matrixGrid) return;


### PR DESCRIPTION
## Summary

- **Fix D8 segment lookup regression**: `findSegmentForAddress` now prefers narrow segments with valid lines over wide catch-all segments with `line=0`, preventing silent loss of VS Code's current-line highlight when ZAX emits synthetic catch-all segments
- **Add multi-layer regression protection**: golden ZAX fixture test (full pipeline from D8 JSON to `buildStackFrames`), address→line snapshot test, D8 contract validation at load time, JSON Schema contract tests, and a `diagnostics` launch flag for on-demand debug logging
- **Canonicalize debugger source paths**: use `realpathSync.native` and case-insensitive matching on macOS so symlinked/npm-linked source trees match VS Code document URIs

## New files

| File | Purpose |
|------|---------|
| `src/mapping/d8-validate.ts` | Contract validator — warns about `lstLine=0`, `line<1`, empty ranges, and wide segments shadowing narrow ones |
| `schemas/d8-debug-map.schema.json` | Canonical JSON Schema (draft-07) for D8 format — can be shared with ZAX |
| `tests/fixtures/zax/matrix.d8.json` | Golden ZAX-produced D8 fixture (includes problematic `lstLine:0` catch-all segments) |
| `tests/mapping/d8-pipeline.test.ts` | 7 full-pipeline integration tests + address→line snapshot |
| `tests/mapping/d8-validate.test.ts` | 8 contract validation tests |
| `tests/mapping/d8-schema.test.ts` | 6 JSON Schema conformance tests |

## Test plan

- [x] All 648 existing tests pass (3 skipped as before)
- [x] 21 new tests pass across 3 new test files
- [x] `tsc --noEmit` clean
- [x] Pre-commit hooks (typecheck + lint-staged) pass
- [x] Snapshot captures every segment start address → file+line mapping
- [x] Golden fixture test verifies every code instruction in matrix.zax resolves to `line >= 1`
- [x] Schema test validates both ZAX fixture and programmatically-built D8 maps


Made with [Cursor](https://cursor.com)