### PR TITLE
Unify idle startup shell with project workflow (#208)

### DIFF
--- a/src/extension/platform-view-idle-html.ts
+++ b/src/extension/platform-view-idle-html.ts
@@ -39,7 +39,7 @@ export function getPlatformViewIdleHtml(options: {
 </head>
 <body style="padding: 16px; font-family: var(--vscode-font-family); color: var(--vscode-foreground);">
   <p>Debug80</p>
-  <p style="opacity: 0.7;">Create a Debug80 root project to get started.</p>
+  <p style="opacity: 0.7;">Create or select a Debug80 project root to get started.</p>
   <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px;">
     <button id="createProject" style="padding: 6px 10px; font-size: 12px;">Create Project</button>
     <button id="selectProject" style="padding: 6px 10px; font-size: 12px;">Select Root</button>
@@ -87,13 +87,11 @@ export function getPlatformViewIdleHtml(options: {
 </head>
 <body style="padding: 16px; font-family: var(--vscode-font-family); color: var(--vscode-foreground);">
   <p>Debug80</p>
-  <p style="opacity: 0.7;">Configured root detected (${selectedLabel}). Select a root or target to start debugging, or use F5.</p>
+  <p style="opacity: 0.7;">Configured root detected (${selectedLabel}). Use Start Debugging or open the Home tab for project controls.</p>
   ${statusRows}
   <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px;">
     <button id="startDebug" style="padding: 6px 10px; font-size: 12px;">Start Debugging</button>
     <button id="selectProject" style="padding: 6px 10px; font-size: 12px;">Select Root</button>
-    <button id="selectTarget" style="padding: 6px 10px; font-size: 12px;">Select Target</button>
-    <button id="setEntrySource" style="padding: 6px 10px; font-size: 12px;">Set Entry Source</button>
   </div>
   ${selectionHint ? `<p style="opacity: 0.7;">${selectionHint}</p>` : ''}
   <script nonce="${nonce}">
@@ -109,8 +107,6 @@ export function getPlatformViewIdleHtml(options: {
       };
       bind('startDebug', 'startDebug');
       bind('selectProject', 'selectProject');
-      bind('selectTarget', 'selectTarget');
-      bind('setEntrySource', 'setEntrySource');
     }());
   </script>
 </body>

--- a/tests/extension/platform-view-idle-html.test.ts
+++ b/tests/extension/platform-view-idle-html.test.ts
@@ -17,7 +17,7 @@ describe('platform-view idle html', () => {
       multiRoot: false,
     });
 
-    expect(html).toContain('Create a Debug80 root project to get started.');
+    expect(html).toContain('Create or select a Debug80 project root to get started.');
     expect(html).toContain('Create Project');
     expect(html).toContain('Select Root');
     expect(html).toContain("script-src 'nonce-abc123'");
@@ -40,8 +40,9 @@ describe('platform-view idle html', () => {
     expect(html).toContain('Entry: src/main.asm');
     expect(html).toContain('Start Debugging');
     expect(html).toContain('Select Root');
-    expect(html).toContain('Select Target');
-    expect(html).toContain('Set Entry Source');
+    expect(html).not.toContain('Select Target');
+    expect(html).not.toContain('Set Entry Source');
+    expect(html).toContain('open the Home tab for project controls');
     expect(html).toContain("script-src 'nonce-xyz789'");
     expect(html).toContain('Select a workspace root with');
   });


### PR DESCRIPTION
Reduces the startup/idle surface to a thin shell that reuses the shared project-status model and core actions, while keeping Home as the primary workflow surface. This removes the duplicated startup-vs-Home project workflow split without taking on the in-panel selector redesign from #209.\n\nValidation:\n- npm exec vitest run tests/extension/platform-view-idle-html.test.ts tests/extension/platform-view-provider.test.ts\n- npm run lint -- --quiet src/extension/platform-view-idle-html.ts src/extension/platform-view-provider.ts tests/extension/platform-view-idle-html.test.ts\n- npm test