### PR TITLE
ux: replace QuickPick-first root/target flow with in-panel project selectors

### DIFF
--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -229,6 +229,7 @@ export function registerExtensionCommands({
           return undefined;
         }
 
+        workspaceSelection.rememberWorkspace(folder);
         platformViewProvider.refreshIdleView();
 
         const projectConfig = findProjectConfigPath(folder);

--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -13,6 +13,7 @@ import {
 } from './project-config';
 import {
   ProjectTargetSelectionController,
+  listProjectTargetChoices,
   resolvePreferredTargetName,
 } from './project-target-selection';
 import { scaffoldProject } from './project-scaffolding';
@@ -29,6 +30,22 @@ type CommandDependencies = {
   workspaceSelection: WorkspaceSelectionController;
   targetSelection: ProjectTargetSelectionController;
 };
+
+type SelectWorkspaceFolderArgs = {
+  rootPath?: string;
+};
+
+type SelectTargetArgs = {
+  rootPath?: string;
+  targetName?: string;
+};
+
+function findWorkspaceFolder(rootPath: string | undefined): vscode.WorkspaceFolder | undefined {
+  if (rootPath === undefined || rootPath.length === 0) {
+    return undefined;
+  }
+  return vscode.workspace.workspaceFolders?.find((folder) => folder.uri.fsPath === rootPath);
+}
 
 async function resolveFolderForProjectCreation(
   workspaceSelection: WorkspaceSelectionController
@@ -195,108 +212,147 @@ export function registerExtensionCommands({
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('debug80.selectWorkspaceFolder', async () => {
-      const folder = await workspaceSelection.selectWorkspaceFolder();
-      if (!folder) {
-        return undefined;
-      }
-
-      platformViewProvider.refreshIdleView();
-
-      const projectConfig = findProjectConfigPath(folder);
-      if (projectConfig === undefined) {
-        void vscode.window.showInformationMessage(
-          `Debug80: Selected root ${folder.name}. This root does not contain a Debug80 project config.`
-        );
-        return folder;
-      }
-
-      const activeSession = vscode.debug.activeDebugSession;
-      if (activeSession?.type === 'z80') {
-        await vscode.debug.stopDebugging(activeSession);
-        const restarted = await startCurrentProjectDebugging(folder, workspaceSelection);
-        if (restarted) {
-          void vscode.window.showInformationMessage(
-            `Debug80: Switched to root ${folder.name} and restarted debugging.`
-          );
+    vscode.commands.registerCommand(
+      'debug80.selectWorkspaceFolder',
+      async (args?: SelectWorkspaceFolderArgs | string) => {
+        const rootPath = typeof args === 'string' ? args : args?.rootPath;
+        const folder =
+          findWorkspaceFolder(rootPath) ??
+          (rootPath === undefined ? await workspaceSelection.selectWorkspaceFolder() : undefined);
+        if (!folder) {
+          if (rootPath !== undefined) {
+            void vscode.window.showInformationMessage(
+              `Debug80: The workspace root ${rootPath} is not open in this window.`
+            );
+            return undefined;
+          }
+          return undefined;
         }
-        return folder;
-      }
 
-      const started = await startCurrentProjectDebugging(folder, workspaceSelection);
-      if (started) {
-        void vscode.window.showInformationMessage(
-          `Debug80: Selected root ${folder.name} and started debugging.`
-        );
-      }
-      return folder;
-    })
-  );
+        platformViewProvider.refreshIdleView();
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('debug80.selectTarget', async () => {
-      const folder = await workspaceSelection.resolveWorkspaceFolder({
-        requireProject: true,
-        prompt: true,
-        placeHolder: 'Select the Debug80 project folder',
-      });
-      if (!folder) {
-        void vscode.window.showInformationMessage('Debug80: No configured Debug80 project found.');
-        return undefined;
-      }
-
-      const projectConfig = findProjectConfigPath(folder);
-      if (projectConfig === undefined) {
-        void vscode.window.showErrorMessage(
-          `Debug80: Could not find a project config in ${folder.uri.fsPath}.`
-        );
-        return undefined;
-      }
-
-      const previousTarget = resolvePreferredTargetName(context.workspaceState, projectConfig);
-
-      const target = await targetSelection.resolveTarget(projectConfig, {
-        prompt: true,
-        forcePrompt: true,
-        placeHolder: 'Select the active Debug80 target',
-      });
-      if (target === null) {
-        return undefined;
-      }
-      if (target === undefined) {
-        void vscode.window.showInformationMessage(
-          'Debug80: This project does not define any named targets.'
-        );
-        return undefined;
-      }
-
-      platformViewProvider.refreshIdleView();
-
-      const activeSession = vscode.debug.activeDebugSession;
-      if (activeSession?.type === 'z80' && target !== previousTarget) {
-        await vscode.debug.stopDebugging(activeSession);
-        const restarted = await startCurrentProjectDebugging(folder, workspaceSelection);
-        if (restarted) {
+        const projectConfig = findProjectConfigPath(folder);
+        if (projectConfig === undefined) {
           void vscode.window.showInformationMessage(
-            `Debug80: Switched target to ${target} and restarted debugging.`
+            `Debug80: Selected root ${folder.name}. This root does not contain a Debug80 project config.`
           );
-          return target;
+          return folder;
         }
-      }
 
-      if (activeSession?.type !== 'z80') {
+        const activeSession = vscode.debug.activeDebugSession;
+        if (activeSession?.type === 'z80') {
+          await vscode.debug.stopDebugging(activeSession);
+          const restarted = await startCurrentProjectDebugging(folder, workspaceSelection);
+          if (restarted) {
+            void vscode.window.showInformationMessage(
+              `Debug80: Switched to root ${folder.name} and restarted debugging.`
+            );
+          }
+          return folder;
+        }
+
         const started = await startCurrentProjectDebugging(folder, workspaceSelection);
         if (started) {
           void vscode.window.showInformationMessage(
-            `Debug80: Selected target ${target} and started debugging.`
+            `Debug80: Selected root ${folder.name} and started debugging.`
           );
-          return target;
         }
+        return folder;
       }
+    )
+  );
 
-      void vscode.window.showInformationMessage(`Debug80: Selected target ${target}.`);
-      return target;
-    })
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'debug80.selectTarget',
+      async (args?: SelectTargetArgs) => {
+        const folder =
+          findWorkspaceFolder(args?.rootPath) ??
+          (args?.rootPath === undefined
+            ? await workspaceSelection.resolveWorkspaceFolder({
+                requireProject: true,
+                prompt: true,
+                placeHolder: 'Select the Debug80 project folder',
+              })
+            : undefined);
+        if (!folder) {
+          if (args?.rootPath !== undefined) {
+            void vscode.window.showInformationMessage(
+              `Debug80: The workspace root ${args.rootPath} is not open in this window.`
+            );
+            return undefined;
+          }
+          void vscode.window.showInformationMessage('Debug80: No configured Debug80 project found.');
+          return undefined;
+        }
+
+        const projectConfig = findProjectConfigPath(folder);
+        if (projectConfig === undefined) {
+          void vscode.window.showErrorMessage(
+            `Debug80: Could not find a project config in ${folder.uri.fsPath}.`
+          );
+          return undefined;
+        }
+
+        const previousTarget = resolvePreferredTargetName(context.workspaceState, projectConfig);
+
+        const directTarget =
+          args?.targetName !== undefined
+            ? listProjectTargetChoices(projectConfig).find((choice) => choice.name === args.targetName)
+                ?.name
+            : undefined;
+        const target =
+          directTarget ??
+          (await targetSelection.resolveTarget(projectConfig, {
+            prompt: true,
+            forcePrompt: true,
+            placeHolder: 'Select the active Debug80 target',
+          }));
+        if (target === null) {
+          return undefined;
+        }
+        if (target === undefined) {
+          if (args?.targetName !== undefined) {
+            void vscode.window.showInformationMessage(
+              `Debug80: Target ${args.targetName} is not defined in this project.`
+            );
+            return undefined;
+          }
+          void vscode.window.showInformationMessage(
+            'Debug80: This project does not define any named targets.'
+          );
+          return undefined;
+        }
+
+        targetSelection.rememberTarget(projectConfig, target);
+        platformViewProvider.refreshIdleView();
+
+        const activeSession = vscode.debug.activeDebugSession;
+        if (activeSession?.type === 'z80' && target !== previousTarget) {
+          await vscode.debug.stopDebugging(activeSession);
+          const restarted = await startCurrentProjectDebugging(folder, workspaceSelection);
+          if (restarted) {
+            void vscode.window.showInformationMessage(
+              `Debug80: Switched target to ${target} and restarted debugging.`
+            );
+            return target;
+          }
+        }
+
+        if (activeSession?.type !== 'z80') {
+          const started = await startCurrentProjectDebugging(folder, workspaceSelection);
+          if (started) {
+            void vscode.window.showInformationMessage(
+              `Debug80: Selected target ${target} and started debugging.`
+            );
+            return target;
+          }
+        }
+
+        void vscode.window.showInformationMessage(`Debug80: Selected target ${target}.`);
+        return target;
+      }
+    )
   );
 
   context.subscriptions.push(

--- a/src/extension/platform-view-messages.ts
+++ b/src/extension/platform-view-messages.ts
@@ -12,8 +12,8 @@ export type PlatformViewMessage = {
 
 export interface PlatformViewMessageDependencies {
   handleCreateProject: () => PromiseLike<void>;
-  handleSelectProject: () => PromiseLike<void>;
-  handleSelectTarget: () => PromiseLike<void>;
+  handleSelectProject: (args?: { rootPath?: string }) => PromiseLike<void>;
+  handleSelectTarget: (args?: { rootPath?: string; targetName?: string }) => PromiseLike<void>;
   handleRestartDebug: () => PromiseLike<void>;
   handleSetEntrySource: () => PromiseLike<void>;
   currentPlatform: () => PlatformViewPlatform | undefined;
@@ -36,11 +36,22 @@ export async function handlePlatformViewMessage(
     return;
   }
   if (msg?.type === 'selectProject') {
-    await deps.handleSelectProject();
+    await deps.handleSelectProject(
+      typeof msg.rootPath === 'string' && msg.rootPath.length > 0
+        ? { rootPath: msg.rootPath }
+        : undefined
+    );
     return;
   }
   if (msg?.type === 'selectTarget') {
-    await deps.handleSelectTarget();
+    await deps.handleSelectTarget({
+      ...(typeof msg.rootPath === 'string' && msg.rootPath.length > 0
+        ? { rootPath: msg.rootPath }
+        : {}),
+      ...(typeof msg.targetName === 'string' && msg.targetName.length > 0
+        ? { targetName: msg.targetName }
+        : {}),
+    });
     return;
   }
   if (msg?.type === 'restartDebug') {

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -35,16 +35,29 @@ import {
 } from '../platforms/tec1g/ui-panel-state';
 import { appendSerialText as appendTec1gSerialText, clearSerialBuffer as clearTec1gSerialBuffer, createSerialBuffer as createTec1gSerialBuffer } from '../platforms/tec1g/ui-panel-serial';
 import type { Tec1gUpdatePayload } from '../platforms/tec1g/types';
+import { listProjectTargetChoices } from './project-target-selection';
 import { resolveProjectStatusSummary } from './project-status';
 import { getPlatformViewIdleHtml } from './platform-view-idle-html';
+import { findProjectConfigPath } from './project-config';
 
 type PlatformId = 'tec1' | 'tec1g' | 'simple';
 
 type ProjectStatusPayload = {
   rootName?: string;
+  rootPath?: string;
   hasProject?: boolean;
   targetName?: string;
   entrySource?: string;
+  roots: Array<{
+    name: string;
+    path: string;
+    hasProject: boolean;
+  }>;
+  targets: Array<{
+    name: string;
+    description?: string;
+    detail?: string;
+  }>;
 };
 
 export class PlatformViewProvider implements vscode.WebviewViewProvider {
@@ -309,11 +322,16 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
         return;
       }
       if (msg?.type === 'selectProject') {
-        await vscode.commands.executeCommand('debug80.selectWorkspaceFolder');
+        await vscode.commands.executeCommand('debug80.selectWorkspaceFolder', {
+          rootPath: (msg as { rootPath?: string }).rootPath,
+        });
         return;
       }
       if (msg?.type === 'selectTarget') {
-        await vscode.commands.executeCommand('debug80.selectTarget');
+        await vscode.commands.executeCommand('debug80.selectTarget', {
+          rootPath: (msg as { rootPath?: string }).rootPath,
+          targetName: (msg as { targetName?: string }).targetName,
+        });
         return;
       }
       if (msg?.type === 'setEntrySource') {
@@ -454,24 +472,41 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   }
 
   private getProjectStatusPayload(): ProjectStatusPayload {
+    const roots = (vscode.workspace.workspaceFolders ?? []).map((folder) => ({
+      name: folder.name,
+      path: folder.uri.fsPath,
+      hasProject: this.selectedWorkspace?.uri.fsPath === folder.uri.fsPath
+        ? this.hasProject
+        : findProjectConfigPath(folder) !== undefined,
+    }));
     const folder = this.selectedWorkspace;
     if (folder === undefined) {
-      return {};
+      return {
+        roots,
+        targets: [],
+      };
     }
 
+    const projectConfigPath = findProjectConfigPath(folder);
     const projectStatus =
       this.workspaceState !== undefined
         ? resolveProjectStatusSummary(this.workspaceState, folder)
         : undefined;
-    if (projectStatus === undefined) {
+    if (projectStatus === undefined || projectConfigPath === undefined) {
       return {
+        roots,
+        targets: [],
         rootName: folder.name,
+        rootPath: folder.uri.fsPath,
         hasProject: false,
       };
     }
 
     return {
+      roots,
+      targets: listProjectTargetChoices(projectConfigPath),
       rootName: folder.name,
+      rootPath: folder.uri.fsPath,
       hasProject: true,
       ...(projectStatus.targetName !== undefined ? { targetName: projectStatus.targetName } : {}),
       ...(projectStatus.entrySource !== undefined ? { entrySource: projectStatus.entrySource } : {}),

--- a/src/extension/project-target-selection.ts
+++ b/src/extension/project-target-selection.ts
@@ -36,6 +36,8 @@ type LoadedTargetChoices = {
   defaultTarget?: string;
 };
 
+export type ProjectTargetChoice = TargetChoice;
+
 export function getStoredTargetName(
   workspaceState: vscode.Memento,
   projectConfigPath: string
@@ -66,6 +68,10 @@ export function resolvePreferredTargetName(
   }
 
   return undefined;
+}
+
+export function listProjectTargetChoices(projectConfigPath: string): ProjectTargetChoice[] {
+  return loadTargetChoices(projectConfigPath).choices;
 }
 
 function appendEntrySourceSection(

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -9,6 +9,7 @@ const registerCommand = vi.fn((name: string, callback: (...args: unknown[]) => u
   return { dispose: vi.fn() };
 });
 const existsSync = vi.fn();
+const readFileSync = vi.fn();
 const showInformationMessage = vi.fn();
 const showErrorMessage = vi.fn();
 const startDebugging = vi.fn();
@@ -17,6 +18,7 @@ const executeCommand = vi.fn();
 
 vi.mock('fs', () => ({
   existsSync,
+  readFileSync,
 }));
 
 vi.mock('vscode', () => ({
@@ -49,6 +51,14 @@ describe('registerExtensionCommands', () => {
     registeredCommands.clear();
     existsSync.mockImplementation(
       (candidate: string) => path.normalize(candidate) === projectConfigPath
+    );
+    readFileSync.mockReturnValue(
+      JSON.stringify({
+        targets: {
+          app: { sourceFile: 'src/main.asm' },
+          serial: { sourceFile: 'src/serial.asm' },
+        },
+      })
     );
   });
 
@@ -108,7 +118,10 @@ describe('registerExtensionCommands', () => {
     const resolveTarget = vi.fn().mockResolvedValue('serial');
 
     registerExtensionCommands({
-      context: { subscriptions: [] } as never,
+      context: {
+        subscriptions: [],
+        workspaceState: { get: vi.fn(() => undefined), update: vi.fn() },
+      } as never,
       platformViewProvider: { refreshIdleView: vi.fn() } as never,
       sourceColumns: {} as never,
       terminalPanel: {} as never,
@@ -119,6 +132,7 @@ describe('registerExtensionCommands', () => {
       } as never,
       targetSelection: {
         resolveTarget,
+        rememberTarget: vi.fn(),
       } as never,
     });
 
@@ -176,6 +190,46 @@ describe('registerExtensionCommands', () => {
     );
   });
 
+  it('uses a direct root selection without prompting', async () => {
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    const folder = {
+      name: 'tec1g-mon3',
+      uri: { fsPath: '/workspace/tec1g-mon3' },
+      index: 0,
+    };
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder: vi.fn(),
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {} as never,
+    });
+
+    const selectRoot = registeredCommands.get('debug80.selectWorkspaceFolder');
+    expect(selectRoot).toBeTypeOf('function');
+
+    startDebugging.mockResolvedValueOnce(true);
+    const result = await selectRoot?.({ rootPath: folder.uri.fsPath });
+
+    expect(result).toEqual(folder);
+    expect(startDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: { fsPath: '/workspace/tec1g-mon3' } }),
+      expect.objectContaining({
+        type: 'z80',
+        request: 'launch',
+        projectConfig: projectConfigPath,
+        stopOnEntry: false,
+      })
+    );
+  });
+
   it('auto-restarts an active z80 session after changing target', async () => {
     const vscode = await import('vscode');
     const { registerExtensionCommands } = await import('../../src/extension/commands');
@@ -202,6 +256,7 @@ describe('registerExtensionCommands', () => {
       } as never,
       targetSelection: {
         resolveTarget,
+        rememberTarget: vi.fn(),
       } as never,
     });
 
@@ -230,6 +285,39 @@ describe('registerExtensionCommands', () => {
         stopOnEntry: false,
       })
     );
+  });
+
+  it('uses a direct target selection without prompting', async () => {
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    registerExtensionCommands({
+      context: {
+        subscriptions: [],
+        workspaceState: { get: vi.fn(() => undefined), update: vi.fn() },
+      } as never,
+      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder: vi.fn(),
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {
+        resolveTarget: vi.fn(),
+        rememberTarget: vi.fn(),
+      } as never,
+    });
+
+    const selectTarget = registeredCommands.get('debug80.selectTarget');
+    expect(selectTarget).toBeTypeOf('function');
+
+    const result = await selectTarget?.({
+      rootPath: '/workspace/tec1g-mon3',
+      targetName: 'serial',
+    });
+
+    expect(result).toBe('serial');
   });
 
   it('restarts the active z80 session against the current project target', async () => {

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -158,6 +158,7 @@ describe('registerExtensionCommands', () => {
       index: 0,
     };
     const selectWorkspaceFolder = vi.fn().mockResolvedValue(folder);
+    const rememberWorkspace = vi.fn();
 
     registerExtensionCommands({
       context: { subscriptions: [] } as never,
@@ -166,7 +167,7 @@ describe('registerExtensionCommands', () => {
       terminalPanel: {} as never,
       workspaceSelection: {
         resolveWorkspaceFolder: vi.fn(),
-        rememberWorkspace: vi.fn(),
+        rememberWorkspace,
         selectWorkspaceFolder,
       } as never,
       targetSelection: {} as never,
@@ -188,6 +189,7 @@ describe('registerExtensionCommands', () => {
         stopOnEntry: false,
       })
     );
+    expect(rememberWorkspace).toHaveBeenCalledWith(folder);
   });
 
   it('uses a direct root selection without prompting', async () => {
@@ -204,6 +206,7 @@ describe('registerExtensionCommands', () => {
       platformViewProvider: { refreshIdleView: vi.fn() } as never,
       sourceColumns: {} as never,
       terminalPanel: {} as never,
+      workspaceState: { get: vi.fn(() => undefined), update: vi.fn() },
       workspaceSelection: {
         resolveWorkspaceFolder: vi.fn(),
         rememberWorkspace: vi.fn(),
@@ -219,6 +222,7 @@ describe('registerExtensionCommands', () => {
     const result = await selectRoot?.({ rootPath: folder.uri.fsPath });
 
     expect(result).toEqual(folder);
+    expect(startDebugging).toHaveBeenCalled();
     expect(startDebugging).toHaveBeenCalledWith(
       expect.objectContaining({ uri: { fsPath: '/workspace/tec1g-mon3' } }),
       expect.objectContaining({
@@ -228,6 +232,41 @@ describe('registerExtensionCommands', () => {
         stopOnEntry: false,
       })
     );
+  });
+
+  it('remembers a direct root selection even when no project config exists', async () => {
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+    const vscode = await import('vscode');
+
+    const folder = {
+      name: 'notes',
+      uri: { fsPath: '/workspace/notes' },
+      index: 0,
+    };
+    (vscode.workspace as { workspaceFolders?: Array<{ name: string; uri: { fsPath: string }; index: number }> }).workspaceFolders = [folder];
+    const rememberWorkspace = vi.fn();
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder: vi.fn(),
+        rememberWorkspace,
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {} as never,
+    });
+
+    const selectRoot = registeredCommands.get('debug80.selectWorkspaceFolder');
+    expect(selectRoot).toBeTypeOf('function');
+
+    const result = await selectRoot?.({ rootPath: folder.uri.fsPath });
+
+    expect(result).toEqual(folder);
+    expect(rememberWorkspace).toHaveBeenCalledWith(folder);
+    expect(startDebugging).not.toHaveBeenCalled();
   });
 
   it('auto-restarts an active z80 session after changing target', async () => {
@@ -289,6 +328,14 @@ describe('registerExtensionCommands', () => {
 
   it('uses a direct target selection without prompting', async () => {
     const { registerExtensionCommands } = await import('../../src/extension/commands');
+    const vscode = await import('vscode');
+    (vscode.workspace as { workspaceFolders?: Array<{ name: string; uri: { fsPath: string }; index: number }> }).workspaceFolders = [
+      {
+        name: 'tec1g-mon3',
+        uri: { fsPath: '/workspace/tec1g-mon3' },
+        index: 0,
+      },
+    ];
 
     registerExtensionCommands({
       context: {

--- a/tests/extension/platform-view-messages.test.ts
+++ b/tests/extension/platform-view-messages.test.ts
@@ -26,8 +26,11 @@ describe('platform-view message routing', () => {
     const deps = createDependencies('simple');
 
     await handlePlatformViewMessage({ type: 'createProject' }, deps);
-    await handlePlatformViewMessage({ type: 'selectProject' }, deps);
-    await handlePlatformViewMessage({ type: 'selectTarget' }, deps);
+    await handlePlatformViewMessage({ type: 'selectProject', rootPath: '/workspace/a' }, deps);
+    await handlePlatformViewMessage(
+      { type: 'selectTarget', rootPath: '/workspace/a', targetName: 'app' },
+      deps
+    );
     await handlePlatformViewMessage({ type: 'restartDebug' }, deps);
     await handlePlatformViewMessage({ type: 'setEntrySource' }, deps);
     await handlePlatformViewMessage({ type: 'startDebug' }, deps);
@@ -35,8 +38,11 @@ describe('platform-view message routing', () => {
     await handlePlatformViewMessage({ type: 'serialSave', text: 'hello' }, deps);
 
     expect(deps.handleCreateProject).toHaveBeenCalledTimes(1);
-    expect(deps.handleSelectProject).toHaveBeenCalledTimes(1);
-    expect(deps.handleSelectTarget).toHaveBeenCalledTimes(1);
+    expect(deps.handleSelectProject).toHaveBeenCalledWith({ rootPath: '/workspace/a' });
+    expect(deps.handleSelectTarget).toHaveBeenCalledWith({
+      rootPath: '/workspace/a',
+      targetName: 'app',
+    });
     expect(deps.handleRestartDebug).toHaveBeenCalledTimes(1);
     expect(deps.handleSetEntrySource).toHaveBeenCalledTimes(1);
     expect(deps.handleStartDebug).toHaveBeenCalledTimes(1);

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -4,21 +4,30 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { executeCommand, resolveProjectStatusSummary } = vi.hoisted(() => ({
+const { executeCommand, resolveProjectStatusSummary, findProjectConfigPath, listProjectTargetChoices } = vi.hoisted(() => ({
   executeCommand: vi.fn(() => Promise.resolve()),
   resolveProjectStatusSummary: vi.fn(() => ({
     projectName: 'demo',
     targetName: 'app',
     entrySource: 'src/main.asm',
   })),
+  findProjectConfigPath: vi.fn((folder: { uri: { fsPath: string } }) => `${folder.uri.fsPath}/.vscode/debug80.json`),
+  listProjectTargetChoices: vi.fn(() => [
+    { name: 'app', description: 'src/main.asm', detail: 'src/main.asm' },
+    { name: 'serial', description: 'src/serial.asm', detail: 'src/serial.asm' },
+  ]),
 }));
+
+let workspaceFolders: Array<{ name: string; uri: { fsPath: string } }> | undefined;
 
 vi.mock('vscode', () => {
   return {
     commands: { executeCommand },
     debug: { activeDebugSession: undefined },
     workspace: {
-      workspaceFolders: undefined,
+      get workspaceFolders() {
+        return workspaceFolders;
+      },
       fs: { readFile: vi.fn(), writeFile: vi.fn() },
     },
     window: {
@@ -40,6 +49,14 @@ vi.mock('vscode', () => {
 
 vi.mock('../../src/extension/project-status', () => ({
   resolveProjectStatusSummary,
+}));
+
+vi.mock('../../src/extension/project-config', () => ({
+  findProjectConfigPath,
+}));
+
+vi.mock('../../src/extension/project-target-selection', () => ({
+  listProjectTargetChoices,
 }));
 
 import * as path from 'path';
@@ -75,6 +92,7 @@ function createWebviewView(): vscode.WebviewView {
 describe('PlatformViewProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    workspaceFolders = undefined;
   });
 
   it('renders Tec1 HTML when the webview resolves and the platform is Tec1', async () => {
@@ -128,6 +146,12 @@ describe('PlatformViewProvider', () => {
     } as vscode.CancellationToken);
 
     provider.setPlatform('tec1g', undefined, { reveal: false, tab: 'ui' });
+    workspaceFolders = [
+      {
+        name: 'demo',
+        uri: { fsPath: '/workspace/demo' },
+      },
+    ];
     provider.setSelectedWorkspace({
       name: 'demo',
       uri: { fsPath: '/workspace/demo' },
@@ -144,9 +168,15 @@ describe('PlatformViewProvider', () => {
       if (
         message.type === 'projectStatus' &&
         message.rootName === 'demo' &&
+        message.rootPath === '/workspace/demo' &&
         message.hasProject === true &&
         message.targetName === 'app' &&
-        message.entrySource === 'src/main.asm'
+        message.entrySource === 'src/main.asm' &&
+        Array.isArray(message.roots) &&
+        message.roots.length === 1 &&
+        message.roots[0]?.path === '/workspace/demo' &&
+        Array.isArray(message.targets) &&
+        message.targets.length === 2
       ) {
         found = true;
         break;

--- a/tests/platforms/tec1/ui-panel-html.test.ts
+++ b/tests/platforms/tec1/ui-panel-html.test.ts
@@ -38,8 +38,9 @@ describe('tec1 ui-panel-html', () => {
     const html = getTec1Html('home', webview, extensionUri);
     expect(html).toContain('Home');
     expect(html).toContain('panel-home');
-    expect(html).toContain('Select Root');
-    expect(html).toContain('Select Target');
+    expect(html).toContain('homeRootSelect');
+    expect(html).toContain('homeTargetSelect');
+    expect(html).toContain('Quick Pick');
     expect(html).toContain('Set Entry Source');
     expect(html).toContain('panel-ui');
     expect(html).toContain('panel-memory');

--- a/tests/platforms/tec1g/ui-panel-html.test.ts
+++ b/tests/platforms/tec1g/ui-panel-html.test.ts
@@ -38,8 +38,9 @@ describe('tec1g ui-panel-html', () => {
     const html = getTec1gHtml('home', webview, extensionUri);
     expect(html).toContain('Home');
     expect(html).toContain('panel-home');
-    expect(html).toContain('Select Root');
-    expect(html).toContain('Select Target');
+    expect(html).toContain('homeRootSelect');
+    expect(html).toContain('homeTargetSelect');
+    expect(html).toContain('Quick Pick');
     expect(html).toContain('Set Entry Source');
     expect(html).toContain('panel-ui');
     expect(html).toContain('panel-memory');

--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -29,6 +29,31 @@ body {
       display: grid;
       gap: 8px;
     }
+    .home-controls {
+      display: grid;
+      gap: 10px;
+      margin-bottom: 12px;
+    }
+    .home-control {
+      display: grid;
+      gap: 6px;
+    }
+    .home-control-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 8px;
+      align-items: center;
+    }
+    .home-select {
+      width: 100%;
+      min-width: 0;
+      border: 1px solid #4a4a4a;
+      border-radius: 8px;
+      background: #1b1b1b;
+      color: #f0f0f0;
+      padding: 6px 8px;
+      font-size: 12px;
+    }
     .home-status-row {
       display: grid;
       grid-template-columns: minmax(88px, 120px) 1fr;
@@ -67,6 +92,9 @@ body {
     }
     .session-button:hover {
       background: #2d2d2d;
+    }
+    .session-button-fallback {
+      white-space: nowrap;
     }
     .session-button-primary {
       background: #3b4b1c;

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -18,6 +18,22 @@
       <div class="home-panel">
         <div class="home-card">
           <div class="home-kicker">DEBUG80 HOME</div>
+          <div class="home-controls">
+            <div class="home-control">
+              <label class="home-label" for="homeRootSelect">Root</label>
+              <div class="home-control-row">
+                <select class="home-select" id="homeRootSelect"></select>
+                <button class="session-button session-button-fallback" id="selectProject">Quick Pick</button>
+              </div>
+            </div>
+            <div class="home-control">
+              <label class="home-label" for="homeTargetSelect">Target</label>
+              <div class="home-control-row">
+                <select class="home-select" id="homeTargetSelect"></select>
+                <button class="session-button session-button-fallback" id="selectTarget">Quick Pick</button>
+              </div>
+            </div>
+          </div>
           <div class="home-status">
             <div class="home-status-row">
               <span class="home-label">Root</span>
@@ -38,12 +54,10 @@
           </div>
         </div>
         <div class="home-actions">
-          <button class="session-button" id="selectProject">Select Root</button>
-          <button class="session-button" id="selectTarget">Select Target</button>
           <button class="session-button" id="setEntrySource">Set Entry Source</button>
         </div>
         <p class="home-note">
-          Debug80 follows workspace roots. Select a configured root and target here, then use the UI and CPU tabs while the session runs.
+          Debug80 follows workspace roots. Use the selectors above to switch roots and targets directly, or use Quick Pick when you need the full picker flow.
         </p>
       </div>
     </div>

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -17,6 +17,8 @@ const DEFAULT_TAB: PanelTab =
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
 const selectTargetButton = document.getElementById('selectTarget') as HTMLButtonElement | null;
 const setEntrySourceButton = document.getElementById('setEntrySource') as HTMLButtonElement | null;
+const homeRootSelect = document.getElementById('homeRootSelect') as HTMLSelectElement | null;
+const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const homeRootName = document.getElementById('homeRootName') as HTMLElement | null;
 const homeProjectState = document.getElementById('homeProjectState') as HTMLElement | null;
 const homeTargetName = document.getElementById('homeTargetName') as HTMLElement | null;
@@ -73,6 +75,7 @@ const hexOrder = [
 let speedMode = 'fast';
 let uiRevision = 0;
 let shiftLatched = false;
+let currentRootPath = '';
 const audio = createAudioController(muteEl);
 const lcdRenderer = createLcdRenderer();
 const matrixRenderer = createMatrixRenderer();
@@ -89,6 +92,85 @@ setEntrySourceButton?.addEventListener('click', () => {
   vscode.postMessage({ type: 'setEntrySource' });
 });
 
+homeRootSelect?.addEventListener('change', () => {
+  const rootPath = homeRootSelect.value;
+  if (!rootPath) {
+    return;
+  }
+  vscode.postMessage({ type: 'selectProject', rootPath });
+});
+
+homeTargetSelect?.addEventListener('change', () => {
+  const targetName = homeTargetSelect.value;
+  if (!targetName) {
+    return;
+  }
+  vscode.postMessage({
+    type: 'selectTarget',
+    rootPath: currentRootPath,
+    targetName,
+  });
+});
+
+function clearSelectOptions(select: HTMLSelectElement): void {
+  while (select.firstChild) {
+    select.removeChild(select.firstChild);
+  }
+}
+
+function setSelectPlaceholder(select: HTMLSelectElement, label: string): void {
+  const option = document.createElement('option');
+  option.value = '';
+  option.textContent = label;
+  option.disabled = true;
+  option.selected = true;
+  select.appendChild(option);
+}
+
+function setRootOptions(options: Array<{ name: string; path: string; hasProject: boolean }>, selectedRootPath?: string): void {
+  if (!homeRootSelect) {
+    return;
+  }
+  clearSelectOptions(homeRootSelect);
+  if (options.length === 0) {
+    setSelectPlaceholder(homeRootSelect, 'No workspace roots available');
+    homeRootSelect.disabled = true;
+    return;
+  }
+  setSelectPlaceholder(homeRootSelect, 'Select root...');
+  for (const option of options) {
+    const el = document.createElement('option');
+    el.value = option.path;
+    el.textContent = `${option.name} — ${option.path}`;
+    el.title = option.hasProject ? 'Configured Debug80 project' : 'No Debug80 project config';
+    homeRootSelect.appendChild(el);
+  }
+  homeRootSelect.disabled = false;
+  homeRootSelect.value = selectedRootPath ?? '';
+}
+
+function setTargetOptions(options: Array<{ name: string; description?: string; detail?: string }>, selectedTargetName?: string): void {
+  if (!homeTargetSelect) {
+    return;
+  }
+  clearSelectOptions(homeTargetSelect);
+  if (options.length === 0) {
+    setSelectPlaceholder(homeTargetSelect, 'No targets available');
+    homeTargetSelect.disabled = true;
+    return;
+  }
+  setSelectPlaceholder(homeTargetSelect, 'Select target...');
+  for (const option of options) {
+    const el = document.createElement('option');
+    el.value = option.name;
+    el.textContent = option.description ? `${option.name} — ${option.description}` : option.name;
+    el.title = option.detail ?? option.description ?? option.name;
+    homeTargetSelect.appendChild(el);
+  }
+  homeTargetSelect.disabled = false;
+  homeTargetSelect.value = selectedTargetName ?? '';
+}
+
 function setHomeValue(node: HTMLElement | null, value: string | undefined, fallback: string): void {
   if (!node) {
     return;
@@ -98,10 +180,16 @@ function setHomeValue(node: HTMLElement | null, value: string | undefined, fallb
 
 function applyProjectStatus(payload: {
   rootName?: string;
+  rootPath?: string;
   hasProject?: boolean;
   targetName?: string;
   entrySource?: string;
+  roots?: Array<{ name: string; path: string; hasProject: boolean }>;
+  targets?: Array<{ name: string; description?: string; detail?: string }>;
 }): void {
+  currentRootPath = payload.rootPath ?? '';
+  setRootOptions(payload.roots ?? [], currentRootPath);
+  setTargetOptions(payload.targets ?? [], payload.targetName);
   setHomeValue(homeRootName, payload.rootName, 'No root selected');
   setHomeValue(
     homeProjectState,

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -18,6 +18,22 @@
       <div class="home-panel">
         <div class="home-card">
           <div class="home-kicker">DEBUG80 HOME</div>
+          <div class="home-controls">
+            <div class="home-control">
+              <label class="home-label" for="homeRootSelect">Root</label>
+              <div class="home-control-row">
+                <select class="home-select" id="homeRootSelect"></select>
+                <button class="session-button session-button-fallback" id="selectProject">Quick Pick</button>
+              </div>
+            </div>
+            <div class="home-control">
+              <label class="home-label" for="homeTargetSelect">Target</label>
+              <div class="home-control-row">
+                <select class="home-select" id="homeTargetSelect"></select>
+                <button class="session-button session-button-fallback" id="selectTarget">Quick Pick</button>
+              </div>
+            </div>
+          </div>
           <div class="home-status">
             <div class="home-status-row">
               <span class="home-label">Root</span>
@@ -38,12 +54,10 @@
           </div>
         </div>
         <div class="home-actions">
-          <button class="session-button" id="selectProject">Select Root</button>
-          <button class="session-button" id="selectTarget">Select Target</button>
           <button class="session-button" id="setEntrySource">Set Entry Source</button>
         </div>
         <p class="home-note">
-          Debug80 follows workspace roots. Select a configured root and target here, then use the UI and CPU tabs while the session runs.
+          Debug80 follows workspace roots. Use the selectors above to switch roots and targets directly, or use Quick Pick when you need the full picker flow.
         </p>
       </div>
     </div>

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -65,14 +65,29 @@ type MemorySnapshotPayload = {
   }>;
 };
 
+type ProjectRootOption = {
+  name: string;
+  path: string;
+  hasProject: boolean;
+};
+
+type ProjectTargetOption = {
+  name: string;
+  description?: string;
+  detail?: string;
+};
+
 type IncomingMessage =
   | { type: 'selectTab'; tab: string }
   | {
       type: 'projectStatus';
       rootName?: string;
+      rootPath?: string;
       hasProject?: boolean;
       targetName?: string;
       entrySource?: string;
+      roots: ProjectRootOption[];
+      targets: ProjectTargetOption[];
     }
   | { type: 'uiVisibility'; visibility: Record<string, boolean>; persist?: boolean }
   | ({ type: 'update'; uiRevision?: number } & Tec1gUpdatePayload)
@@ -89,6 +104,8 @@ const DEFAULT_TAB: PanelTab =
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
 const selectTargetButton = document.getElementById('selectTarget') as HTMLButtonElement | null;
 const setEntrySourceButton = document.getElementById('setEntrySource') as HTMLButtonElement | null;
+const homeRootSelect = document.getElementById('homeRootSelect') as HTMLSelectElement | null;
+const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const homeRootName = document.getElementById('homeRootName') as HTMLElement | null;
 const homeProjectState = document.getElementById('homeProjectState') as HTMLElement | null;
 const homeTargetName = document.getElementById('homeTargetName') as HTMLElement | null;
@@ -113,6 +130,7 @@ const SHIFT_BIT = 0x20;
 const DIGITS = 6;
 let sysCtrlSegs: HTMLElement[] = [];
 let sysCtrlValue = 0;
+let currentRootPath = '';
 const digitEls: HTMLElement[] = [];
 for (let i = 0; i < DIGITS; i++) {
   const digit = createDigit();
@@ -249,6 +267,85 @@ setEntrySourceButton?.addEventListener('click', () => {
   vscode.postMessage({ type: 'setEntrySource' });
 });
 
+homeRootSelect?.addEventListener('change', () => {
+  const rootPath = homeRootSelect.value;
+  if (!rootPath) {
+    return;
+  }
+  vscode.postMessage({ type: 'selectProject', rootPath });
+});
+
+homeTargetSelect?.addEventListener('change', () => {
+  const targetName = homeTargetSelect.value;
+  if (!targetName) {
+    return;
+  }
+  vscode.postMessage({
+    type: 'selectTarget',
+    rootPath: currentRootPath,
+    targetName,
+  });
+});
+
+function clearSelectOptions(select: HTMLSelectElement): void {
+  while (select.firstChild) {
+    select.removeChild(select.firstChild);
+  }
+}
+
+function setSelectPlaceholder(select: HTMLSelectElement, label: string): void {
+  const option = document.createElement('option');
+  option.value = '';
+  option.textContent = label;
+  option.disabled = true;
+  option.selected = true;
+  select.appendChild(option);
+}
+
+function setRootOptions(options: ProjectRootOption[], selectedRootPath?: string): void {
+  if (!homeRootSelect) {
+    return;
+  }
+  clearSelectOptions(homeRootSelect);
+  if (options.length === 0) {
+    setSelectPlaceholder(homeRootSelect, 'No workspace roots available');
+    homeRootSelect.disabled = true;
+    return;
+  }
+  setSelectPlaceholder(homeRootSelect, 'Select root...');
+  for (const option of options) {
+    const el = document.createElement('option');
+    el.value = option.path;
+    el.textContent = `${option.name} — ${option.path}`;
+    el.title = option.hasProject ? 'Configured Debug80 project' : 'No Debug80 project config';
+    homeRootSelect.appendChild(el);
+  }
+  homeRootSelect.disabled = false;
+  homeRootSelect.value = selectedRootPath ?? '';
+}
+
+function setTargetOptions(options: ProjectTargetOption[], selectedTargetName?: string): void {
+  if (!homeTargetSelect) {
+    return;
+  }
+  clearSelectOptions(homeTargetSelect);
+  if (options.length === 0) {
+    setSelectPlaceholder(homeTargetSelect, 'No targets available');
+    homeTargetSelect.disabled = true;
+    return;
+  }
+  setSelectPlaceholder(homeTargetSelect, 'Select target...');
+  for (const option of options) {
+    const el = document.createElement('option');
+    el.value = option.name;
+    el.textContent = option.description ? `${option.name} — ${option.description}` : option.name;
+    el.title = option.detail ?? option.description ?? option.name;
+    homeTargetSelect.appendChild(el);
+  }
+  homeTargetSelect.disabled = false;
+  homeTargetSelect.value = selectedTargetName ?? '';
+}
+
 function setHomeValue(node: HTMLElement | null, value: string | undefined, fallback: string): void {
   if (!node) {
     return;
@@ -258,10 +355,16 @@ function setHomeValue(node: HTMLElement | null, value: string | undefined, fallb
 
 function applyProjectStatus(payload: {
   rootName?: string;
+  rootPath?: string;
   hasProject?: boolean;
   targetName?: string;
   entrySource?: string;
+  roots?: ProjectRootOption[];
+  targets?: ProjectTargetOption[];
 }): void {
+  currentRootPath = payload.rootPath ?? '';
+  setRootOptions(payload.roots ?? [], currentRootPath);
+  setTargetOptions(payload.targets ?? [], payload.targetName);
   setHomeValue(homeRootName, payload.rootName, 'No root selected');
   setHomeValue(
     homeProjectState,


### PR DESCRIPTION
## Summary

This narrows the project workflow onto the Home tab itself. Root and target are now visible and changeable in-panel, while Quick Pick remains available as the fallback path.

## Scope

- Add root and target selectors to the Home tab for Tec-1 and Tec-1G.
- Carry root/target option payloads through the extension project-status path.
- Preserve Quick Pick fallback behavior for root and target selection commands.
- Keep multi-root behavior explicit by keying selections to workspace paths.

## Verification

- `./node_modules/.bin/vitest run tests/extension/commands.test.ts tests/extension/platform-view-messages.test.ts tests/extension/platform-view-provider.test.ts tests/platforms/tec1/ui-panel-html.test.ts tests/platforms/tec1g/ui-panel-html.test.ts`
- `./node_modules/.bin/eslint src/extension/commands.ts src/extension/platform-view-messages.ts src/extension/platform-view-provider.ts src/extension/project-target-selection.ts webview/tec1/index.ts webview/tec1g/index.ts tests/extension/commands.test.ts tests/extension/platform-view-messages.test.ts tests/extension/platform-view-provider.test.ts tests/platforms/tec1/ui-panel-html.test.ts tests/platforms/tec1g/ui-panel-html.test.ts`
- `npm test`
