### PR TITLE
feat: allow paused memory editing

### DIFF
--- a/src/debug/adapter.ts
+++ b/src/debug/adapter.ts
@@ -41,6 +41,7 @@ import { AssembleFailureError } from './assembler';
 import { buildRomSourcesResponse } from './rom-requests';
 import { handleTerminalInput, handleTerminalBreak } from './terminal-request';
 import { handleMemorySnapshotRequest } from './memory-request';
+import { handleMemoryWriteRequest } from './memory-write';
 import { handleRegisterWriteRequest } from './register-request';
 import { populateFromConfig } from './launch-args';
 import {
@@ -129,6 +130,7 @@ export class Z80DebugSession extends DebugSession {
     );
     const memoryDeps = {
       getRuntime: () => this.sessionState.runtime,
+      getRunning: () => this.sessionState.runState.isRunning,
       getSymbolAnchors: () => this.sessionState.symbolAnchors,
       getLookupAnchors: () => this.sourceState.lookupAnchors,
       getSymbolList: () => this.sessionState.symbolList,
@@ -143,6 +145,15 @@ export class Z80DebugSession extends DebugSession {
     );
     this.commandRouter.register('debug80/registerWrite', (response, args) => {
       const error = handleRegisterWriteRequest(this.sessionState, args);
+      if (error !== null) {
+        this.sendErrorResponse(response, 1, error);
+        return true;
+      }
+      this.sendResponse(response);
+      return true;
+    });
+    this.commandRouter.register('debug80/memoryWrite', (response, args) => {
+      const error = handleMemoryWriteRequest(this.sessionState, args);
       if (error !== null) {
         this.sendErrorResponse(response, 1, error);
         return true;

--- a/src/debug/memory-request.ts
+++ b/src/debug/memory-request.ts
@@ -7,6 +7,7 @@ import { buildMemorySnapshotResponse, type MemorySnapshotContext } from './memor
 
 export type MemoryRequestDeps = {
   getRuntime: () => MemorySnapshotContext['runtime'] | undefined;
+  getRunning: () => boolean;
   getSymbolAnchors: () => MemorySnapshotContext['symbolAnchors'];
   getLookupAnchors: () => MemorySnapshotContext['lookupAnchors'];
   getSymbolList: () => MemorySnapshotContext['symbolList'];
@@ -26,6 +27,7 @@ export function handleMemorySnapshotRequest(
   }
   const snapshot = buildMemorySnapshotResponse(args, {
     runtime,
+    running: deps.getRunning(),
     symbolAnchors: deps.getSymbolAnchors(),
     lookupAnchors: deps.getLookupAnchors(),
     symbolList: deps.getSymbolList(),

--- a/src/debug/memory-snapshot.ts
+++ b/src/debug/memory-snapshot.ts
@@ -18,6 +18,7 @@ export type SnapshotRuntime = {
 
 export type MemorySnapshotContext = {
   runtime: SnapshotRuntime;
+  running: boolean;
   symbolAnchors: SourceMapAnchor[];
   lookupAnchors: SourceMapAnchor[];
   symbolList: Array<{ name: string; address: number }>;
@@ -29,6 +30,7 @@ export function buildMemorySnapshotResponse(
 ): {
   before: number;
   rowSize: 8 | 16;
+  running: boolean;
   views: ReturnType<typeof buildMemorySnapshotViews>;
   symbols: Array<{ name: string; address: number }>;
   registers: {
@@ -91,6 +93,7 @@ export function buildMemorySnapshotResponse(
   return {
     before,
     rowSize,
+    running: ctx.running,
     views,
     symbols: ctx.symbolList,
     registers: {

--- a/src/debug/memory-write.ts
+++ b/src/debug/memory-write.ts
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Helpers for paused-session memory write requests.
+ */
+
+import type { SessionStateShape } from './session-state';
+
+type MemoryWriteArgs = {
+  address?: unknown;
+  value?: unknown;
+};
+
+function parseAddress(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? value & 0xffff : null;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.startsWith('0x') || trimmed.startsWith('0X')) {
+    return null;
+  }
+  if (!/^[0-9a-fA-F]+$/.test(trimmed)) {
+    return null;
+  }
+  const parsed = Number.parseInt(trimmed, 16);
+  return Number.isFinite(parsed) ? parsed & 0xffff : null;
+}
+
+function parseByteValue(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) && value >= 0 && value <= 0xff ? value & 0xff : null;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.startsWith('0x') || trimmed.startsWith('0X')) {
+    return null;
+  }
+  if (!/^[0-9a-fA-F]+$/.test(trimmed) || trimmed.length > 2) {
+    return null;
+  }
+  const parsed = Number.parseInt(trimmed, 16);
+  return Number.isFinite(parsed) ? parsed & 0xff : null;
+}
+
+export function handleMemoryWriteRequest(
+  sessionState: SessionStateShape,
+  args: unknown
+): string | null {
+  if (sessionState.runtime === undefined) {
+    return 'Debug80: No program loaded.';
+  }
+  if (sessionState.runState.isRunning) {
+    return 'Debug80: Memory can only be edited while paused.';
+  }
+  if (args === null || typeof args !== 'object') {
+    return 'Debug80: Invalid memory write request.';
+  }
+
+  const payload = args as MemoryWriteArgs;
+  const address = parseAddress(payload.address);
+  if (address === null) {
+    return 'Debug80: Invalid memory address.';
+  }
+  const value = parseByteValue(payload.value);
+  if (value === null) {
+    return 'Debug80: Invalid hex byte.';
+  }
+
+  const runtime = sessionState.runtime;
+  if (typeof runtime.hardware.memWrite === 'function') {
+    runtime.hardware.memWrite(address, value);
+  } else {
+    runtime.hardware.memory[address] = value;
+  }
+  return null;
+}

--- a/src/platforms/panel-messages.ts
+++ b/src/platforms/panel-messages.ts
@@ -15,6 +15,7 @@ export type PanelMessage = {
   code?: number;
   mode?: string;
   register?: string;
+  address?: number;
   value?: string;
   text?: string;
   tab?: string;
@@ -42,6 +43,7 @@ export type PanelCommands = {
   speed: string;
   serialSend: string;
   registerWrite: string;
+  memoryWrite: string;
 };
 
 async function sendCommand(
@@ -110,6 +112,31 @@ export async function handleCommonPanelMessage<TTab extends string>(
     });
     if (!ok && ctx.isPanelVisible()) {
       // Rehydrate from the runtime when the adapter rejects the write so the UI snaps back.
+      void refreshSnapshot(
+        ctx.refreshController.state,
+        ctx.refreshController.handlers,
+        ctx.refreshController.snapshotPayload(),
+        { allowErrors: true }
+      );
+      return true;
+    }
+    void refreshSnapshot(
+      ctx.refreshController.state,
+      ctx.refreshController.handlers,
+      ctx.refreshController.snapshotPayload(),
+      { allowErrors: true }
+    );
+    return true;
+  }
+  if (msg.type === 'memoryEdit' && typeof msg.address === 'number' && typeof msg.value === 'string') {
+    if (session?.type !== 'z80') {
+      return true;
+    }
+    const ok = await sendCommand(session, commands.memoryWrite, {
+      address: msg.address,
+      value: msg.value,
+    });
+    if (!ok && ctx.isPanelVisible()) {
       void refreshSnapshot(
         ctx.refreshController.state,
         ctx.refreshController.handlers,

--- a/src/platforms/tec1/ui-panel-messages.ts
+++ b/src/platforms/tec1/ui-panel-messages.ts
@@ -21,5 +21,6 @@ export async function handleTec1Message(msg: Tec1Message, ctx: MessageContext): 
     speed: 'debug80/tec1Speed',
     serialSend: 'debug80/tec1SerialInput',
     registerWrite: 'debug80/registerWrite',
+    memoryWrite: 'debug80/memoryWrite',
   });
 }

--- a/src/platforms/tec1g/ui-panel-messages.ts
+++ b/src/platforms/tec1g/ui-panel-messages.ts
@@ -28,6 +28,7 @@ export async function handleTec1gMessage(msg: Tec1gMessage, ctx: MessageContext)
     speed: 'debug80/tec1gSpeed',
     serialSend: 'debug80/tec1gSerialInput',
     registerWrite: 'debug80/registerWrite',
+    memoryWrite: 'debug80/memoryWrite',
   })) {
     return;
   }

--- a/tests/debug/memory-snapshot.test.ts
+++ b/tests/debug/memory-snapshot.test.ts
@@ -36,6 +36,7 @@ describe('memory-snapshot', () => {
       },
       {
         runtime,
+        running: false,
         symbolAnchors: [],
         lookupAnchors: [],
         symbolList: [{ name: 'ENTRY', address: 0x10 }],
@@ -44,6 +45,7 @@ describe('memory-snapshot', () => {
 
     expect(snapshot.before).toBe(8);
     expect(snapshot.rowSize).toBe(8);
+    expect(snapshot.running).toBe(false);
     expect(snapshot.views).toHaveLength(1);
     expect(snapshot.views[0]?.address).toBe(0x10);
     expect(snapshot.symbols).toEqual([{ name: 'ENTRY', address: 0x10 }]);

--- a/tests/debug/memory-write.test.ts
+++ b/tests/debug/memory-write.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @file Memory write request tests.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { createSessionState } from '../../src/debug/session-state';
+import { handleMemoryWriteRequest } from '../../src/debug/memory-write';
+import { createZ80Runtime } from '../../src/z80/runtime';
+
+describe('memory-write', () => {
+  it('writes a byte through the runtime memory hook when paused', () => {
+    const sessionState = createSessionState();
+    sessionState.runtime = createZ80Runtime({
+      memory: new Uint8Array(0x10000),
+      startAddress: 0,
+    });
+    sessionState.runState.isRunning = false;
+    const memWrite = vi.fn();
+    sessionState.runtime.hardware.memWrite = memWrite;
+
+    const error = handleMemoryWriteRequest(sessionState, {
+      address: 0x1234,
+      value: 'ab',
+    });
+
+    expect(error).toBeNull();
+    expect(memWrite).toHaveBeenCalledWith(0x1234, 0xab);
+    expect(sessionState.runtime.hardware.memory[0x1234]).toBe(0);
+  });
+
+  it('rejects writes while the session is running', () => {
+    const sessionState = createSessionState();
+    sessionState.runtime = createZ80Runtime({
+      memory: new Uint8Array(0x10000),
+      startAddress: 0,
+    });
+    sessionState.runState.isRunning = true;
+
+    const error = handleMemoryWriteRequest(sessionState, {
+      address: 0x1234,
+      value: 'ab',
+    });
+
+    expect(error).toBe('Debug80: Memory can only be edited while paused.');
+  });
+});

--- a/tests/platforms/panel-messages.test.ts
+++ b/tests/platforms/panel-messages.test.ts
@@ -34,6 +34,7 @@ describe('panel-messages', () => {
         speed: 'debug80/tec1Speed',
         serialSend: 'debug80/tec1SerialInput',
         registerWrite: 'debug80/registerWrite',
+        memoryWrite: 'debug80/memoryWrite',
       }
     );
 
@@ -71,6 +72,7 @@ describe('panel-messages', () => {
         speed: 'debug80/tec1Speed',
         serialSend: 'debug80/tec1SerialInput',
         registerWrite: 'debug80/registerWrite',
+        memoryWrite: 'debug80/memoryWrite',
       }
     );
 
@@ -78,6 +80,82 @@ describe('panel-messages', () => {
     expect(customRequest).toHaveBeenCalledWith('debug80/registerWrite', {
       register: 'bc',
       value: '1234',
+    });
+    expect(postSnapshot).toHaveBeenCalled();
+  });
+
+  it('sends memory write requests and refreshes after success', async () => {
+    const memoryViews = createMemoryViewState();
+    const postSnapshot = vi.fn().mockResolvedValue(undefined);
+    const refreshController = createRefreshController(() => ({ views: [] }), {
+      postSnapshot,
+      onSnapshotPosted: vi.fn(),
+      onSnapshotFailed: vi.fn(),
+    });
+    const customRequest = vi.fn().mockResolvedValue(undefined);
+    const handled = await handleCommonPanelMessage(
+      { type: 'memoryEdit', address: 0x1234, value: 'AB' },
+      {
+        getSession: () => ({ type: 'z80', customRequest }),
+        refreshController,
+        autoRefreshMs: 150,
+        setActiveTab: vi.fn(),
+        getActiveTab: vi.fn(() => 'memory'),
+        isPanelVisible: vi.fn(() => true),
+        memoryViews,
+      },
+      {
+        key: 'debug80/tec1Key',
+        reset: 'debug80/tec1Reset',
+        speed: 'debug80/tec1Speed',
+        serialSend: 'debug80/tec1SerialInput',
+        registerWrite: 'debug80/registerWrite',
+        memoryWrite: 'debug80/memoryWrite',
+      }
+    );
+
+    expect(handled).toBe(true);
+    expect(customRequest).toHaveBeenCalledWith('debug80/memoryWrite', {
+      address: 0x1234,
+      value: 'AB',
+    });
+    expect(postSnapshot).toHaveBeenCalled();
+  });
+
+  it('refreshes the snapshot when memory writes are rejected', async () => {
+    const memoryViews = createMemoryViewState();
+    const postSnapshot = vi.fn().mockResolvedValue(undefined);
+    const refreshController = createRefreshController(() => ({ views: [] }), {
+      postSnapshot,
+      onSnapshotPosted: vi.fn(),
+      onSnapshotFailed: vi.fn(),
+    });
+    const customRequest = vi.fn().mockRejectedValue(new Error('running'));
+    const handled = await handleCommonPanelMessage(
+      { type: 'memoryEdit', address: 0x1234, value: 'AB' },
+      {
+        getSession: () => ({ type: 'z80', customRequest }),
+        refreshController,
+        autoRefreshMs: 150,
+        setActiveTab: vi.fn(),
+        getActiveTab: vi.fn(() => 'memory'),
+        isPanelVisible: vi.fn(() => true),
+        memoryViews,
+      },
+      {
+        key: 'debug80/tec1Key',
+        reset: 'debug80/tec1Reset',
+        speed: 'debug80/tec1Speed',
+        serialSend: 'debug80/tec1SerialInput',
+        registerWrite: 'debug80/registerWrite',
+        memoryWrite: 'debug80/memoryWrite',
+      }
+    );
+
+    expect(handled).toBe(true);
+    expect(customRequest).toHaveBeenCalledWith('debug80/memoryWrite', {
+      address: 0x1234,
+      value: 'AB',
     });
     expect(postSnapshot).toHaveBeenCalled();
   });

--- a/tests/webview/common/memory-panel.test.ts
+++ b/tests/webview/common/memory-panel.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @file Shared memory panel editing tests.
+ */
+
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MemoryPanel } from '../../../webview/common/memory-panel';
+import type { VscodeApi } from '../../../webview/common/vscode';
+
+function createElement<T extends HTMLElement>(
+  tagName: string,
+  className?: string
+): T {
+  const element = document.createElement(tagName) as T;
+  if (className !== undefined) {
+    element.className = className;
+  }
+  return element;
+}
+
+function createPanel(vscode: VscodeApi) {
+  const registerStrip = createElement<HTMLDivElement>('div');
+  const statusEl = createElement<HTMLDivElement>('div');
+  const dump = createElement<HTMLDivElement>('div');
+  const view = document.createElement('select');
+  const address = document.createElement('input');
+  const addr = createElement<HTMLSpanElement>('span');
+  const symbol = createElement<HTMLSpanElement>('span');
+
+  document.body.append(registerStrip, statusEl, dump, view, address, addr, symbol);
+
+  const panel = new MemoryPanel({
+    vscode,
+    registerStrip,
+    statusEl,
+    views: [
+      {
+        id: 'a',
+        view,
+        address,
+        addr,
+        symbol,
+        dump,
+      },
+    ],
+    getRowSize: () => 8,
+    isActive: () => true,
+  });
+
+  panel.wire();
+
+  return { panel, dump, statusEl };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('shared memory panel', () => {
+  it('renders editable byte inputs and posts plain-hex memory edits', () => {
+    const postMessage = vi.fn();
+    const { panel, dump } = createPanel({
+      postMessage,
+      getState: vi.fn(),
+      setState: vi.fn(),
+    });
+
+    panel.handleSnapshot({
+      running: false,
+      views: [
+        {
+          id: 'a',
+          address: 0x1000,
+          start: 0x1000,
+          bytes: [0x41, 0x42, 0x43, 0x44],
+          focus: 1,
+        },
+      ],
+    });
+
+    const inputs = dump.querySelectorAll<HTMLInputElement>('input.memory-byte-input');
+    expect(inputs).toHaveLength(4);
+    expect(inputs[0]?.disabled).toBe(false);
+    expect(inputs[0]?.value).toBe('41');
+
+    if (!inputs[0]) {
+      throw new Error('first memory input missing');
+    }
+
+    inputs[0].value = 'ab';
+    inputs[0].dispatchEvent(new Event('focusout', { bubbles: true }));
+
+    expect(inputs[0].value).toBe('AB');
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'memoryEdit',
+      address: 0x1000,
+      value: 'AB',
+    });
+  });
+
+  it('disables byte inputs while the runtime is running', () => {
+    const { panel, dump } = createPanel({
+      postMessage: vi.fn(),
+      getState: vi.fn(),
+      setState: vi.fn(),
+    });
+
+    panel.handleSnapshot({
+      running: true,
+      views: [
+        {
+          id: 'a',
+          address: 0x2000,
+          start: 0x2000,
+          bytes: [0x10, 0x20],
+          focus: 0,
+        },
+      ],
+    });
+
+    const inputs = dump.querySelectorAll<HTMLInputElement>('input.memory-byte-input');
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0]?.disabled).toBe(true);
+    expect(inputs[1]?.disabled).toBe(true);
+  });
+});

--- a/webview/common/memory-panel.ts
+++ b/webview/common/memory-panel.ts
@@ -42,6 +42,7 @@ type MemoryPanelOptions = {
 export class MemoryPanel {
   private readonly symbolMap = new Map<string, number>();
   private symbolsKey = '';
+  private editingEnabled = false;
 
   constructor(private readonly options: MemoryPanelOptions) {}
 
@@ -59,7 +60,37 @@ export class MemoryPanel {
         this.requestSnapshot();
       });
       entry.address?.addEventListener('change', () => this.requestSnapshot());
+      entry.dump?.addEventListener('keydown', (event) => {
+        const input = event.target;
+        if (!isMemoryByteInput(input)) {
+          return;
+        }
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          input.blur();
+        } else if (event.key === 'Escape') {
+          event.preventDefault();
+          const previousValue = input.dataset.previous ?? input.value;
+          input.value = previousValue;
+          input.blur();
+        }
+      });
+      entry.dump?.addEventListener('focusout', (event) => {
+        const input = event.target;
+        if (!isMemoryByteInput(input)) {
+          return;
+        }
+        void this.commitMemoryEdit(input);
+      });
     });
+  }
+
+  setEditingEnabled(enabled: boolean): void {
+    if (this.editingEnabled === enabled) {
+      return;
+    }
+    this.editingEnabled = enabled;
+    this.updateMemoryInputsState();
   }
 
   requestSnapshot(): void {
@@ -103,8 +134,18 @@ export class MemoryPanel {
     }
   }
 
-  handleSnapshot(payload: { symbols?: Array<{ name: string; address: number }>; registers?: RegisterData; views?: SnapshotView[] }): void {
+  handleSnapshot(
+    payload: {
+      symbols?: Array<{ name: string; address: number }>;
+      registers?: RegisterData;
+      views?: SnapshotView[];
+      running?: boolean;
+    }
+  ): void {
     this.updateSymbols(payload.symbols || []);
+    if (typeof payload.running === 'boolean') {
+      this.setEditingEnabled(!payload.running);
+    }
     if (payload.registers) {
       this.renderRegisters(payload.registers);
     }
@@ -261,7 +302,7 @@ export class MemoryPanel {
         return;
       }
       target.addr.textContent = formatHex(entry.address ?? 0, 4);
-      renderDump(target.dump, entry.start, entry.bytes, entry.focus ?? 0, rowSize);
+      renderDump(target.dump, entry.start, entry.bytes, entry.focus ?? 0, rowSize, this.editingEnabled);
       if (entry.symbol) {
         if (entry.symbolOffset) {
           const offset = entry.symbolOffset.toString(16).toUpperCase();
@@ -272,6 +313,39 @@ export class MemoryPanel {
       } else {
         target.symbol.textContent = '';
       }
+    });
+  }
+
+  private updateMemoryInputsState(): void {
+    this.options.views.forEach((entry) => {
+      entry.dump
+        ?.querySelectorAll<HTMLInputElement>('input.memory-byte-input')
+        .forEach((input) => {
+          input.disabled = !this.editingEnabled;
+        });
+    });
+  }
+
+  private commitMemoryEdit(input: HTMLInputElement): void {
+    const address = Number.parseInt(input.dataset.address ?? '', 16);
+    const previousValue = input.dataset.previous ?? input.value;
+    const value = normalizeHexInput(input.value, 2);
+    if (!Number.isFinite(address) || value === null) {
+      input.value = previousValue;
+      if (this.options.statusEl) {
+        this.options.statusEl.textContent = 'Memory edit failed';
+      }
+      return;
+    }
+    if (value === previousValue) {
+      return;
+    }
+    input.value = value;
+    input.dataset.previous = value;
+    this.options.vscode.postMessage({
+      type: 'memoryEdit',
+      address: address & 0xffff,
+      value,
     });
   }
 }
@@ -300,7 +374,8 @@ function renderDump(
   start: number,
   bytes: number[],
   focusOffset: number,
-  rowSize: number
+  rowSize: number,
+  editingEnabled: boolean
 ): void {
   let html = '';
   for (let i = 0; i < bytes.length; i += rowSize) {
@@ -311,17 +386,32 @@ function renderDump(
       const idx = i + j;
       const value = bytes[idx];
       const cls = idx === focusOffset ? 'byte focus' : 'byte';
+      const byteValue = formatByteHex(value);
       html +=
-        '<span class="' +
+        '<input class="' +
         cls +
-        '">' +
-        value.toString(16).toUpperCase().padStart(2, '0') +
-        '</span>';
+        ' memory-byte-input" type="text" spellcheck="false" autocomplete="off" inputmode="text" maxlength="2" data-address="' +
+        formatByteHex((rowAddr + j) & 0xffff, 4) +
+        '" data-previous="' +
+        byteValue +
+        '" value="' +
+        byteValue +
+        '"' +
+        (editingEnabled ? '' : ' disabled') +
+        ' />';
       ascii += value >= 32 && value <= 126 ? String.fromCharCode(value) : '.';
     }
     html += '<span class="ascii">' + ascii + '</span></div>';
   }
   el.innerHTML = html;
+}
+
+function isMemoryByteInput(target: EventTarget | null): target is HTMLInputElement {
+  return target instanceof HTMLInputElement && target.classList.contains('memory-byte-input');
+}
+
+function formatByteHex(value: number, width = 2): string {
+  return value.toString(16).toUpperCase().padStart(width, '0');
 }
 
 function parseAddress(text: string): number | undefined {

--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -457,6 +457,30 @@ body {
       width: 22px;
       text-align: center;
     }
+    #memoryPanel .memory-byte-input {
+      appearance: none;
+      border: 1px solid transparent;
+      background: transparent;
+      color: inherit;
+      font: inherit;
+      line-height: inherit;
+      padding: 0;
+      margin: 0;
+      width: 22px;
+      text-align: center;
+      border-radius: 4px;
+      text-transform: uppercase;
+    }
+    #memoryPanel .memory-byte-input:focus {
+      outline: none;
+      border-color: #7aa2f7;
+      background: rgba(122, 162, 247, 0.12);
+      box-shadow: 0 0 0 1px rgba(122, 162, 247, 0.35);
+    }
+    #memoryPanel .memory-byte-input:disabled {
+      opacity: 0.72;
+      cursor: default;
+    }
     #memoryPanel .byte.focus {
       color: #111;
       background: #ffd05c;

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -54,6 +54,7 @@ type Tec1gUpdatePayload = {
 type MemorySnapshotPayload = {
   symbols?: Array<{ name: string; address: number }>;
   registers?: Record<string, number | string | undefined>;
+  running?: boolean;
   views?: Array<{
     id: string;
     address?: number;


### PR DESCRIPTION
## Summary\n- Add inline byte editing to the shared CPU memory panel, limited to paused sessions\n- Add a narrow debug adapter memory-write request and route webview edits through it\n- Refresh snapshots after edits and disable inputs while the runtime is running\n- Add focused tests for the adapter request, panel routing, and jsdom memory-panel behavior\n\n## Verification\n- npm test\n- npm run lint