### PR TITLE
fix: rename Entry Source to Program File (#210)

### DIFF
--- a/docs/design-project-workflow.md
+++ b/docs/design-project-workflow.md
@@ -177,9 +177,9 @@ active target unless the user explicitly chooses another launch configuration.
 
 This needs a clear and rigid rule.
 
-### Rule 1: Once a project exists, the entry source is explicit
+### Rule 1: Once a project exists, the program file is explicit
 
-The active target in `debug80.json` defines the entry source via `sourceFile` or equivalent.
+The active target in `debug80.json` defines the program file via `sourceFile` or equivalent.
 
 ### Rule 2: Inference is bootstrap-only
 
@@ -202,7 +202,7 @@ Bootstrap inference order:
 
 Debug80 should provide:
 
-- `Debug80: Set Entry Source`
+- `Debug80: Set Program File`
 - `Debug80: Set Active Target`
 - `Debug80: New ASM Source`
 - `Debug80: New ZAX Source`
@@ -247,7 +247,7 @@ This state drives the UI:
 
 ### Source and entry management
 
-- `Debug80: Set Entry Source`
+- `Debug80: Set Program File`
 - `Debug80: New ASM Source`
 - `Debug80: New ZAX Source`
 - `Debug80: Reveal Project Config`
@@ -270,7 +270,7 @@ Show a compact status block:
 - current folder
 - current project state
 - active target
-- entry source
+- program file
 - platform
 
 Primary actions:
@@ -278,7 +278,7 @@ Primary actions:
 - Debug
 - Select Project
 - Select Target
-- Set Entry Source
+- Set Program File
 - New ASM Source
 - New ZAX Source
 
@@ -396,7 +396,7 @@ manually creating files first.
 ### Project-scoped state
 
 - active target name
-- last selected entry source during creation flow if not yet committed
+- last selected program file during creation flow if not yet committed
 
 The durable source of truth should still be the project config. Remembered state is a
 convenience layer only.
@@ -413,7 +413,7 @@ convenience layer only.
 4. Debug80 asks for platform.
 5. Debug80 asks whether to create ASM or ZAX starter.
 6. Debug80 creates folder, source file, project config, and launch config.
-7. Debug80 opens the starter file and marks it as entry source.
+7. Debug80 opens the starter file and marks it as the program file.
 8. User presses `F5`.
 
 ### Flow B: Add Debug80 to an existing source folder
@@ -421,7 +421,7 @@ convenience layer only.
 1. User opens a folder containing `asm` or `zax` files.
 2. Debug80 detects source-only state.
 3. Debug80 offers `Create Project`.
-4. Debug80 proposes an inferred entry source or asks the user to choose one.
+4. Debug80 proposes an inferred program file or asks the user to choose one.
 5. Debug80 creates config and launch.
 6. `F5` debugs the created target.
 
@@ -457,12 +457,12 @@ convenience layer only.
 - Add platform selection.
 - Add source language selection.
 - Add starter-file creation.
-- Ask for entry source only when inference is ambiguous.
+- Ask for program file only when inference is ambiguous.
 
 ### Phase 4: Add target and entry management
 
 - Add `Select Active Target`.
-- Add `Set Entry Source`.
+- Add `Set Program File`.
 - Persist project and target selection.
 
 ### Phase 5: Align `F5` with Debug80 context

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
       },
       {
         "command": "debug80.setEntrySource",
-        "title": "Debug80: Set Entry Source"
+        "title": "Debug80: Set Program File"
       },
       {
         "command": "debug80.openRomSource",

--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -417,10 +417,10 @@ export function registerExtensionCommands({
           await vscode.window.showQuickPick(
             candidates.map((candidate) => ({
               label: candidate,
-              ...(candidate === currentSource ? { description: 'current entry source' } : {}),
+              ...(candidate === currentSource ? { description: 'current program file' } : {}),
             })),
             {
-              placeHolder: 'Select the entry source for the active Debug80 target',
+              placeHolder: 'Select the program file for the active Debug80 target',
               matchOnDescription: true,
             }
           )
@@ -432,13 +432,13 @@ export function registerExtensionCommands({
 
       const updated = updateProjectTargetSource(projectConfig, target, picked);
       if (!updated) {
-        void vscode.window.showErrorMessage('Debug80: Failed to update the project entry source.');
+        void vscode.window.showErrorMessage('Debug80: Failed to update the project program file.');
         return undefined;
       }
 
       platformViewProvider.refreshIdleView();
       void vscode.window.showInformationMessage(
-        `Debug80: Set ${target} entry source to ${picked}.`
+        `Debug80: Set ${target} program file to ${picked}.`
       );
       return picked;
     })

--- a/src/extension/platform-view-idle-html.ts
+++ b/src/extension/platform-view-idle-html.ts
@@ -72,7 +72,7 @@ export function getPlatformViewIdleHtml(options: {
   const statusRows = [
     options.projectName !== undefined ? `<p style="margin: 6px 0 0; opacity: 0.85;">Root: ${options.projectName}</p>` : '',
     options.targetName !== undefined ? `<p style="margin: 4px 0 0; opacity: 0.85;">Target: ${options.targetName}</p>` : '',
-    options.entrySource !== undefined ? `<p style="margin: 4px 0 0; opacity: 0.85;">Entry: ${options.entrySource}</p>` : '',
+    options.entrySource !== undefined ? `<p style="margin: 4px 0 0; opacity: 0.85;">Program: ${options.entrySource}</p>` : '',
   ]
     .filter((row) => row.length > 0)
     .join('');

--- a/src/extension/project-config.ts
+++ b/src/extension/project-config.ts
@@ -41,7 +41,7 @@ export function readProjectConfig(projectConfigPath: string): ProjectConfig | un
 /**
  * Merged launch args resolve the assemble input as `asm` before `sourceFile`
  * (see `populateFromConfig` in launch-args). Keep both in sync when the user
- * picks a new entry source so ZAX (and asm80) targets assemble the selected file.
+ * picks a new program file so ZAX (and asm80) targets assemble the selected file.
  */
 function nextTargetEntrySource(
   target: Record<string, unknown>,

--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -238,7 +238,7 @@ async function chooseEntrySource(
     placeHolder:
       sourceFiles.length === 0
         ? 'Create a starter source file for this Debug80 project'
-        : 'Choose the entry source for this Debug80 project',
+        : 'Choose the program file for this Debug80 project',
     matchOnDescription: true,
   });
   return picked?.choice;

--- a/src/extension/project-target-selection.ts
+++ b/src/extension/project-target-selection.ts
@@ -239,7 +239,7 @@ export class ProjectTargetSelectionController {
     if (picked.applyEntrySource !== undefined) {
       const ok = updateProjectTargetSource(projectConfigPath, picked.targetName, picked.applyEntrySource);
       if (!ok) {
-        void vscode.window.showErrorMessage('Debug80: Failed to update the project entry source.');
+        void vscode.window.showErrorMessage('Debug80: Failed to update the project program file.');
         return null;
       }
       this.rememberTarget(projectConfigPath, picked.targetName);

--- a/tests/extension/platform-view-idle-html.test.ts
+++ b/tests/extension/platform-view-idle-html.test.ts
@@ -37,11 +37,11 @@ describe('platform-view idle html', () => {
     expect(html).toContain('Configured root detected (Workspace).');
     expect(html).toContain('Root: caverns80');
     expect(html).toContain('Target: app');
-    expect(html).toContain('Entry: src/main.asm');
+    expect(html).toContain('Program: src/main.asm');
     expect(html).toContain('Start Debugging');
     expect(html).toContain('Select Root');
     expect(html).not.toContain('Select Target');
-    expect(html).not.toContain('Set Entry Source');
+    expect(html).not.toContain('Set Program File');
     expect(html).toContain('open the Home tab for project controls');
     expect(html).toContain("script-src 'nonce-xyz789'");
     expect(html).toContain('Select a workspace root with');

--- a/tests/extension/project-config.test.ts
+++ b/tests/extension/project-config.test.ts
@@ -78,7 +78,7 @@ describe('project-config helpers', () => {
     expect(pkg.debug80?.targets?.app?.assembler).toBe('zax');
   });
 
-  it('sets assembler to zax when entry source is .zax and syncs asm', () => {
+  it('sets assembler to zax when program file is .zax and syncs asm', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-zax-entry-'));
     const configPath = path.join(root, 'debug80.json');
     fs.writeFileSync(

--- a/tests/extension/project-status.test.ts
+++ b/tests/extension/project-status.test.ts
@@ -7,7 +7,7 @@ import { resolveProjectStatusSummary } from '../../src/extension/project-status'
 vi.mock('vscode', () => ({}));
 
 describe('project-status', () => {
-  it('resolves the selected project target and entry source', () => {
+  it('resolves the selected project target and program file', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-project-status-'));
     fs.mkdirSync(path.join(root, '.vscode'), { recursive: true });
     fs.writeFileSync(

--- a/tests/platforms/tec1/ui-panel-html.test.ts
+++ b/tests/platforms/tec1/ui-panel-html.test.ts
@@ -41,7 +41,7 @@ describe('tec1 ui-panel-html', () => {
     expect(html).toContain('homeRootSelect');
     expect(html).toContain('homeTargetSelect');
     expect(html).toContain('Quick Pick');
-    expect(html).toContain('Set Entry Source');
+    expect(html).toContain('Set Program File');
     expect(html).toContain('panel-ui');
     expect(html).toContain('panel-memory');
     expect(html).toContain('LCD (HD44780 A00)');

--- a/tests/platforms/tec1g/ui-panel-html.test.ts
+++ b/tests/platforms/tec1g/ui-panel-html.test.ts
@@ -41,7 +41,7 @@ describe('tec1g ui-panel-html', () => {
     expect(html).toContain('homeRootSelect');
     expect(html).toContain('homeTargetSelect');
     expect(html).toContain('Quick Pick');
-    expect(html).toContain('Set Entry Source');
+    expect(html).toContain('Set Program File');
     expect(html).toContain('panel-ui');
     expect(html).toContain('panel-memory');
     expect(html).toContain('LCD (HD44780 A00)');

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -48,13 +48,13 @@
               <span class="home-value" id="homeTargetName">No target selected</span>
             </div>
             <div class="home-status-row">
-              <span class="home-label">Entry</span>
-              <span class="home-value" id="homeEntrySource">No entry source selected</span>
+              <span class="home-label">Program</span>
+              <span class="home-value" id="homeEntrySource">No program file selected</span>
             </div>
           </div>
         </div>
         <div class="home-actions">
-          <button class="session-button" id="setEntrySource">Set Entry Source</button>
+          <button class="session-button" id="setEntrySource" title="Sets the program file for the active target">Set Program File</button>
         </div>
         <p class="home-note">
           Debug80 follows workspace roots. Use the selectors above to switch roots and targets directly, or use Quick Pick when you need the full picker flow.

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -197,7 +197,7 @@ function applyProjectStatus(payload: {
     payload.rootName ? 'No Debug80 project in this root' : 'No root selected'
   );
   setHomeValue(homeTargetName, payload.targetName, 'No target selected');
-  setHomeValue(homeEntrySource, payload.entrySource, 'No entry source selected');
+  setHomeValue(homeEntrySource, payload.entrySource, 'No program file selected');
 }
 
 applyProjectStatus({});

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -48,13 +48,13 @@
               <span class="home-value" id="homeTargetName">No target selected</span>
             </div>
             <div class="home-status-row">
-              <span class="home-label">Entry</span>
-              <span class="home-value" id="homeEntrySource">No entry source selected</span>
+              <span class="home-label">Program</span>
+              <span class="home-value" id="homeEntrySource">No program file selected</span>
             </div>
           </div>
         </div>
         <div class="home-actions">
-          <button class="session-button" id="setEntrySource">Set Entry Source</button>
+          <button class="session-button" id="setEntrySource" title="Sets the program file for the active target">Set Program File</button>
         </div>
         <p class="home-note">
           Debug80 follows workspace roots. Use the selectors above to switch roots and targets directly, or use Quick Pick when you need the full picker flow.

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -373,7 +373,7 @@ function applyProjectStatus(payload: {
     payload.rootName ? 'No Debug80 project in this root' : 'No root selected'
   );
   setHomeValue(homeTargetName, payload.targetName, 'No target selected');
-  setHomeValue(homeEntrySource, payload.entrySource, 'No entry source selected');
+  setHomeValue(homeEntrySource, payload.entrySource, 'No program file selected');
 }
 
 applyProjectStatus({});


### PR DESCRIPTION
## Summary
- Renames all user-facing occurrences of "Entry Source" to "Program File" across commands, webview HTML, idle view, status labels, and documentation
- Adds tooltips to the "Set Program File" buttons in both TEC-1 and TEC-1G Home tabs explaining that it sets the program file for the active target
- Internal variable names (`entrySource`, `setEntrySource`, etc.) are left unchanged to avoid a large refactor

## Test plan
- [x] All 660 existing tests pass (93 test files)
- [ ] Verify command palette shows "Debug80: Set Program File"
- [ ] Verify Home tab in TEC-1 and TEC-1G panels shows "Program" label and "Set Program File" button
- [ ] Verify idle view shows "Program: <filename>" instead of "Entry: <filename>"
- [ ] Verify QuickPick placeholder says "program file" instead of "entry source"

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)