### PR TITLE
feat(debug): DAP setVariable for Registers scope (#205)

### DIFF
--- a/src/debug/adapter-request-controller.ts
+++ b/src/debug/adapter-request-controller.ts
@@ -23,6 +23,10 @@ import type { VariableService } from './variable-service';
 import type { SessionStateShape } from './session-state';
 import type { PlatformRegistry } from './platform-registry';
 import { ADDR_MASK } from '../platforms/tec-common';
+import {
+  tryWriteRegisterByKey,
+  writableRegisterKeyFromVariableName,
+} from './register-request';
 
 export interface AdapterRequestControllerDeps {
   threadId: number;
@@ -302,6 +306,40 @@ export class AdapterRequestController {
       ),
     };
 
+    this.deps.sendResponse(response);
+  }
+
+  public setVariableRequest(
+    response: DebugProtocol.SetVariableResponse,
+    args: DebugProtocol.SetVariableArguments
+  ): void {
+    if (!this.deps.variableService.isRegistersVariablesReference(args.variablesReference)) {
+      this.deps.sendErrorResponse(response, 1, 'Debug80: This variable cannot be edited here.');
+      return;
+    }
+
+    const registerKey = writableRegisterKeyFromVariableName(args.name);
+    if (registerKey === null) {
+      this.deps.sendErrorResponse(
+        response,
+        1,
+        'Debug80: This register is read-only or not recognized.'
+      );
+      return;
+    }
+
+    const err = tryWriteRegisterByKey(this.deps.sessionState, registerKey, args.value);
+    if (err !== null) {
+      this.deps.sendErrorResponse(response, 1, err);
+      return;
+    }
+
+    const runtime = this.deps.sessionState.runtime;
+    const variables = this.deps.variableService.resolveVariables(args.variablesReference, runtime);
+    const updated = variables.find((v) => v.name === args.name);
+    response.body = {
+      value: updated?.value ?? String(args.value),
+    };
     this.deps.sendResponse(response);
   }
 

--- a/src/debug/adapter.ts
+++ b/src/debug/adapter.ts
@@ -189,6 +189,7 @@ export class Z80DebugSession extends DebugSession {
     response.body = response.body ?? {};
     response.body.supportsConfigurationDoneRequest = true;
     response.body.supportsSingleThreadExecutionRequests = true;
+    response.body.supportsSetVariable = true;
 
     this.sendResponse(response);
     this.sendEvent(new InitializedEvent());
@@ -384,6 +385,13 @@ export class Z80DebugSession extends DebugSession {
     args: DebugProtocol.VariablesArguments
   ): void {
     this.requestController.variablesRequest(response, args);
+  }
+
+  protected setVariableRequest(
+    response: DebugProtocol.SetVariableResponse,
+    args: DebugProtocol.SetVariableArguments
+  ): void {
+    this.requestController.setVariableRequest(response, args);
   }
 
   protected disconnectRequest(

--- a/src/debug/register-request.ts
+++ b/src/debug/register-request.ts
@@ -13,19 +13,99 @@ type RegisterWriteArgs = {
 
 const WRITABLE_REGISTERS = new Set(['bc', 'de', 'hl', 'bcp', 'dep', 'hlp', 'ix', 'iy', 'pc', 'sp']);
 
-function parseHexValue(value: unknown): number | null {
+/** Parses hex for register writes; accepts plain hex or `0x` / `0X` prefixed values. */
+export function parseHexValue(value: unknown): number | null {
   if (typeof value !== 'string') {
     return null;
   }
-  const trimmed = value.trim();
-  if (trimmed.length === 0 || trimmed.startsWith('0x') || trimmed.startsWith('0X')) {
+  let trimmed = value.trim();
+  if (trimmed.length === 0) {
     return null;
   }
-  if (!/^[0-9a-fA-F]+$/.test(trimmed)) {
+  if (trimmed.startsWith('0x') || trimmed.startsWith('0X')) {
+    trimmed = trimmed.slice(2).trim();
+  }
+  if (trimmed.length === 0 || !/^[0-9a-fA-F]+$/.test(trimmed)) {
     return null;
   }
   const parsed = Number.parseInt(trimmed, 16);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeRegisterVariableQuotes(name: string): string {
+  return name.trim().replace(/\u2032/g, "'").replace(/\u2019/g, "'");
+}
+
+/**
+ * Maps a Registers-scope variable `name` (as shown in the Variables UI) to a
+ * writable register key, or `null` if the name is unknown or read-only.
+ */
+export function writableRegisterKeyFromVariableName(variableName: string): string | null {
+  const n = normalizeRegisterVariableQuotes(variableName);
+  const lower = n.toLowerCase();
+  const prime = lower.endsWith("'");
+  const base = prime ? lower.slice(0, -1) : lower;
+
+  if (prime) {
+    if (base === 'bc') {
+      return 'bcp';
+    }
+    if (base === 'de') {
+      return 'dep';
+    }
+    if (base === 'hl') {
+      return 'hlp';
+    }
+    return null;
+  }
+
+  if (base === 'pc') {
+    return 'pc';
+  }
+  if (base === 'sp') {
+    return 'sp';
+  }
+  if (base === 'bc') {
+    return 'bc';
+  }
+  if (base === 'de') {
+    return 'de';
+  }
+  if (base === 'hl') {
+    return 'hl';
+  }
+  if (base === 'ix') {
+    return 'ix';
+  }
+  if (base === 'iy') {
+    return 'iy';
+  }
+  return null;
+}
+
+export function tryWriteRegisterByKey(
+  sessionState: SessionStateShape,
+  registerKey: string,
+  value: unknown
+): string | null {
+  if (sessionState.runtime === undefined) {
+    return 'Debug80: No program loaded.';
+  }
+  if (sessionState.runState.isRunning) {
+    return 'Debug80: Registers can only be edited while paused.';
+  }
+  if (!WRITABLE_REGISTERS.has(registerKey)) {
+    return 'Debug80: Unsupported register.';
+  }
+
+  const parsed = parseHexValue(value);
+  if (parsed === null) {
+    return 'Debug80: Invalid hex value.';
+  }
+
+  const cpu = sessionState.runtime.getRegisters();
+  setRegisterPair(cpu, registerKey, parsed);
+  return null;
 }
 
 function setRegisterPair(cpu: Cpu, name: string, value: number): void {
@@ -75,12 +155,6 @@ export function handleRegisterWriteRequest(
   sessionState: SessionStateShape,
   args: unknown
 ): string | null {
-  if (sessionState.runtime === undefined) {
-    return 'Debug80: No program loaded.';
-  }
-  if (sessionState.runState.isRunning) {
-    return 'Debug80: Registers can only be edited while paused.';
-  }
   if (args === null || typeof args !== 'object') {
     return 'Debug80: Invalid register write request.';
   }
@@ -91,14 +165,7 @@ export function handleRegisterWriteRequest(
     return 'Debug80: Unsupported register.';
   }
 
-  const value = parseHexValue(payload.value);
-  if (value === null) {
-    return 'Debug80: Invalid hex value.';
-  }
-
-  const cpu = sessionState.runtime.getRegisters();
-  setRegisterPair(cpu, register, value);
-  return null;
+  return tryWriteRegisterByKey(sessionState, register, payload.value);
 }
 
 export function sendRegisterWriteResponse(

--- a/src/debug/variable-service.ts
+++ b/src/debug/variable-service.ts
@@ -15,11 +15,19 @@ type RegisterRuntime = {
  * Builds variable scopes and register variables.
  */
 export class VariableService {
+  private registersScopeRef: number | undefined;
+
   constructor(private readonly variableHandles: Handles<string>) {}
 
   createScopes(): DebugProtocol.Scope[] {
-    const registersRef = this.variableHandles.create('registers');
-    return [new Scope('Registers', registersRef, false)];
+    if (this.registersScopeRef === undefined) {
+      this.registersScopeRef = this.variableHandles.create('registers');
+    }
+    return [new Scope('Registers', this.registersScopeRef, false)];
+  }
+
+  isRegistersVariablesReference(variablesReference: number): boolean {
+    return this.variableHandles.get(variablesReference) === 'registers';
   }
 
   resolveVariables(
@@ -44,17 +52,34 @@ export class VariableService {
     const dep = ((regs.d_prime & 0xff) << 8) | (regs.e_prime & 0xff);
     const hlp = ((regs.h_prime & 0xff) << 8) | (regs.l_prime & 0xff);
 
+    const readOnly = { attributes: ['readOnly' as const] };
+
     return [
-      { name: 'Flags', value: this.flagsToString(regs.flags), variablesReference: 0 },
+      {
+        name: 'Flags',
+        value: this.flagsToString(regs.flags),
+        variablesReference: 0,
+        presentationHint: readOnly,
+      },
       { name: 'PC', value: this.format16(runtime.getPC()), variablesReference: 0 },
       { name: 'SP', value: this.format16(regs.sp), variablesReference: 0 },
 
-      { name: 'AF', value: this.format16(af), variablesReference: 0 },
+      {
+        name: 'AF',
+        value: this.format16(af),
+        variablesReference: 0,
+        presentationHint: readOnly,
+      },
       { name: 'BC', value: this.format16(bc), variablesReference: 0 },
       { name: 'DE', value: this.format16(de), variablesReference: 0 },
       { name: 'HL', value: this.format16(hl), variablesReference: 0 },
 
-      { name: "AF'", value: this.format16(afp), variablesReference: 0 },
+      {
+        name: "AF'",
+        value: this.format16(afp),
+        variablesReference: 0,
+        presentationHint: readOnly,
+      },
       { name: "BC'", value: this.format16(bcp), variablesReference: 0 },
       { name: "DE'", value: this.format16(dep), variablesReference: 0 },
       { name: "HL'", value: this.format16(hlp), variablesReference: 0 },
@@ -62,8 +87,18 @@ export class VariableService {
       { name: 'IX', value: this.format16(regs.ix), variablesReference: 0 },
       { name: 'IY', value: this.format16(regs.iy), variablesReference: 0 },
 
-      { name: 'I', value: this.format8(regs.i), variablesReference: 0 },
-      { name: 'R', value: this.format8(regs.r), variablesReference: 0 },
+      {
+        name: 'I',
+        value: this.format8(regs.i),
+        variablesReference: 0,
+        presentationHint: readOnly,
+      },
+      {
+        name: 'R',
+        value: this.format8(regs.r),
+        variablesReference: 0,
+        presentationHint: readOnly,
+      },
     ];
   }
 

--- a/tests/debug/adapter-integration.test.ts
+++ b/tests/debug/adapter-integration.test.ts
@@ -95,6 +95,22 @@ describe('adapter integration', () => {
     harness = undefined;
   });
 
+  it('initialize response advertises setVariable for native register editing', async () => {
+    const { client } = harness ?? createHarness();
+    const initResp = await client.sendRequest<{ body?: { supportsSetVariable?: boolean } }>(
+      'initialize',
+      {
+        adapterID: 'z80',
+        pathFormat: 'path',
+        linesStartAt1: true,
+        columnsStartAt1: true,
+      }
+    );
+    expect(initResp.body?.supportsSetVariable).toBe(true);
+    await client.waitForEvent('initialized');
+    await client.sendRequest('disconnect');
+  });
+
   it('launches from discovered workspace config when projectConfig is omitted', async () => {
     const { client } = harness ?? createHarness();
 

--- a/tests/debug/adapter-request-controller.test.ts
+++ b/tests/debug/adapter-request-controller.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('vscode', () => ({}));
 
+import { Handles } from '@vscode/debugadapter';
 import { AdapterRequestController } from '../../src/debug/adapter-request-controller';
 import { createSessionState } from '../../src/debug/session-state';
 import * as runtimeControl from '../../src/debug/runtime-control';
+import { VariableService } from '../../src/debug/variable-service';
+import { createZ80Runtime } from '../../src/z80/runtime';
 
 function createController() {
   const sessionState = createSessionState();
@@ -94,5 +97,98 @@ describe('adapter-request-controller startup sequencing', () => {
     controller.startConfiguredExecutionIfReady();
 
     expect(runUntilStopSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('AdapterRequestController setVariableRequest', () => {
+  it('updates a writable register and returns the formatted value', () => {
+    const sessionState = createSessionState();
+    sessionState.runtime = createZ80Runtime({
+      memory: new Uint8Array(0x10000),
+      startAddress: 0,
+    });
+    sessionState.runState.isRunning = false;
+
+    const handles = new Handles<string>();
+    const variableService = new VariableService(handles);
+    const registersRef = variableService.createScopes()[0]?.variablesReference ?? 0;
+
+    const deps = {
+      threadId: 1,
+      breakpointManager: {
+        setPending: vi.fn(),
+        applyForSource: vi.fn(),
+        rebuild: vi.fn(),
+        hasAddress: vi.fn(() => false),
+      },
+      sourceState: {} as never,
+      sessionState,
+      platformState: { active: 'simple' },
+      variableService,
+      commandRouter: { handle: vi.fn(() => false) } as never,
+      platformRegistry: { clear: vi.fn(), getHandler: vi.fn() } as never,
+      sendResponse: vi.fn(),
+      sendErrorResponse: vi.fn(),
+      sendEvent: vi.fn(),
+      getRuntimeControlContext: vi.fn(),
+    };
+
+    const controller = new AdapterRequestController(deps as never);
+    controller.setVariableRequest({} as never, {
+      variablesReference: registersRef,
+      name: 'DE',
+      value: '0x0102',
+    });
+
+    expect(deps.sendErrorResponse).not.toHaveBeenCalled();
+    expect(deps.sendResponse).toHaveBeenCalledTimes(1);
+    const responseArg = deps.sendResponse.mock.calls[0]?.[0] as { body?: { value?: string } };
+    expect(responseArg.body?.value).toBe('0x0102');
+    const cpu = sessionState.runtime.getRegisters();
+    expect(cpu.d).toBe(0x01);
+    expect(cpu.e).toBe(0x02);
+  });
+
+  it('rejects setVariable for read-only register names', () => {
+    const sessionState = createSessionState();
+    sessionState.runtime = createZ80Runtime({
+      memory: new Uint8Array(0x10000),
+      startAddress: 0,
+    });
+    sessionState.runState.isRunning = false;
+
+    const handles = new Handles<string>();
+    const variableService = new VariableService(handles);
+    const registersRef = variableService.createScopes()[0]?.variablesReference ?? 0;
+
+    const deps = {
+      threadId: 1,
+      breakpointManager: {
+        setPending: vi.fn(),
+        applyForSource: vi.fn(),
+        rebuild: vi.fn(),
+        hasAddress: vi.fn(() => false),
+      },
+      sourceState: {} as never,
+      sessionState,
+      platformState: { active: 'simple' },
+      variableService,
+      commandRouter: { handle: vi.fn(() => false) } as never,
+      platformRegistry: { clear: vi.fn(), getHandler: vi.fn() } as never,
+      sendResponse: vi.fn(),
+      sendErrorResponse: vi.fn(),
+      sendEvent: vi.fn(),
+      getRuntimeControlContext: vi.fn(),
+    };
+
+    const controller = new AdapterRequestController(deps as never);
+    controller.setVariableRequest({} as never, {
+      variablesReference: registersRef,
+      name: 'AF',
+      value: '0x0000',
+    });
+
+    expect(deps.sendResponse).not.toHaveBeenCalled();
+    expect(deps.sendErrorResponse).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/debug/register-request.test.ts
+++ b/tests/debug/register-request.test.ts
@@ -4,7 +4,11 @@
 
 import { describe, expect, it } from 'vitest';
 import { createSessionState } from '../../src/debug/session-state';
-import { handleRegisterWriteRequest } from '../../src/debug/register-request';
+import {
+  handleRegisterWriteRequest,
+  parseHexValue,
+  writableRegisterKeyFromVariableName,
+} from '../../src/debug/register-request';
 import { createZ80Runtime } from '../../src/z80/runtime';
 
 describe('register-request', () => {
@@ -41,5 +45,38 @@ describe('register-request', () => {
     });
 
     expect(error).toBe('Debug80: Registers can only be edited while paused.');
+  });
+
+  it('accepts 0x-prefixed hex values for custom register writes', () => {
+    const sessionState = createSessionState();
+    sessionState.runtime = createZ80Runtime({
+      memory: new Uint8Array(0x10000),
+      startAddress: 0,
+    });
+    sessionState.runState.isRunning = false;
+
+    const error = handleRegisterWriteRequest(sessionState, {
+      register: 'hl',
+      value: '0x4243',
+    });
+
+    expect(error).toBeNull();
+    const cpu = sessionState.runtime.getRegisters();
+    expect(cpu.h).toBe(0x42);
+    expect(cpu.l).toBe(0x43);
+  });
+
+  it('maps Registers UI names to writable keys', () => {
+    expect(writableRegisterKeyFromVariableName('BC')).toBe('bc');
+    expect(writableRegisterKeyFromVariableName("BC'")).toBe('bcp');
+    expect(writableRegisterKeyFromVariableName('IX')).toBe('ix');
+    expect(writableRegisterKeyFromVariableName('AF')).toBeNull();
+    expect(writableRegisterKeyFromVariableName("AF'")).toBeNull();
+  });
+
+  it('parses hex with optional 0x prefix', () => {
+    expect(parseHexValue('0x10')).toBe(0x10);
+    expect(parseHexValue('ff')).toBe(0xff);
+    expect(parseHexValue('0Xabcd')).toBe(0xabcd);
   });
 });

--- a/tests/debug/variable-service.test.ts
+++ b/tests/debug/variable-service.test.ts
@@ -75,4 +75,14 @@ describe('VariableService', () => {
     const variables = service.resolveVariables(999, undefined);
     expect(variables).toEqual([]);
   });
+
+  it('reuses the same Registers scope variablesReference across scope requests', () => {
+    const handles = new Handles<string>();
+    const service = new VariableService(handles);
+    const ref1 = service.createScopes()[0]?.variablesReference ?? 0;
+    const ref2 = service.createScopes()[0]?.variablesReference ?? 0;
+    expect(ref2).toBe(ref1);
+    expect(service.isRegistersVariablesReference(ref1)).toBe(true);
+    expect(service.isRegistersVariablesReference(ref1 + 1)).toBe(false);
+  });
 });


### PR DESCRIPTION
Implements native VS Code Variables / Registers editing while paused via DAP `setVariable`.

- `supportsSetVariable: true` and `setVariableRequest` for the Registers scope only
- Maps UI names (BC, DE', etc.) to the same writable keys as `debug80/registerWrite`
- `parseHexValue` accepts `0x` prefixes; stable Registers `variablesReference`
- Read-only hints for Flags, AF, AF', I, R

Closes #205

Made with [Cursor](https://cursor.com)