### PR TITLE
Simplify the home panel project selection flow

### DIFF
--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -231,33 +231,6 @@ export function registerExtensionCommands({
 
         workspaceSelection.rememberWorkspace(folder);
         platformViewProvider.refreshIdleView();
-
-        const projectConfig = findProjectConfigPath(folder);
-        if (projectConfig === undefined) {
-          void vscode.window.showInformationMessage(
-            `Debug80: Selected root ${folder.name}. This root does not contain a Debug80 project config.`
-          );
-          return folder;
-        }
-
-        const activeSession = vscode.debug.activeDebugSession;
-        if (activeSession?.type === 'z80') {
-          await vscode.debug.stopDebugging(activeSession);
-          const restarted = await startCurrentProjectDebugging(folder, workspaceSelection);
-          if (restarted) {
-            void vscode.window.showInformationMessage(
-              `Debug80: Switched to root ${folder.name} and restarted debugging.`
-            );
-          }
-          return folder;
-        }
-
-        const started = await startCurrentProjectDebugging(folder, workspaceSelection);
-        if (started) {
-          void vscode.window.showInformationMessage(
-            `Debug80: Selected root ${folder.name} and started debugging.`
-          );
-        }
         return folder;
       }
     )

--- a/src/extension/platform-view-idle-html.ts
+++ b/src/extension/platform-view-idle-html.ts
@@ -27,6 +27,7 @@ export function getPlatformViewIdleHtml(options: {
   nonce?: string;
 }): string {
   const nonce = options.nonce ?? createPlatformViewNonce();
+  void nonce;
 
   if (!options.hasProject) {
     return `<!DOCTYPE html>
@@ -34,31 +35,12 @@ export function getPlatformViewIdleHtml(options: {
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+        content="default-src 'none'; style-src 'unsafe-inline';">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body style="padding: 16px; font-family: var(--vscode-font-family); color: var(--vscode-foreground);">
   <p>Debug80</p>
-  <p style="opacity: 0.7;">Create or select a Debug80 project root to get started.</p>
-  <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px;">
-    <button id="createProject" style="padding: 6px 10px; font-size: 12px;">Create Project</button>
-    <button id="selectProject" style="padding: 6px 10px; font-size: 12px;">Select Root</button>
-  </div>
-  <script nonce="${nonce}">
-    (function () {
-      const vscode = acquireVsCodeApi();
-      const bind = (id, type) => {
-        const button = document.getElementById(id);
-        if (button) {
-          button.addEventListener('click', () => {
-            vscode.postMessage({ type });
-          });
-        }
-      };
-      bind('createProject', 'createProject');
-      bind('selectProject', 'selectProject');
-    }());
-  </script>
+  <p style="opacity: 0.7;">Open the Home tab to select a project root and target.</p>
 </body>
 </html>`;
   }
@@ -82,33 +64,14 @@ export function getPlatformViewIdleHtml(options: {
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+        content="default-src 'none'; style-src 'unsafe-inline';">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body style="padding: 16px; font-family: var(--vscode-font-family); color: var(--vscode-foreground);">
   <p>Debug80</p>
-  <p style="opacity: 0.7;">Configured root detected (${selectedLabel}). Use Start Debugging or open the Home tab for project controls.</p>
+  <p style="opacity: 0.7;">Configured root detected (${selectedLabel}). Open the Home tab to review the selected root and target.</p>
   ${statusRows}
-  <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px;">
-    <button id="startDebug" style="padding: 6px 10px; font-size: 12px;">Start Debugging</button>
-    <button id="selectProject" style="padding: 6px 10px; font-size: 12px;">Select Root</button>
-  </div>
   ${selectionHint ? `<p style="opacity: 0.7;">${selectionHint}</p>` : ''}
-  <script nonce="${nonce}">
-    (function () {
-      const vscode = acquireVsCodeApi();
-      const bind = (id, type) => {
-        const button = document.getElementById(id);
-        if (button) {
-          button.addEventListener('click', () => {
-            vscode.postMessage({ type });
-          });
-        }
-      };
-      bind('startDebug', 'startDebug');
-      bind('selectProject', 'selectProject');
-    }());
-  </script>
 </body>
 </html>`;
 }

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -149,7 +149,7 @@ describe('registerExtensionCommands', () => {
     });
   });
 
-  it('selects a configured root and starts debugging immediately', async () => {
+  it('selects a configured root without starting debugging', async () => {
     const { registerExtensionCommands } = await import('../../src/extension/commands');
 
     const folder = {
@@ -159,10 +159,11 @@ describe('registerExtensionCommands', () => {
     };
     const selectWorkspaceFolder = vi.fn().mockResolvedValue(folder);
     const rememberWorkspace = vi.fn();
+    const refreshIdleView = vi.fn();
 
     registerExtensionCommands({
       context: { subscriptions: [] } as never,
-      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      platformViewProvider: { refreshIdleView } as never,
       sourceColumns: {} as never,
       terminalPanel: {} as never,
       workspaceSelection: {
@@ -176,20 +177,12 @@ describe('registerExtensionCommands', () => {
     const selectRoot = registeredCommands.get('debug80.selectWorkspaceFolder');
     expect(selectRoot).toBeTypeOf('function');
 
-    startDebugging.mockResolvedValueOnce(true);
     const result = await selectRoot?.();
 
     expect(result).toEqual(folder);
-    expect(startDebugging).toHaveBeenCalledWith(
-      expect.objectContaining({ uri: { fsPath: '/workspace/tec1g-mon3' } }),
-      expect.objectContaining({
-        type: 'z80',
-        request: 'launch',
-        projectConfig: projectConfigPath,
-        stopOnEntry: false,
-      })
-    );
     expect(rememberWorkspace).toHaveBeenCalledWith(folder);
+    expect(refreshIdleView).toHaveBeenCalled();
+    expect(startDebugging).not.toHaveBeenCalled();
   });
 
   it('uses a direct root selection without prompting', async () => {
@@ -201,9 +194,10 @@ describe('registerExtensionCommands', () => {
       index: 0,
     };
 
+    const refreshIdleView = vi.fn();
     registerExtensionCommands({
       context: { subscriptions: [] } as never,
-      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      platformViewProvider: { refreshIdleView } as never,
       sourceColumns: {} as never,
       terminalPanel: {} as never,
       workspaceState: { get: vi.fn(() => undefined), update: vi.fn() },
@@ -218,20 +212,11 @@ describe('registerExtensionCommands', () => {
     const selectRoot = registeredCommands.get('debug80.selectWorkspaceFolder');
     expect(selectRoot).toBeTypeOf('function');
 
-    startDebugging.mockResolvedValueOnce(true);
     const result = await selectRoot?.({ rootPath: folder.uri.fsPath });
 
     expect(result).toEqual(folder);
-    expect(startDebugging).toHaveBeenCalled();
-    expect(startDebugging).toHaveBeenCalledWith(
-      expect.objectContaining({ uri: { fsPath: '/workspace/tec1g-mon3' } }),
-      expect.objectContaining({
-        type: 'z80',
-        request: 'launch',
-        projectConfig: projectConfigPath,
-        stopOnEntry: false,
-      })
-    );
+    expect(refreshIdleView).toHaveBeenCalled();
+    expect(startDebugging).not.toHaveBeenCalled();
   });
 
   it('remembers a direct root selection even when no project config exists', async () => {

--- a/tests/extension/platform-view-idle-html.test.ts
+++ b/tests/extension/platform-view-idle-html.test.ts
@@ -17,10 +17,10 @@ describe('platform-view idle html', () => {
       multiRoot: false,
     });
 
-    expect(html).toContain('Create or select a Debug80 project root to get started.');
-    expect(html).toContain('Create Project');
-    expect(html).toContain('Select Root');
-    expect(html).toContain("script-src 'nonce-abc123'");
+    expect(html).toContain('Open the Home tab to select a project root and target.');
+    expect(html).not.toContain('Create Project');
+    expect(html).not.toContain('Select Root');
+    expect(html).not.toContain("script-src 'nonce-abc123'");
     expect(html).not.toContain('Start Debugging');
   });
 
@@ -38,12 +38,12 @@ describe('platform-view idle html', () => {
     expect(html).toContain('Root: caverns80');
     expect(html).toContain('Target: app');
     expect(html).toContain('Program: src/main.asm');
-    expect(html).toContain('Start Debugging');
-    expect(html).toContain('Select Root');
+    expect(html).not.toContain('Start Debugging');
+    expect(html).not.toContain('Select Root');
     expect(html).not.toContain('Select Target');
     expect(html).not.toContain('Set Program File');
-    expect(html).toContain('open the Home tab for project controls');
-    expect(html).toContain("script-src 'nonce-xyz789'");
+    expect(html).toContain('Open the Home tab to review the selected root and target');
+    expect(html).not.toContain("script-src 'nonce-xyz789'");
     expect(html).toContain('Select a workspace root with');
   });
 

--- a/tests/platforms/tec1/ui-panel-html.test.ts
+++ b/tests/platforms/tec1/ui-panel-html.test.ts
@@ -40,8 +40,9 @@ describe('tec1 ui-panel-html', () => {
     expect(html).toContain('panel-home');
     expect(html).toContain('homeRootSelect');
     expect(html).toContain('homeTargetSelect');
-    expect(html).toContain('Quick Pick');
-    expect(html).toContain('Set Program File');
+    expect(html).not.toContain('Quick Pick');
+    expect(html).not.toContain('Set Program File');
+    expect(html).toContain('Select a root, then select a target. Changing the target starts or restarts the debug session.');
     expect(html).toContain('panel-ui');
     expect(html).toContain('panel-memory');
     expect(html).toContain('LCD (HD44780 A00)');

--- a/tests/platforms/tec1g/ui-panel-html.test.ts
+++ b/tests/platforms/tec1g/ui-panel-html.test.ts
@@ -40,8 +40,9 @@ describe('tec1g ui-panel-html', () => {
     expect(html).toContain('panel-home');
     expect(html).toContain('homeRootSelect');
     expect(html).toContain('homeTargetSelect');
-    expect(html).toContain('Quick Pick');
-    expect(html).toContain('Set Program File');
+    expect(html).not.toContain('Quick Pick');
+    expect(html).not.toContain('Set Program File');
+    expect(html).toContain('Select a root, then select a target. Changing the target starts or restarts the debug session.');
     expect(html).toContain('panel-ui');
     expect(html).toContain('panel-memory');
     expect(html).toContain('LCD (HD44780 A00)');

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -23,14 +23,12 @@
               <label class="home-label" for="homeRootSelect">Root</label>
               <div class="home-control-row">
                 <select class="home-select" id="homeRootSelect"></select>
-                <button class="session-button session-button-fallback" id="selectProject">Quick Pick</button>
               </div>
             </div>
             <div class="home-control">
               <label class="home-label" for="homeTargetSelect">Target</label>
               <div class="home-control-row">
                 <select class="home-select" id="homeTargetSelect"></select>
-                <button class="session-button session-button-fallback" id="selectTarget">Quick Pick</button>
               </div>
             </div>
           </div>
@@ -53,11 +51,8 @@
             </div>
           </div>
         </div>
-        <div class="home-actions">
-          <button class="session-button" id="setEntrySource" title="Sets the program file for the active target">Set Program File</button>
-        </div>
         <p class="home-note">
-          Debug80 follows workspace roots. Use the selectors above to switch roots and targets directly, or use Quick Pick when you need the full picker flow.
+          Select a root, then select a target. Changing the target starts or restarts the debug session.
         </p>
       </div>
     </div>

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -14,9 +14,6 @@ const DEFAULT_TAB: PanelTab =
     : document.body.dataset.activeTab === 'ui'
       ? 'ui'
       : 'home';
-const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
-const selectTargetButton = document.getElementById('selectTarget') as HTMLButtonElement | null;
-const setEntrySourceButton = document.getElementById('setEntrySource') as HTMLButtonElement | null;
 const homeRootSelect = document.getElementById('homeRootSelect') as HTMLSelectElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const homeRootName = document.getElementById('homeRootName') as HTMLElement | null;
@@ -79,18 +76,6 @@ let currentRootPath = '';
 const audio = createAudioController(muteEl);
 const lcdRenderer = createLcdRenderer();
 const matrixRenderer = createMatrixRenderer();
-
-selectProjectButton?.addEventListener('click', () => {
-  vscode.postMessage({ type: 'selectProject' });
-});
-
-selectTargetButton?.addEventListener('click', () => {
-  vscode.postMessage({ type: 'selectTarget' });
-});
-
-setEntrySourceButton?.addEventListener('click', () => {
-  vscode.postMessage({ type: 'setEntrySource' });
-});
 
 homeRootSelect?.addEventListener('change', () => {
   const rootPath = homeRootSelect.value;

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -23,14 +23,12 @@
               <label class="home-label" for="homeRootSelect">Root</label>
               <div class="home-control-row">
                 <select class="home-select" id="homeRootSelect"></select>
-                <button class="session-button session-button-fallback" id="selectProject">Quick Pick</button>
               </div>
             </div>
             <div class="home-control">
               <label class="home-label" for="homeTargetSelect">Target</label>
               <div class="home-control-row">
                 <select class="home-select" id="homeTargetSelect"></select>
-                <button class="session-button session-button-fallback" id="selectTarget">Quick Pick</button>
               </div>
             </div>
           </div>
@@ -53,11 +51,8 @@
             </div>
           </div>
         </div>
-        <div class="home-actions">
-          <button class="session-button" id="setEntrySource" title="Sets the program file for the active target">Set Program File</button>
-        </div>
         <p class="home-note">
-          Debug80 follows workspace roots. Use the selectors above to switch roots and targets directly, or use Quick Pick when you need the full picker flow.
+          Select a root, then select a target. Changing the target starts or restarts the debug session.
         </p>
       </div>
     </div>

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -102,9 +102,6 @@ const DEFAULT_TAB: PanelTab =
     : document.body.dataset.activeTab === 'ui'
       ? 'ui'
       : 'home';
-const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
-const selectTargetButton = document.getElementById('selectTarget') as HTMLButtonElement | null;
-const setEntrySourceButton = document.getElementById('setEntrySource') as HTMLButtonElement | null;
 const homeRootSelect = document.getElementById('homeRootSelect') as HTMLSelectElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const homeRootName = document.getElementById('homeRootName') as HTMLElement | null;
@@ -255,18 +252,6 @@ let shiftLatched = false;
 let audioCtx: AudioContext | null = null;
 let osc: OscillatorNode | null = null;
 let gain: GainNode | null = null;
-
-selectProjectButton?.addEventListener('click', () => {
-  vscode.postMessage({ type: 'selectProject' });
-});
-
-selectTargetButton?.addEventListener('click', () => {
-  vscode.postMessage({ type: 'selectTarget' });
-});
-
-setEntrySourceButton?.addEventListener('click', () => {
-  vscode.postMessage({ type: 'setEntrySource' });
-});
 
 homeRootSelect?.addEventListener('change', () => {
   const rootPath = homeRootSelect.value;


### PR DESCRIPTION
## Summary
- remove Quick Pick and Set Program File buttons from the Home panel in both TEC-1 and TEC-1G webviews
- stop auto-starting debug sessions when selecting a root; selecting a target now remains the single restart trigger in the panel flow
- replace the separate startup action shell with a minimal idle message that points users back to the Home tab

## Verification
- npm run build
- npx vitest run tests/extension/commands.test.ts tests/extension/platform-view-idle-html.test.ts tests/platforms/tec1/ui-panel-html.test.ts tests/platforms/tec1g/ui-panel-html.test.ts
- npx eslint src/extension/commands.ts src/extension/platform-view-idle-html.ts tests/extension/commands.test.ts tests/extension/platform-view-idle-html.test.ts tests/platforms/tec1/ui-panel-html.test.ts tests/platforms/tec1g/ui-panel-html.test.ts webview/tec1/index.ts webview/tec1g/index.ts --ext .ts
- npm test