### PR TITLE
Refine project header and restore startup auto-launch

### DIFF
--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -146,6 +146,41 @@ async function startCurrentProjectDebugging(
   });
 }
 
+async function maybeAutoStartSingleTargetForRootChange(
+  folder: vscode.WorkspaceFolder,
+  workspaceSelection: WorkspaceSelectionController,
+  targetSelection: ProjectTargetSelectionController
+): Promise<string | undefined> {
+  const projectConfig = findProjectConfigPath(folder);
+  if (projectConfig === undefined) {
+    return undefined;
+  }
+
+  const choices = listProjectTargetChoices(projectConfig);
+  if (choices.length !== 1) {
+    return undefined;
+  }
+
+  const onlyTarget = choices[0]?.name;
+  if (onlyTarget === undefined) {
+    return undefined;
+  }
+
+  targetSelection.rememberTarget(projectConfig, onlyTarget);
+
+  const activeSession = vscode.debug.activeDebugSession;
+  if (activeSession?.type === 'z80') {
+    await vscode.debug.stopDebugging(activeSession);
+  }
+
+  const started = await startCurrentProjectDebugging(folder, workspaceSelection);
+  if (!started) {
+    return undefined;
+  }
+
+  return onlyTarget;
+}
+
 export function registerExtensionCommands({
   context,
   platformViewProvider,
@@ -231,6 +266,17 @@ export function registerExtensionCommands({
 
         workspaceSelection.rememberWorkspace(folder);
         platformViewProvider.refreshIdleView();
+
+        const singleTarget = await maybeAutoStartSingleTargetForRootChange(
+          folder,
+          workspaceSelection,
+          targetSelection
+        );
+        if (singleTarget !== undefined) {
+          void vscode.window.showInformationMessage(
+            `Debug80: Selected root ${folder.name} and started target ${singleTarget}.`
+          );
+        }
         return folder;
       }
     )

--- a/src/extension/workspace-selection.ts
+++ b/src/extension/workspace-selection.ts
@@ -5,6 +5,7 @@
 import * as vscode from 'vscode';
 import { PlatformViewProvider } from './platform-view-provider';
 import { findProjectConfigPath } from './project-config';
+import { resolvePreferredTargetName } from './project-target-selection';
 
 const WORKSPACE_KEY = 'debug80.selectedWorkspace';
 const PROJECT_CONFIG_WATCH_GLOBS = ['**/.vscode/debug80.json', '**/debug80.json', '**/.debug80.json'];
@@ -16,6 +17,8 @@ export type ResolveWorkspaceFolderOptions = {
 };
 
 export class WorkspaceSelectionController {
+  private startupAutoStartAttempted = false;
+
   constructor(
     private readonly context: vscode.ExtensionContext,
     private readonly platformViewProvider: PlatformViewProvider
@@ -24,6 +27,7 @@ export class WorkspaceSelectionController {
   registerInfrastructure(): void {
     this.updateHasProject();
     this.applySelectedWorkspace();
+    this.maybeAutoStartRememberedProject();
 
     PROJECT_CONFIG_WATCH_GLOBS.forEach((pattern) => {
       const configWatcher = vscode.workspace.createFileSystemWatcher(pattern);
@@ -166,5 +170,39 @@ export class WorkspaceSelectionController {
   private applySelectedWorkspace(): void {
     const selected = this.resolvePreferredWorkspace(false);
     this.platformViewProvider.setSelectedWorkspace(selected);
+  }
+
+  private maybeAutoStartRememberedProject(): void {
+    if (this.startupAutoStartAttempted) {
+      return;
+    }
+    this.startupAutoStartAttempted = true;
+
+    if (vscode.debug.activeDebugSession?.type === 'z80') {
+      return;
+    }
+
+    const selected = this.resolvePreferredWorkspace(true);
+    if (selected === undefined) {
+      return;
+    }
+
+    const projectConfigPath = findProjectConfigPath(selected);
+    if (projectConfigPath === undefined) {
+      return;
+    }
+
+    const preferredTarget = resolvePreferredTargetName(this.context.workspaceState, projectConfigPath);
+    if (preferredTarget === undefined) {
+      return;
+    }
+
+    void vscode.debug.startDebugging(selected, {
+      type: 'z80',
+      request: 'launch',
+      name: 'Debug80: Current Project',
+      projectConfig: projectConfigPath,
+      stopOnEntry: false,
+    });
   }
 }

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -219,6 +219,60 @@ describe('registerExtensionCommands', () => {
     expect(startDebugging).not.toHaveBeenCalled();
   });
 
+  it('auto-starts when a selected root exposes exactly one target', async () => {
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    readFileSync.mockReturnValueOnce(
+      JSON.stringify({
+        targets: {
+          matrix: { sourceFile: 'src/matrix.zax' },
+        },
+      })
+    );
+
+    const folder = {
+      name: 'tec1g-mon3',
+      uri: { fsPath: '/workspace/tec1g-mon3' },
+      index: 0,
+    };
+    const rememberWorkspace = vi.fn();
+    const rememberTarget = vi.fn();
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder: vi.fn(),
+        rememberWorkspace,
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {
+        rememberTarget,
+      } as never,
+    });
+
+    const selectRoot = registeredCommands.get('debug80.selectWorkspaceFolder');
+    expect(selectRoot).toBeTypeOf('function');
+
+    startDebugging.mockResolvedValueOnce(true);
+    const result = await selectRoot?.({ rootPath: folder.uri.fsPath });
+
+    expect(result).toEqual(folder);
+    expect(rememberWorkspace).toHaveBeenCalledWith(folder);
+    expect(rememberTarget).toHaveBeenCalledWith(projectConfigPath, 'matrix');
+    expect(startDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: { fsPath: '/workspace/tec1g-mon3' } }),
+      expect.objectContaining({
+        type: 'z80',
+        request: 'launch',
+        projectConfig: projectConfigPath,
+        stopOnEntry: false,
+      })
+    );
+  });
+
   it('remembers a direct root selection even when no project config exists', async () => {
     const { registerExtensionCommands } = await import('../../src/extension/commands');
     const vscode = await import('vscode');

--- a/tests/extension/workspace-selection.test.ts
+++ b/tests/extension/workspace-selection.test.ts
@@ -195,7 +195,7 @@ describe('WorkspaceSelectionController', () => {
         type: 'z80',
         request: 'launch',
         name: 'Debug80: Current Project',
-        projectConfig: '/workspace/caverns80/.vscode/debug80.json',
+        projectConfig: path.normalize('/workspace/caverns80/.vscode/debug80.json'),
         stopOnEntry: false,
       })
     );

--- a/tests/extension/workspace-selection.test.ts
+++ b/tests/extension/workspace-selection.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const showQuickPick = vi.fn();
 const executeCommand = vi.fn();
 const existsSync = vi.fn();
+const startDebugging = vi.fn();
+const resolvePreferredTargetName = vi.fn();
 
 let workspaceFolders: Array<{ name: string; uri: { fsPath: string } }> | undefined;
 let storedPath: string | undefined;
@@ -20,11 +22,24 @@ vi.mock('vscode', () => ({
   commands: {
     executeCommand,
   },
+  debug: {
+    activeDebugSession: undefined,
+    startDebugging,
+  },
   workspace: {
     get workspaceFolders() {
       return workspaceFolders;
     },
+    createFileSystemWatcher: vi.fn(() => ({
+      onDidCreate: vi.fn(),
+      onDidDelete: vi.fn(),
+    })),
+    onDidChangeWorkspaceFolders: vi.fn(() => ({ dispose: vi.fn() })),
   },
+}));
+
+vi.mock('../../src/extension/project-target-selection', () => ({
+  resolvePreferredTargetName,
 }));
 
 describe('WorkspaceSelectionController', () => {
@@ -32,6 +47,7 @@ describe('WorkspaceSelectionController', () => {
     vi.clearAllMocks();
     workspaceFolders = undefined;
     storedPath = undefined;
+    resolvePreferredTargetName.mockReturnValue(undefined);
   });
 
   it('reuses the remembered workspace without prompting', async () => {
@@ -144,5 +160,44 @@ describe('WorkspaceSelectionController', () => {
       expect.objectContaining({ placeHolder: 'Select the Debug80 project folder to debug' })
     );
     expect(update).toHaveBeenCalledWith('debug80.selectedWorkspace', '/workspace/caverns80');
+  });
+
+  it('auto-starts the remembered project on startup when a preferred target exists', async () => {
+    workspaceFolders = [{ name: 'caverns80', uri: { fsPath: '/workspace/caverns80' } }];
+    storedPath = '/workspace/caverns80';
+    existsSync.mockImplementation(
+      (candidate: string) =>
+        path.normalize(candidate) === path.normalize('/workspace/caverns80/.vscode/debug80.json')
+    );
+    resolvePreferredTargetName.mockReturnValue('app');
+
+    const { WorkspaceSelectionController } = await import(
+      '../../src/extension/workspace-selection'
+    );
+    const platformViewProvider = {
+      setSelectedWorkspace: vi.fn(),
+      setHasProject: vi.fn(),
+    };
+
+    const controller = new WorkspaceSelectionController(
+      {
+        subscriptions: [],
+        workspaceState: { get: vi.fn(() => storedPath), update: vi.fn() },
+      } as never,
+      platformViewProvider as never
+    );
+
+    controller.registerInfrastructure();
+
+    expect(startDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: { fsPath: '/workspace/caverns80' } }),
+      expect.objectContaining({
+        type: 'z80',
+        request: 'launch',
+        name: 'Debug80: Current Project',
+        projectConfig: '/workspace/caverns80/.vscode/debug80.json',
+        stopOnEntry: false,
+      })
+    );
   });
 });

--- a/tests/platforms/tec1/ui-panel-html.test.ts
+++ b/tests/platforms/tec1/ui-panel-html.test.ts
@@ -40,7 +40,7 @@ describe('tec1 ui-panel-html', () => {
     expect(html).toContain('homeTargetSelect');
     expect(html).toContain('project-header');
     expect(html).toContain('project-label');
-    expect(html).toContain('Root');
+    expect(html).toContain('Project');
     expect(html).toContain('Target');
     expect(html).not.toContain('panel-home');
     expect(html).not.toContain('Home');

--- a/tests/platforms/tec1/ui-panel-html.test.ts
+++ b/tests/platforms/tec1/ui-panel-html.test.ts
@@ -36,9 +36,12 @@ describe('tec1 ui-panel-html', () => {
 
   it('includes key UI sections', () => {
     const html = getTec1Html('ui', webview, extensionUri);
-    expect(html).toContain('homeRootSelect');
+    expect(html).toContain('selectProject');
     expect(html).toContain('homeTargetSelect');
     expect(html).toContain('project-header');
+    expect(html).toContain('project-label');
+    expect(html).toContain('Root');
+    expect(html).toContain('Target');
     expect(html).not.toContain('panel-home');
     expect(html).not.toContain('Home');
     expect(html).toContain('panel-ui');

--- a/tests/platforms/tec1g/ui-panel-html.test.ts
+++ b/tests/platforms/tec1g/ui-panel-html.test.ts
@@ -36,9 +36,12 @@ describe('tec1g ui-panel-html', () => {
 
   it('includes key UI sections', () => {
     const html = getTec1gHtml('ui', webview, extensionUri);
-    expect(html).toContain('homeRootSelect');
+    expect(html).toContain('selectProject');
     expect(html).toContain('homeTargetSelect');
     expect(html).toContain('project-header');
+    expect(html).toContain('project-label');
+    expect(html).toContain('Root');
+    expect(html).toContain('Target');
     expect(html).not.toContain('panel-home');
     expect(html).not.toContain('Home');
     expect(html).toContain('panel-ui');

--- a/tests/platforms/tec1g/ui-panel-html.test.ts
+++ b/tests/platforms/tec1g/ui-panel-html.test.ts
@@ -40,7 +40,7 @@ describe('tec1g ui-panel-html', () => {
     expect(html).toContain('homeTargetSelect');
     expect(html).toContain('project-header');
     expect(html).toContain('project-label');
-    expect(html).toContain('Root');
+    expect(html).toContain('Project');
     expect(html).toContain('Target');
     expect(html).not.toContain('panel-home');
     expect(html).not.toContain('Home');

--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -13,6 +13,40 @@ body {
       gap: 8px;
       margin-bottom: 8px;
       align-items: center;
+      flex-wrap: wrap;
+    }
+    .project-control {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      min-width: 0;
+      flex: 1;
+    }
+    .project-label {
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #9a9a9a;
+      flex: 0 0 auto;
+    }
+    .project-root-button {
+      flex: 1;
+      min-width: 0;
+      border: 1px solid #333;
+      border-radius: 6px;
+      background: #1b1b1b;
+      color: #f0f0f0;
+      padding: 4px 8px;
+      font-size: 11px;
+      text-align: left;
+      cursor: pointer;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .project-root-button:disabled {
+      cursor: default;
+      color: #7a7a7a;
     }
     .project-select {
       flex: 1;

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -11,7 +11,7 @@
 <div id="app" tabindex="0">
     <div class="project-header" id="projectHeader">
       <div class="project-control">
-        <span class="project-label">Root</span>
+        <span class="project-label">Project</span>
         <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
       </div>
       <div class="project-control">

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -10,8 +10,14 @@
 <body data-active-tab="{{activeTab}}">
 <div id="app" tabindex="0">
     <div class="project-header" id="projectHeader">
-      <select class="project-select" id="homeRootSelect"></select>
-      <select class="project-select" id="homeTargetSelect"></select>
+      <div class="project-control">
+        <span class="project-label">Root</span>
+        <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
+      </div>
+      <div class="project-control">
+        <span class="project-label">Target</span>
+        <select class="project-select" id="homeTargetSelect"></select>
+      </div>
     </div>
     <div class="tabs">
       <button class="tab" data-tab="ui">UI</button>

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -116,13 +116,13 @@ function setRootOptions(
   const selected = options.find((option) => option.path === selectedRootPath) ?? options[0];
   selectProjectButton.disabled = false;
   selectProjectButton.textContent =
-    selected !== undefined ? `${selected.name} — ${selected.path}` : 'Select workspace root';
+    selected !== undefined ? selected.name : 'Select workspace root';
   selectProjectButton.title =
     selected === undefined
       ? 'Select workspace root'
       : selected.hasProject
-        ? 'Configured Debug80 project'
-        : 'No Debug80 project config';
+        ? `${selected.name} — ${selected.path}`
+        : `${selected.name} — ${selected.path} (no Debug80 project config)`;
 }
 
 function setTargetOptions(options: Array<{ name: string; description?: string; detail?: string }>, selectedTargetName?: string): void {
@@ -139,7 +139,7 @@ function setTargetOptions(options: Array<{ name: string; description?: string; d
   for (const option of options) {
     const el = document.createElement('option');
     el.value = option.name;
-    el.textContent = option.description ? `${option.name} — ${option.description}` : option.name;
+    el.textContent = option.name;
     el.title = option.detail ?? option.description ?? option.name;
     homeTargetSelect.appendChild(el);
   }

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -12,7 +12,7 @@ const DEFAULT_TAB: PanelTab =
   document.body.dataset.activeTab === 'memory'
     ? 'memory'
     : 'ui';
-const homeRootSelect = document.getElementById('homeRootSelect') as HTMLSelectElement | null;
+const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const displayEl = document.getElementById('display') as HTMLElement;
 const keypadEl = document.getElementById('keypad') as HTMLElement;
@@ -69,12 +69,8 @@ const audio = createAudioController(muteEl);
 const lcdRenderer = createLcdRenderer();
 const matrixRenderer = createMatrixRenderer();
 
-homeRootSelect?.addEventListener('change', () => {
-  const rootPath = homeRootSelect.value;
-  if (!rootPath) {
-    return;
-  }
-  vscode.postMessage({ type: 'selectProject', rootPath });
+selectProjectButton?.addEventListener('click', () => {
+  vscode.postMessage({ type: 'selectProject' });
 });
 
 homeTargetSelect?.addEventListener('change', () => {
@@ -104,26 +100,29 @@ function setSelectPlaceholder(select: HTMLSelectElement, label: string): void {
   select.appendChild(option);
 }
 
-function setRootOptions(options: Array<{ name: string; path: string; hasProject: boolean }>, selectedRootPath?: string): void {
-  if (!homeRootSelect) {
+function setRootOptions(
+  options: Array<{ name: string; path: string; hasProject: boolean }>,
+  selectedRootPath?: string
+): void {
+  if (!selectProjectButton) {
     return;
   }
-  clearSelectOptions(homeRootSelect);
   if (options.length === 0) {
-    setSelectPlaceholder(homeRootSelect, 'No workspace roots available');
-    homeRootSelect.disabled = true;
+    selectProjectButton.disabled = true;
+    selectProjectButton.textContent = 'No workspace roots available';
+    selectProjectButton.title = 'No workspace roots available';
     return;
   }
-  setSelectPlaceholder(homeRootSelect, 'Select root...');
-  for (const option of options) {
-    const el = document.createElement('option');
-    el.value = option.path;
-    el.textContent = `${option.name} — ${option.path}`;
-    el.title = option.hasProject ? 'Configured Debug80 project' : 'No Debug80 project config';
-    homeRootSelect.appendChild(el);
-  }
-  homeRootSelect.disabled = false;
-  homeRootSelect.value = selectedRootPath ?? '';
+  const selected = options.find((option) => option.path === selectedRootPath) ?? options[0];
+  selectProjectButton.disabled = false;
+  selectProjectButton.textContent =
+    selected !== undefined ? `${selected.name} — ${selected.path}` : 'Select workspace root';
+  selectProjectButton.title =
+    selected === undefined
+      ? 'Select workspace root'
+      : selected.hasProject
+        ? 'Configured Debug80 project'
+        : 'No Debug80 project config';
 }
 
 function setTargetOptions(options: Array<{ name: string; description?: string; detail?: string }>, selectedTargetName?: string): void {

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -11,7 +11,7 @@
 <div id="app" tabindex="0">
     <div class="project-header" id="projectHeader">
       <div class="project-control">
-        <span class="project-label">Root</span>
+        <span class="project-label">Project</span>
         <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
       </div>
       <div class="project-control">

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -10,8 +10,14 @@
 <body data-active-tab="{{activeTab}}">
 <div id="app" tabindex="0">
     <div class="project-header" id="projectHeader">
-      <select class="project-select" id="homeRootSelect"></select>
-      <select class="project-select" id="homeTargetSelect"></select>
+      <div class="project-control">
+        <span class="project-label">Root</span>
+        <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
+      </div>
+      <div class="project-control">
+        <span class="project-label">Target</span>
+        <select class="project-select" id="homeTargetSelect"></select>
+      </div>
     </div>
     <div class="tabs">
       <button class="tab" data-tab="ui">UI</button>

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -287,13 +287,13 @@ function setRootOptions(options: ProjectRootOption[], selectedRootPath?: string)
   const selected = options.find((option) => option.path === selectedRootPath) ?? options[0];
   selectProjectButton.disabled = false;
   selectProjectButton.textContent =
-    selected !== undefined ? `${selected.name} — ${selected.path}` : 'Select workspace root';
+    selected !== undefined ? selected.name : 'Select workspace root';
   selectProjectButton.title =
     selected === undefined
       ? 'Select workspace root'
       : selected.hasProject
-        ? 'Configured Debug80 project'
-        : 'No Debug80 project config';
+        ? `${selected.name} — ${selected.path}`
+        : `${selected.name} — ${selected.path} (no Debug80 project config)`;
 }
 
 function setTargetOptions(options: ProjectTargetOption[], selectedTargetName?: string): void {
@@ -310,7 +310,7 @@ function setTargetOptions(options: ProjectTargetOption[], selectedTargetName?: s
   for (const option of options) {
     const el = document.createElement('option');
     el.value = option.name;
-    el.textContent = option.description ? `${option.name} — ${option.description}` : option.name;
+    el.textContent = option.name;
     el.title = option.detail ?? option.description ?? option.name;
     homeTargetSelect.appendChild(el);
   }

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -100,7 +100,7 @@ const DEFAULT_TAB: PanelTab =
   document.body.dataset.activeTab === 'memory'
     ? 'memory'
     : 'ui';
-const homeRootSelect = document.getElementById('homeRootSelect') as HTMLSelectElement | null;
+const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const displayEl = document.getElementById('display') as HTMLElement;
 const keypadEl = document.getElementById('keypad') as HTMLElement;
@@ -243,12 +243,8 @@ let audioCtx: AudioContext | null = null;
 let osc: OscillatorNode | null = null;
 let gain: GainNode | null = null;
 
-homeRootSelect?.addEventListener('change', () => {
-  const rootPath = homeRootSelect.value;
-  if (!rootPath) {
-    return;
-  }
-  vscode.postMessage({ type: 'selectProject', rootPath });
+selectProjectButton?.addEventListener('click', () => {
+  vscode.postMessage({ type: 'selectProject' });
 });
 
 homeTargetSelect?.addEventListener('change', () => {
@@ -279,25 +275,25 @@ function setSelectPlaceholder(select: HTMLSelectElement, label: string): void {
 }
 
 function setRootOptions(options: ProjectRootOption[], selectedRootPath?: string): void {
-  if (!homeRootSelect) {
+  if (!selectProjectButton) {
     return;
   }
-  clearSelectOptions(homeRootSelect);
   if (options.length === 0) {
-    setSelectPlaceholder(homeRootSelect, 'No workspace roots available');
-    homeRootSelect.disabled = true;
+    selectProjectButton.disabled = true;
+    selectProjectButton.textContent = 'No workspace roots available';
+    selectProjectButton.title = 'No workspace roots available';
     return;
   }
-  setSelectPlaceholder(homeRootSelect, 'Select root...');
-  for (const option of options) {
-    const el = document.createElement('option');
-    el.value = option.path;
-    el.textContent = `${option.name} — ${option.path}`;
-    el.title = option.hasProject ? 'Configured Debug80 project' : 'No Debug80 project config';
-    homeRootSelect.appendChild(el);
-  }
-  homeRootSelect.disabled = false;
-  homeRootSelect.value = selectedRootPath ?? '';
+  const selected = options.find((option) => option.path === selectedRootPath) ?? options[0];
+  selectProjectButton.disabled = false;
+  selectProjectButton.textContent =
+    selected !== undefined ? `${selected.name} — ${selected.path}` : 'Select workspace root';
+  selectProjectButton.title =
+    selected === undefined
+      ? 'Select workspace root'
+      : selected.hasProject
+        ? 'Configured Debug80 project'
+        : 'No Debug80 project config';
 }
 
 function setTargetOptions(options: ProjectTargetOption[], selectedTargetName?: string): void {


### PR DESCRIPTION
## Summary
- refine the compact project header so Project and Target are clearer and less verbose
- make project changes auto-start only for single-target projects while keeping multi-target changes explicit
- restore startup auto-launch when a remembered project has a valid preferred target

## Verification
- npm run build
- npm test