### PR TITLE
Add debugger session status badge

### DIFF
--- a/src/debug/adapter-request-controller.ts
+++ b/src/debug/adapter-request-controller.ts
@@ -19,6 +19,7 @@ import {
 import { resolveMappedPath } from './path-resolver';
 import { normalizeSourcePath } from './launch-args';
 import { getUnmappedCallReturnAddress } from './step-call-resolver';
+import { emitDebugSessionStatus } from './session-status';
 import type { VariableService } from './variable-service';
 import type { SessionStateShape } from './session-state';
 import type { PlatformRegistry } from './platform-registry';
@@ -394,6 +395,7 @@ export class AdapterRequestController {
       this.deps.sessionState.runState.haltNotified = true;
       this.deps.sessionState.runState.lastStopReason = 'halt';
       this.deps.sessionState.runState.lastBreakpointAddress = null;
+      emitDebugSessionStatus(this.deps.sendEvent, 'paused');
       this.deps.sendEvent(new StoppedEvent('halt', this.deps.threadId));
       return;
     }

--- a/src/debug/adapter.ts
+++ b/src/debug/adapter.ts
@@ -55,6 +55,7 @@ import {
 import { Logger, NullLogger } from '../util/logger';
 import { AdapterRequestController } from './adapter-request-controller';
 import { handleWarmRebuildRequest } from './rebuild-request';
+import { emitDebugSessionStatus } from './session-status';
 
 /** DAP thread identifier (single-threaded Z80) */
 const THREAD_ID = 1;
@@ -310,6 +311,7 @@ export class Z80DebugSession extends DebugSession {
     }
     this.sessionState.runState.lastStopReason = 'entry';
     this.sessionState.runState.lastBreakpointAddress = null;
+    emitDebugSessionStatus((event) => this.sendEvent(event as DebugProtocol.Event), 'paused');
     this.sendEvent(new StoppedEvent('entry', THREAD_ID));
   }
 

--- a/src/debug/runtime-control.ts
+++ b/src/debug/runtime-control.ts
@@ -17,6 +17,7 @@ import type { LaunchSequenceContext } from './launch-sequence';
 import type { LaunchSessionArtifacts } from './launch-sequence';
 import type { BreakpointManager } from './breakpoint-manager';
 import type { CpuStateSnapshot } from '../z80/runtime';
+import { emitDebugSessionStatus } from './session-status';
 
 export interface RuntimeControlContext {
   getRuntime: () => Z80Runtime | undefined;
@@ -279,6 +280,7 @@ export async function runUntilStopAsync(
   let lastThrottleMs = Date.now();
   const getRuntimeCapabilities = (): RuntimeControlCapabilities | undefined =>
     context.getRuntimeCapabilities();
+  emitDebugSessionStatus(context.sendEvent, 'running');
   // eslint-disable-next-line no-constant-condition
   while (true) {
     for (let i = 0; i < CHUNK; i += 1) {
@@ -294,6 +296,7 @@ export async function runUntilStopAsync(
         context.setLastStopReason('pause');
         context.setLastBreakpointAddress(null);
         getRuntimeCapabilities()?.silenceSpeaker();
+        emitDebugSessionStatus(context.sendEvent, 'paused');
         context.sendEvent(new StoppedEvent('pause', 1));
         return;
       }
@@ -320,6 +323,7 @@ export async function runUntilStopAsync(
         context.setRunning(false);
         context.setLastStopReason('breakpoint');
         context.setLastBreakpointAddress(pc);
+        emitDebugSessionStatus(context.sendEvent, 'paused');
         context.sendEvent(new StoppedEvent('breakpoint', 1));
         return;
       }
@@ -328,6 +332,7 @@ export async function runUntilStopAsync(
         context.setRunning(false);
         context.setLastStopReason('step');
         context.setLastBreakpointAddress(null);
+        emitDebugSessionStatus(context.sendEvent, 'paused');
         context.sendEvent(new StoppedEvent('step', 1));
         return;
       }
@@ -347,6 +352,7 @@ export async function runUntilStopAsync(
         context.setRunning(false);
         context.setLastStopReason('step');
         context.setLastBreakpointAddress(null);
+        emitDebugSessionStatus(context.sendEvent, 'paused');
         context.sendEvent(
           new OutputEvent(
             `Debug80: ${limitLabel} stopped after ${maxInstructions} instructions (target not reached).\n`
@@ -403,6 +409,7 @@ export async function runUntilReturnAsync(
   let lastThrottleMs = Date.now();
   const getRuntimeCapabilities = (): RuntimeControlCapabilities | undefined =>
     context.getRuntimeCapabilities();
+  emitDebugSessionStatus(context.sendEvent, 'running');
   // eslint-disable-next-line no-constant-condition
   while (true) {
     for (let i = 0; i < CHUNK; i += 1) {
@@ -417,6 +424,7 @@ export async function runUntilReturnAsync(
         context.setLastStopReason('pause');
         context.setLastBreakpointAddress(null);
         getRuntimeCapabilities()?.silenceSpeaker();
+        emitDebugSessionStatus(context.sendEvent, 'paused');
         context.sendEvent(new StoppedEvent('pause', 1));
         return;
       }
@@ -440,6 +448,7 @@ export async function runUntilReturnAsync(
           context.setRunning(false);
           context.setLastStopReason('breakpoint');
           context.setLastBreakpointAddress(pc);
+          emitDebugSessionStatus(context.sendEvent, 'paused');
           context.sendEvent(new StoppedEvent('breakpoint', 1));
           return;
         }
@@ -461,6 +470,7 @@ export async function runUntilReturnAsync(
           context.setRunning(false);
           context.setLastStopReason('step');
           context.setLastBreakpointAddress(null);
+          emitDebugSessionStatus(context.sendEvent, 'paused');
           context.sendEvent(new StoppedEvent('step', 1));
           return;
         }
@@ -471,6 +481,7 @@ export async function runUntilReturnAsync(
         context.setRunning(false);
         context.setLastStopReason('step');
         context.setLastBreakpointAddress(null);
+        emitDebugSessionStatus(context.sendEvent, 'paused');
         context.sendEvent(
           new OutputEvent(
             `Debug80: step out stopped after ${maxInstructions} instructions (return not observed).\n`

--- a/src/debug/session-status.ts
+++ b/src/debug/session-status.ts
@@ -1,0 +1,10 @@
+import { Event as DapEvent } from '@vscode/debugadapter';
+
+export type DebugSessionStatus = 'starting' | 'running' | 'paused' | 'not running';
+
+export function emitDebugSessionStatus(
+  sendEvent: (event: unknown) => void,
+  status: DebugSessionStatus
+): void {
+  sendEvent(new DapEvent('debug80/sessionStatus', { status }));
+}

--- a/src/extension/debug-session-events.ts
+++ b/src/extension/debug-session-events.ts
@@ -69,6 +69,7 @@ export function registerDebugSessionHandlers({
     vscode.debug.onDidStartDebugSession((session) => {
       if (session.type === 'z80') {
         assemblyDiagnostics.clear();
+        platformViewProvider.setSessionStatus('starting');
         sessionState.activeZ80Sessions.add(session.id);
         terminalPanel.clear();
         platformViewProvider.clear();
@@ -167,6 +168,19 @@ export function registerDebugSessionHandlers({
               sessionState.romSourcesOpenedSessions.add(evt.session.id);
             }
           });
+        }
+        return;
+      }
+      if (evt.event === 'debug80/sessionStatus') {
+        const body = evt.body as { status?: string } | undefined;
+        const status = body?.status;
+        if (
+          status === 'starting' ||
+          status === 'running' ||
+          status === 'paused' ||
+          status === 'not running'
+        ) {
+          platformViewProvider.setSessionStatus(status);
         }
         return;
       }

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -3,6 +3,7 @@
  */
 
 import * as vscode from 'vscode';
+import type { DebugSessionStatus } from '../debug/session-status';
 import { Tec1PanelTab, getTec1Html } from '../platforms/tec1/ui-panel-html';
 import { createMemoryViewState as createTec1MemoryViewState } from '../platforms/tec1/ui-panel-memory';
 import { handleTec1Message, Tec1Message } from '../platforms/tec1/ui-panel-messages';
@@ -95,6 +96,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   private tec1gSerialBuffer = createTec1gSerialBuffer();
   private tec1gMemoryViews = createTec1gMemoryViewState();
   private tec1gUiVisibilityOverride: Record<string, boolean> | undefined;
+  private sessionStatus: DebugSessionStatus = 'not running';
   private tec1gRefreshController = createTec1gRefreshController(
     () => this.buildSnapshotPayload(this.tec1gMemoryViews),
     {
@@ -154,6 +156,14 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       this.reveal(options?.focus ?? false);
     }
     this.renderCurrentView(true);
+  }
+
+  setSessionStatus(status: DebugSessionStatus): void {
+    this.sessionStatus = status;
+    if (!this.currentPlatform) {
+      return;
+    }
+    this.postMessage({ type: 'sessionStatus', status });
   }
 
   setTec1gUiVisibility(visibility: Record<string, boolean> | undefined, persist = false): void {
@@ -293,6 +303,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     }
     this.currentSession = undefined;
     this.currentSessionId = undefined;
+    this.setSessionStatus('not running');
     stopTec1AutoRefresh(this.tec1RefreshController.state);
     stopTec1gAutoRefresh(this.tec1gRefreshController.state);
     this.clear();
@@ -404,6 +415,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     if (this.currentPlatform === 'tec1') {
       this.view.webview.html = getTec1Html(this.tec1ActiveTab, this.view.webview, this.extensionUri);
       this.postProjectStatus();
+      this.postSessionStatus();
       this.postMessage({
         type: 'update',
         uiRevision: this.nextUiRevision(),
@@ -423,6 +435,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     if (this.currentPlatform === 'tec1g') {
       this.view.webview.html = getTec1gHtml(this.tec1gActiveTab, this.view.webview, this.extensionUri);
       this.postProjectStatus();
+      this.postSessionStatus();
       this.postMessage({
         type: 'update',
         uiRevision: this.nextUiRevision(),
@@ -462,6 +475,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     if (rehydrate || this.view.webview.html.length === 0) {
       this.view.webview.html = getTec1gHtml(this.tec1gActiveTab, this.view.webview, this.extensionUri);
       this.postProjectStatus();
+      this.postSessionStatus();
     }
   }
 
@@ -470,6 +484,13 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       return;
     }
     this.postMessage({ type: 'projectStatus', ...this.getProjectStatusPayload() });
+  }
+
+  private postSessionStatus(): void {
+    if (!this.view || !this.currentPlatform) {
+      return;
+    }
+    this.postMessage({ type: 'sessionStatus', status: this.sessionStatus });
   }
 
   private getProjectStatusPayload(): ProjectStatusPayload {

--- a/tests/debug/runtime-control.test.ts
+++ b/tests/debug/runtime-control.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { OutputEvent, StoppedEvent } from '@vscode/debugadapter';
+import { Event as DapEvent, OutputEvent, StoppedEvent } from '@vscode/debugadapter';
 import { applyStepInfo, runUntilReturnAsync, runUntilStopAsync } from '../../src/debug/runtime-control';
 import type {
   RuntimeControlCapabilities,
@@ -168,6 +168,31 @@ describe('runtime-control', () => {
     await runUntilStopAsync(context);
     expect(stopReason).toBe('breakpoint');
     expect(stopAddress).toBe(0x1234);
+    expect(events.some((e) => e instanceof StoppedEvent)).toBe(true);
+  });
+
+  it('emits running and paused session status events during the stop loop', async () => {
+    const context = makeContext({
+      pauseRequested: true,
+      runtimeCapabilities: {
+        recordCycles: vi.fn(),
+        silenceSpeaker: vi.fn(),
+        getClockHz: () => 0,
+        getYieldMs: () => 0,
+      },
+    });
+    const events: unknown[] = [];
+    context.sendEvent = (event) => events.push(event);
+
+    await runUntilStopAsync(context);
+
+    const statusEvents = events.filter(
+      (event): event is DapEvent =>
+        event instanceof DapEvent && event.event === 'debug80/sessionStatus'
+    );
+    expect(statusEvents).toHaveLength(2);
+    expect(statusEvents[0]?.body).toEqual({ status: 'running' });
+    expect(statusEvents[1]?.body).toEqual({ status: 'paused' });
     expect(events.some((e) => e instanceof StoppedEvent)).toBe(true);
   });
 

--- a/tests/extension/debug-session-events.test.ts
+++ b/tests/extension/debug-session-events.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @file Debug session status bridge tests.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SessionStateManager } from '../../src/extension/session-state-manager';
+import { registerDebugSessionHandlers } from '../../src/extension/debug-session-events';
+
+const onDidStartDebugSession = vi.fn(() => ({ dispose: vi.fn() }));
+const onDidTerminateDebugSession = vi.fn(() => ({ dispose: vi.fn() }));
+const onDidReceiveDebugSessionCustomEvent = vi.fn(() => ({ dispose: vi.fn() }));
+
+const startHandlers: Array<(session: { id: string; type: string; configuration?: Record<string, unknown>; workspaceFolder?: unknown }) => void> = [];
+const terminateHandlers: Array<(session: { id: string; type: string }) => void> = [];
+const customHandlers: Array<(evt: { session: { id: string; type: string; configuration?: Record<string, unknown>; workspaceFolder?: unknown }; event: string; body?: unknown }) => void> = [];
+
+vi.mock('vscode', () => ({
+  debug: {
+    onDidStartDebugSession: vi.fn((handler: (session: unknown) => void) => {
+      startHandlers.push(handler as never);
+      return onDidStartDebugSession();
+    }),
+    onDidTerminateDebugSession: vi.fn((handler: (session: unknown) => void) => {
+      terminateHandlers.push(handler as never);
+      return onDidTerminateDebugSession();
+    }),
+    onDidReceiveDebugSessionCustomEvent: vi.fn((handler: (evt: unknown) => void) => {
+      customHandlers.push(handler as never);
+      return onDidReceiveDebugSessionCustomEvent();
+    }),
+  },
+  commands: { executeCommand: vi.fn(() => Promise.resolve(true)) },
+  workspace: {
+    workspaceFolders: undefined,
+  },
+  Uri: {
+    file: (value: string) => ({ fsPath: value }),
+  },
+  Range: class Range {
+    constructor(
+      public startLine: number,
+      public startCharacter: number,
+      public endLine: number,
+      public endCharacter: number
+    ) {}
+  },
+  Diagnostic: class Diagnostic {
+    constructor(
+      public range: unknown,
+      public message: string,
+      public severity: number
+    ) {}
+  },
+  DiagnosticSeverity: { Error: 0 },
+}));
+
+describe('debug session status bridge', () => {
+  beforeEach(() => {
+    startHandlers.length = 0;
+    terminateHandlers.length = 0;
+    customHandlers.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('forwards start, custom status, and termination events to the platform view', () => {
+    const platformViewProvider = {
+      setSessionStatus: vi.fn(),
+      clear: vi.fn(),
+      handleSessionTerminated: vi.fn(),
+      setPlatform: vi.fn(),
+      setTec1gUiVisibility: vi.fn(),
+      updateTec1: vi.fn(),
+      updateTec1g: vi.fn(),
+      appendTec1Serial: vi.fn(),
+      appendTec1gSerial: vi.fn(),
+    } as never;
+    const sessionState = new SessionStateManager();
+    const sourceColumns = {
+      onSessionStarted: vi.fn(),
+      onSessionTerminated: vi.fn(),
+      getSessionColumns: vi.fn(() => ({ source: 1, panel: 2 })),
+    } as never;
+    const terminalPanel = {
+      clear: vi.fn(),
+      open: vi.fn(),
+      hasPanel: vi.fn(() => false),
+      appendOutput: vi.fn(),
+    } as never;
+    const workspaceSelection = {
+      rememberWorkspace: vi.fn(),
+    } as never;
+    const context = { subscriptions: [] as Array<{ dispose: () => void }> } as never;
+    const rebuildDiagnostics = { clear: vi.fn(), delete: vi.fn() } as never;
+    const assemblyDiagnostics = { clear: vi.fn(), set: vi.fn() } as never;
+
+    registerDebugSessionHandlers({
+      context,
+      rebuildDiagnostics,
+      assemblyDiagnostics,
+      platformViewProvider,
+      sessionState,
+      sourceColumns,
+      terminalPanel,
+      workspaceSelection,
+    });
+
+    const session = {
+      id: 'session-1',
+      type: 'z80',
+      configuration: {
+        openRomSourcesOnLaunch: false,
+        openMainSourceOnLaunch: true,
+      },
+      workspaceFolder: undefined,
+    };
+
+    startHandlers[0]?.(session);
+    customHandlers[0]?.({
+      session,
+      event: 'debug80/sessionStatus',
+      body: { status: 'running' },
+    });
+    customHandlers[0]?.({
+      session,
+      event: 'debug80/sessionStatus',
+      body: { status: 'paused' },
+    });
+    terminateHandlers[0]?.(session);
+
+    expect(platformViewProvider.setSessionStatus).toHaveBeenNthCalledWith(1, 'starting');
+    expect(platformViewProvider.setSessionStatus).toHaveBeenNthCalledWith(2, 'running');
+    expect(platformViewProvider.setSessionStatus).toHaveBeenNthCalledWith(3, 'paused');
+    expect(platformViewProvider.handleSessionTerminated).toHaveBeenCalledWith('session-1');
+  });
+});

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -363,4 +363,56 @@ describe('PlatformViewProvider', () => {
     expect(statusMessages[0]?.targetName).toBe('app');
     expect(statusMessages[0]?.entrySource).toBe('src/main.asm');
   });
+
+  it('posts sessionStatus updates to the active webview', () => {
+    const provider = new PlatformViewProvider(extensionRoot, {
+      get: vi.fn(),
+      update: vi.fn(),
+    } as never);
+    const webviewView = createWebviewView();
+
+    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
+      isCancellationRequested: false,
+      onCancellationRequested: vi.fn(),
+    } as vscode.CancellationToken);
+    provider.setPlatform('tec1g', undefined, { reveal: false, tab: 'ui' });
+
+    (webviewView.webview.postMessage as ReturnType<typeof vi.fn>).mockClear();
+    provider.setSessionStatus('running');
+
+    const statusMessages = getPostMessageCalls(webviewView).filter(
+      ([msg]) => msg.type === 'sessionStatus'
+    );
+    expect(statusMessages).toHaveLength(1);
+    expect(statusMessages[0]?.[0]).toEqual({
+      type: 'sessionStatus',
+      status: 'running',
+    });
+  });
+
+  it('returns the session badge to Not running when the active session terminates', () => {
+    const provider = new PlatformViewProvider(extensionRoot, {
+      get: vi.fn(),
+      update: vi.fn(),
+    } as never);
+    const webviewView = createWebviewView();
+
+    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
+      isCancellationRequested: false,
+      onCancellationRequested: vi.fn(),
+    } as vscode.CancellationToken);
+    provider.setPlatform('tec1g', { id: 'session-1' } as never, { reveal: false, tab: 'ui' });
+
+    (webviewView.webview.postMessage as ReturnType<typeof vi.fn>).mockClear();
+    provider.handleSessionTerminated('session-1');
+
+    const statusMessages = getPostMessageCalls(webviewView).filter(
+      ([msg]) => msg.type === 'sessionStatus'
+    );
+    expect(statusMessages).toHaveLength(1);
+    expect(statusMessages[0]?.[0]).toEqual({
+      type: 'sessionStatus',
+      status: 'not running',
+    });
+  });
 });

--- a/tests/webview/session-status.test.ts
+++ b/tests/webview/session-status.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @file Regression tests: debugger session status badge contract.
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createSessionStatusController } from '../../webview/common/session-status';
+
+const HTML_PATHS = [
+  ['tec1', path.resolve(__dirname, '../../webview/tec1/index.html')],
+  ['tec1g', path.resolve(__dirname, '../../webview/tec1g/index.html')],
+] as const;
+
+type PostedMessage = { type: string; [key: string]: unknown };
+
+function buildDom(htmlPath: string): Document {
+  const html = fs.readFileSync(htmlPath, 'utf8').replace(/\{\{\w+\}\}/g, '');
+  document.documentElement.innerHTML = html;
+  return document;
+}
+
+function createVscodeMock(messages: PostedMessage[]) {
+  return {
+    postMessage: (message: PostedMessage) => {
+      messages.push(message);
+    },
+    getState: () => null,
+    setState: () => {},
+  };
+}
+
+describe('debugger session status badge', () => {
+  it.each(HTML_PATHS)('renders the badge in the %s top bar', (_label, htmlPath) => {
+    buildDom(htmlPath);
+    const badge = document.getElementById('sessionStatus') as HTMLButtonElement | null;
+    const tabs = document.querySelector('.tabs');
+
+    expect(tabs).not.toBeNull();
+    expect(badge).not.toBeNull();
+    if (!tabs || !badge) {
+      throw new Error('session status badge is missing');
+    }
+    expect(tabs.contains(badge)).toBe(true);
+    expect(badge?.textContent).toBe('Not running');
+    expect(badge?.dataset.status).toBe('not-running');
+    expect(badge?.disabled).toBe(false);
+  });
+
+  it.each(HTML_PATHS)('updates the badge text for %s session states', (_label, htmlPath) => {
+    buildDom(htmlPath);
+    const messages: PostedMessage[] = [];
+    const controller = createSessionStatusController(
+      createVscodeMock(messages),
+      document.getElementById('sessionStatus')
+    );
+    const badge = document.getElementById('sessionStatus') as HTMLButtonElement | null;
+
+    controller.setStatus('starting');
+    expect(badge?.textContent).toBe('Starting...');
+    expect(badge?.dataset.status).toBe('starting');
+    expect(badge?.disabled).toBe(true);
+
+    controller.setStatus('running');
+    expect(badge?.textContent).toBe('Running');
+    expect(badge?.dataset.status).toBe('running');
+
+    controller.setStatus('paused');
+    expect(badge?.textContent).toBe('Paused');
+    expect(badge?.dataset.status).toBe('paused');
+
+    controller.dispose();
+  });
+
+  it.each(HTML_PATHS)('starts debugging when the %s badge is clicked in the idle state', (_label, htmlPath) => {
+    buildDom(htmlPath);
+    const messages: PostedMessage[] = [];
+    createSessionStatusController(
+      createVscodeMock(messages),
+      document.getElementById('sessionStatus')
+    );
+
+    const badge = document.getElementById('sessionStatus') as HTMLButtonElement | null;
+    badge?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(messages).toContainEqual({ type: 'startDebug' });
+  });
+});

--- a/webview/common/session-status.ts
+++ b/webview/common/session-status.ts
@@ -1,0 +1,66 @@
+import type { VscodeApi } from './vscode';
+
+export type SessionStatus = 'starting' | 'running' | 'paused' | 'not running';
+
+export interface SessionStatusController {
+  setStatus: (status: SessionStatus) => void;
+  dispose: () => void;
+}
+
+const STATUS_LABELS: Record<SessionStatus, string> = {
+  starting: 'Starting...',
+  running: 'Running',
+  paused: 'Paused',
+  'not running': 'Not running',
+};
+
+const STATUS_TITLES: Record<SessionStatus, string> = {
+  starting: 'Debugger session is starting',
+  running: 'Debugger session is running',
+  paused: 'Debugger session is paused',
+  'not running': 'Click to start debugging',
+};
+
+function statusClass(status: SessionStatus): string {
+  return `session-status status-${status.replace(/\s+/g, '-')}`;
+}
+
+export function createSessionStatusController(
+  vscode: VscodeApi,
+  element: HTMLButtonElement | null
+): SessionStatusController {
+  if (!element) {
+    return {
+      setStatus: () => undefined,
+      dispose: () => undefined,
+    };
+  }
+
+  let currentStatus: SessionStatus = 'not running';
+  const handleClick = (): void => {
+    if (currentStatus !== 'not running') {
+      return;
+    }
+    vscode.postMessage({ type: 'startDebug' });
+  };
+
+  const applyStatus = (status: SessionStatus): void => {
+    currentStatus = status;
+    element.textContent = STATUS_LABELS[status];
+    element.dataset.status = status.replace(/\s+/g, '-');
+    element.className = statusClass(status);
+    element.title = STATUS_TITLES[status];
+    element.disabled = status !== 'not running';
+  };
+
+  element.type = 'button';
+  element.addEventListener('click', handleClick);
+  applyStatus('not running');
+
+  return {
+    setStatus: applyStatus,
+    dispose: () => {
+      element.removeEventListener('click', handleClick);
+    },
+  };
+}

--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -259,8 +259,17 @@ body {
     }
     .tabs {
       display: flex;
-      gap: 8px;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
       margin-bottom: 12px;
+    }
+    .tabs-buttons {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      min-width: 0;
+      flex: 1;
     }
     .tab {
       background: #1f1f1f;
@@ -276,6 +285,43 @@ body {
       background: #3a3a3a;
       color: #fff;
       border-color: #5a5a5a;
+    }
+    .session-status {
+      border: 1px solid #3b3b3b;
+      border-radius: 999px;
+      padding: 5px 10px;
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      background: #242424;
+      color: #cfcfcf;
+      cursor: default;
+      min-width: 108px;
+      text-align: center;
+      white-space: nowrap;
+    }
+    .session-status:not(:disabled) {
+      cursor: pointer;
+    }
+    .session-status.status-starting {
+      background: #3a2f18;
+      color: #ffd48a;
+      border-color: #7d5a20;
+    }
+    .session-status.status-running {
+      background: #1f3a26;
+      color: #b5f0c5;
+      border-color: #3f7750;
+    }
+    .session-status.status-paused {
+      background: #1c2e44;
+      color: #c0d7ff;
+      border-color: #47658e;
+    }
+    .session-status.status-not-running {
+      background: #242424;
+      color: #d0d0d0;
+      border-color: #454545;
     }
     .panel {
       display: none;

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -20,8 +20,11 @@
       </div>
     </div>
     <div class="tabs">
-      <button class="tab" data-tab="ui">UI</button>
-      <button class="tab" data-tab="memory">CPU</button>
+      <div class="tabs-buttons">
+        <button class="tab" data-tab="ui">UI</button>
+        <button class="tab" data-tab="memory">CPU</button>
+      </div>
+      <button class="session-status" id="sessionStatus" type="button" data-status="not-running">Not running</button>
     </div>
     <div class="panel panel-ui" id="panel-ui">
       <div class="layout">

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -1,5 +1,6 @@
 import { createDigit } from '../common/digits';
 import { MemoryPanel } from '../common/memory-panel';
+import { createSessionStatusController } from '../common/session-status';
 import { acquireVscodeApi } from '../common/vscode';
 import { createAudioController } from './audio';
 import { createLcdRenderer } from './lcd-renderer';
@@ -13,6 +14,7 @@ const DEFAULT_TAB: PanelTab =
     ? 'memory'
     : 'ui';
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
+const sessionStatusButton = document.getElementById('sessionStatus') as HTMLButtonElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const displayEl = document.getElementById('display') as HTMLElement;
 const keypadEl = document.getElementById('keypad') as HTMLElement;
@@ -68,6 +70,7 @@ let currentRootPath = '';
 const audio = createAudioController(muteEl);
 const lcdRenderer = createLcdRenderer();
 const matrixRenderer = createMatrixRenderer();
+const sessionStatusController = createSessionStatusController(vscode, sessionStatusButton);
 
 selectProjectButton?.addEventListener('click', () => {
   vscode.postMessage({ type: 'selectProject' });
@@ -323,6 +326,10 @@ window.addEventListener('message', event => {
     applyProjectStatus(event.data);
     return;
   }
+  if (event.data.type === 'sessionStatus') {
+    sessionStatusController.setStatus(event.data.status);
+    return;
+  }
   if (event.data.type === 'selectTab') {
     panelLayout.setTab(event.data.tab, false);
     return;
@@ -355,6 +362,7 @@ lcdRenderer.draw();
 matrixRenderer.build();
 matrixRenderer.draw();
 panelLayout.setTab(DEFAULT_TAB, false);
+sessionStatusController.setStatus('not running');
 window.addEventListener('resize', () => panelLayout.scheduleMemoryResize());
 panelLayout.updateMemoryLayout(false);
 
@@ -390,5 +398,6 @@ window.addEventListener('keydown', event => {
 
 window.addEventListener('beforeunload', () => {
   serialUi.dispose();
+  sessionStatusController.dispose();
 });
   

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -20,8 +20,11 @@
       </div>
     </div>
     <div class="tabs">
-      <button class="tab" data-tab="ui">UI</button>
-      <button class="tab" data-tab="memory">CPU</button>
+      <div class="tabs-buttons">
+        <button class="tab" data-tab="ui">UI</button>
+        <button class="tab" data-tab="memory">CPU</button>
+      </div>
+      <button class="session-status" id="sessionStatus" type="button" data-status="not-running">Not running</button>
     </div>
     <div class="panel panel-ui" id="panel-ui">
       <div class="ui-controls" id="uiControls">

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -1,5 +1,6 @@
 import { createDigit } from '../common/digits';
 import { MemoryPanel } from '../common/memory-panel';
+import { createSessionStatusController, type SessionStatus } from '../common/session-status';
 import { acquireVscodeApi } from '../common/vscode';
 import { createGlcdRenderer } from './glcd-renderer';
 import { createLcdRenderer } from './lcd-renderer';
@@ -80,6 +81,7 @@ type ProjectTargetOption = {
 
 type IncomingMessage =
   | { type: 'selectTab'; tab: string }
+  | { type: 'sessionStatus'; status: SessionStatus }
   | {
       type: 'projectStatus';
       rootName?: string;
@@ -101,6 +103,7 @@ const DEFAULT_TAB: PanelTab =
     ? 'memory'
     : 'ui';
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
+const sessionStatusButton = document.getElementById('sessionStatus') as HTMLButtonElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const displayEl = document.getElementById('display') as HTMLElement;
 const keypadEl = document.getElementById('keypad') as HTMLElement;
@@ -123,6 +126,7 @@ let sysCtrlSegs: HTMLElement[] = [];
 let sysCtrlValue = 0;
 let currentRootPath = '';
 const digitEls: HTMLElement[] = [];
+const sessionStatusController = createSessionStatusController(vscode, sessionStatusButton);
 for (let i = 0; i < DIGITS; i++) {
   const digit = createDigit();
   digitEls.push(digit);
@@ -626,6 +630,10 @@ window.addEventListener('message', (event: MessageEvent<IncomingMessage | undefi
     applyProjectStatus(message);
     return;
   }
+  if (message.type === 'sessionStatus') {
+    sessionStatusController.setStatus(message.status);
+    return;
+  }
   if (message.type === 'selectTab') {
     setTab(message.tab, false);
     return;
@@ -663,6 +671,7 @@ visibilityController.wire();
 lcdRenderer.draw();
 glcdRenderer.draw();
 setTab(DEFAULT_TAB, false);
+sessionStatusController.setStatus('not running');
 window.addEventListener('resize', scheduleMemoryResize);
 updateMemoryLayout(false);
 wireTec1gSerialUi(vscode);
@@ -704,5 +713,8 @@ window.addEventListener('keyup', event => {
   if (matrixUi.handleKeyEvent(event, false)) {
     event.preventDefault();
   }
+});
+window.addEventListener('beforeunload', () => {
+  sessionStatusController.dispose();
 });
   


### PR DESCRIPTION
## Summary
- Add a compact debugger session status badge to the shared TEC-1 and TEC-1G top bar
- Drive the badge from actual debug-session lifecycle/custom events: Starting..., Running, Paused, Not running
- Make the Not running badge clickable and route it to the existing debug start flow
- Keep the change narrow and shared through a small webview helper

## Local verification
- `npx tsc -p tsconfig.json --noEmit`
- `npx vitest run tests/webview/session-status.test.ts tests/extension/debug-session-events.test.ts tests/extension/platform-view-provider.test.ts tests/debug/runtime-control.test.ts`
- `npx vitest run -c vitest.webview.config.ts tests/webview/session-status.test.ts`
- `npx eslint src/debug/session-status.ts src/debug/runtime-control.ts src/debug/adapter-request-controller.ts src/debug/adapter.ts src/extension/debug-session-events.ts src/extension/platform-view-provider.ts webview/common/session-status.ts webview/tec1/index.ts webview/tec1g/index.ts tests/webview/session-status.test.ts tests/debug/runtime-control.test.ts tests/extension/debug-session-events.test.ts tests/extension/platform-view-provider.test.ts`
- `npm test`
- `npm run test:e2e:adapter`

## Risks / follow-up
- The badge state is sourced from adapter-emitted custom session-status events plus extension lifecycle events; if future adapter flow changes introduce a new stop/run transition, the status event needs to be kept in sync.
- The idle view does not show the badge, only the platform top bar where the UI/CPU tabs already exist.
