### PR TITLE
Add explicit empty-state UX for no-workspace, no-folder, and no-project scenarios

### DIFF
--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -48,8 +48,22 @@ function findWorkspaceFolder(rootPath: string | undefined): vscode.WorkspaceFold
 }
 
 async function resolveFolderForProjectCreation(
-  workspaceSelection: WorkspaceSelectionController
+  workspaceSelection: WorkspaceSelectionController,
+  rootPath?: string
 ): Promise<vscode.WorkspaceFolder | undefined> {
+  const directFolder = findWorkspaceFolder(rootPath);
+  if (directFolder !== undefined) {
+    workspaceSelection.rememberWorkspace(directFolder);
+    return directFolder;
+  }
+
+  if (rootPath !== undefined && rootPath.length > 0) {
+    void vscode.window.showInformationMessage(
+      `Debug80: The workspace root ${rootPath} is not open in this window.`
+    );
+    return undefined;
+  }
+
   const folder = await workspaceSelection.resolveWorkspaceFolder({
     prompt: true,
     placeHolder: 'Select a folder for the new Debug80 project',
@@ -190,8 +204,8 @@ export function registerExtensionCommands({
   targetSelection,
 }: CommandDependencies): void {
   context.subscriptions.push(
-    vscode.commands.registerCommand('debug80.createProject', async () => {
-      const folder = await resolveFolderForProjectCreation(workspaceSelection);
+    vscode.commands.registerCommand('debug80.createProject', async (args?: { rootPath?: string }) => {
+      const folder = await resolveFolderForProjectCreation(workspaceSelection, args?.rootPath);
       if (!folder) {
         void vscode.window.showErrorMessage('Debug80: No workspace folder available for project creation.');
         return false;

--- a/src/extension/platform-view-messages.ts
+++ b/src/extension/platform-view-messages.ts
@@ -11,7 +11,7 @@ export type PlatformViewMessage = {
 };
 
 export interface PlatformViewMessageDependencies {
-  handleCreateProject: () => PromiseLike<void>;
+  handleCreateProject: (args?: { rootPath?: string }) => PromiseLike<void>;
   handleSelectProject: (args?: { rootPath?: string }) => PromiseLike<void>;
   handleSelectTarget: (args?: { rootPath?: string; targetName?: string }) => PromiseLike<void>;
   handleRestartDebug: () => PromiseLike<void>;
@@ -32,7 +32,11 @@ export async function handlePlatformViewMessage(
   deps: PlatformViewMessageDependencies
 ): Promise<void> {
   if (msg?.type === 'createProject') {
-    await deps.handleCreateProject();
+    await deps.handleCreateProject(
+      typeof msg.rootPath === 'string' && msg.rootPath.length > 0
+        ? { rootPath: msg.rootPath }
+        : undefined
+    );
     return;
   }
   if (msg?.type === 'selectProject') {

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -327,7 +327,9 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
         return;
       }
       if (msg?.type === 'createProject') {
-        await vscode.commands.executeCommand('debug80.createProject');
+        await vscode.commands.executeCommand('debug80.createProject', {
+          rootPath: (msg as { rootPath?: string }).rootPath,
+        });
         return;
       }
       if (msg?.type === 'selectProject') {

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -15,6 +15,8 @@ const showErrorMessage = vi.fn();
 const startDebugging = vi.fn();
 const stopDebugging = vi.fn();
 const executeCommand = vi.fn();
+const scaffoldProject = vi.fn();
+let workspaceFolders: Array<{ name: string; uri: { fsPath: string } }> | undefined;
 
 vi.mock('fs', () => ({
   existsSync,
@@ -39,16 +41,23 @@ vi.mock('vscode', () => ({
     showInputBox: vi.fn(),
   },
   workspace: {
-    workspaceFolders: [{ name: 'tec1g-mon3', uri: { fsPath: '/workspace/tec1g-mon3' }, index: 0 }],
+    get workspaceFolders() {
+      return workspaceFolders;
+    },
     getWorkspaceFolder: vi.fn(),
     updateWorkspaceFolders: vi.fn(() => true),
   },
+}));
+
+vi.mock('../../src/extension/project-scaffolding', () => ({
+  scaffoldProject,
 }));
 
 describe('registerExtensionCommands', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     registeredCommands.clear();
+    workspaceFolders = [{ name: 'tec1g-mon3', uri: { fsPath: '/workspace/tec1g-mon3' }, index: 0 }];
     existsSync.mockImplementation(
       (candidate: string) => path.normalize(candidate) === projectConfigPath
     );
@@ -62,7 +71,9 @@ describe('registerExtensionCommands', () => {
     );
   });
 
-  it('starts debugging with the current project config instead of the selected launch config', async () => {
+  it(
+    'starts debugging with the current project config instead of the selected launch config',
+    async () => {
     const { registerExtensionCommands } = await import('../../src/extension/commands');
 
     const resolveWorkspaceFolder = vi.fn().mockResolvedValue({
@@ -104,6 +115,45 @@ describe('registerExtensionCommands', () => {
       })
     );
     expect(executeCommand).not.toHaveBeenCalledWith('workbench.action.debug.start');
+  },
+    15000
+  );
+
+  it('creates a project directly in an already-open empty workspace root', async () => {
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    workspaceFolders = [{ name: 'empty-root', uri: { fsPath: '/workspace/empty-root' }, index: 0 }];
+    const folder = {
+      name: 'empty-root',
+      uri: { fsPath: '/workspace/empty-root' },
+      index: 0,
+    };
+    const rememberWorkspace = vi.fn();
+    const refreshIdleView = vi.fn();
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder: vi.fn(),
+        rememberWorkspace,
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {} as never,
+    });
+
+    const createProject = registeredCommands.get('debug80.createProject');
+    expect(createProject).toBeTypeOf('function');
+
+    scaffoldProject.mockResolvedValueOnce(true);
+    const result = await createProject?.({ rootPath: folder.uri.fsPath });
+
+    expect(result).toBe(true);
+    expect(rememberWorkspace).toHaveBeenCalledWith(folder);
+    expect(refreshIdleView).toHaveBeenCalled();
+    expect(scaffoldProject).toHaveBeenCalledWith(folder, false);
   });
 
   it('forces a prompt when selecting the active target', async () => {
@@ -275,14 +325,13 @@ describe('registerExtensionCommands', () => {
 
   it('remembers a direct root selection even when no project config exists', async () => {
     const { registerExtensionCommands } = await import('../../src/extension/commands');
-    const vscode = await import('vscode');
 
     const folder = {
       name: 'notes',
       uri: { fsPath: '/workspace/notes' },
       index: 0,
     };
-    (vscode.workspace as { workspaceFolders?: Array<{ name: string; uri: { fsPath: string }; index: number }> }).workspaceFolders = [folder];
+    workspaceFolders = [folder];
     const rememberWorkspace = vi.fn();
 
     registerExtensionCommands({
@@ -367,8 +416,7 @@ describe('registerExtensionCommands', () => {
 
   it('uses a direct target selection without prompting', async () => {
     const { registerExtensionCommands } = await import('../../src/extension/commands');
-    const vscode = await import('vscode');
-    (vscode.workspace as { workspaceFolders?: Array<{ name: string; uri: { fsPath: string }; index: number }> }).workspaceFolders = [
+    workspaceFolders = [
       {
         name: 'tec1g-mon3',
         uri: { fsPath: '/workspace/tec1g-mon3' },

--- a/tests/extension/platform-view-messages.test.ts
+++ b/tests/extension/platform-view-messages.test.ts
@@ -25,7 +25,7 @@ describe('platform-view message routing', () => {
   it('routes control messages to the expected handlers', async () => {
     const deps = createDependencies('simple');
 
-    await handlePlatformViewMessage({ type: 'createProject' }, deps);
+    await handlePlatformViewMessage({ type: 'createProject', rootPath: '/workspace/a' }, deps);
     await handlePlatformViewMessage({ type: 'selectProject', rootPath: '/workspace/a' }, deps);
     await handlePlatformViewMessage(
       { type: 'selectTarget', rootPath: '/workspace/a', targetName: 'app' },
@@ -37,7 +37,7 @@ describe('platform-view message routing', () => {
     await handlePlatformViewMessage({ type: 'serialSendFile' }, deps);
     await handlePlatformViewMessage({ type: 'serialSave', text: 'hello' }, deps);
 
-    expect(deps.handleCreateProject).toHaveBeenCalledTimes(1);
+    expect(deps.handleCreateProject).toHaveBeenCalledWith({ rootPath: '/workspace/a' });
     expect(deps.handleSelectProject).toHaveBeenCalledWith({ rootPath: '/workspace/a' });
     expect(deps.handleSelectTarget).toHaveBeenCalledWith({
       rootPath: '/workspace/a',

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -109,10 +109,14 @@ describe('PlatformViewProvider', () => {
     const provider = new PlatformViewProvider(extensionRoot);
     const webviewView = createWebviewView();
 
-    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
-      isCancellationRequested: false,
-      onCancellationRequested: vi.fn(),
-    } as vscode.CancellationToken);
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
 
     provider.setPlatform('tec1', undefined, { reveal: false, tab: 'ui' });
     await flushPromises();
@@ -125,10 +129,14 @@ describe('PlatformViewProvider', () => {
     const provider = new PlatformViewProvider(extensionRoot);
     const webviewView = createWebviewView();
 
-    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
-      isCancellationRequested: false,
-      onCancellationRequested: vi.fn(),
-    } as vscode.CancellationToken);
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
 
     provider.setPlatform('tec1', undefined, { reveal: false, tab: 'ui' });
     await flushPromises();
@@ -150,10 +158,14 @@ describe('PlatformViewProvider', () => {
     } as never);
     const webviewView = createWebviewView();
 
-    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
-      isCancellationRequested: false,
-      onCancellationRequested: vi.fn(),
-    } as vscode.CancellationToken);
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
 
     provider.setPlatform('tec1g', undefined, { reveal: false, tab: 'ui' });
     workspaceFolders = [
@@ -203,7 +215,9 @@ describe('PlatformViewProvider', () => {
     ).postMessage.mock.calls;
   }
 
-  function findProjectStatusMessages(calls: Array<[Record<string, unknown>]>): Array<Record<string, unknown>> {
+  function findProjectStatusMessages(
+    calls: Array<[Record<string, unknown>]>
+  ): Array<Record<string, unknown>> {
     return calls.filter(([msg]) => msg.type === 'projectStatus').map(([msg]) => msg);
   }
 
@@ -214,10 +228,14 @@ describe('PlatformViewProvider', () => {
     } as never);
     const webviewView = createWebviewView();
 
-    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
-      isCancellationRequested: false,
-      onCancellationRequested: vi.fn(),
-    } as vscode.CancellationToken);
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
 
     workspaceFolders = [{ name: 'demo', uri: { fsPath: '/workspace/demo' } }];
     provider.setSelectedWorkspace({ name: 'demo', uri: { fsPath: '/workspace/demo' } } as never);
@@ -246,10 +264,14 @@ describe('PlatformViewProvider', () => {
       }
     );
 
-    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
-      isCancellationRequested: false,
-      onCancellationRequested: vi.fn(),
-    } as vscode.CancellationToken);
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
 
     workspaceFolders = [{ name: 'demo', uri: { fsPath: '/workspace/demo' } }];
     provider.setSelectedWorkspace({ name: 'demo', uri: { fsPath: '/workspace/demo' } } as never);
@@ -273,13 +295,20 @@ describe('PlatformViewProvider', () => {
     } as never);
     const webviewView = createWebviewView();
 
-    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
-      isCancellationRequested: false,
-      onCancellationRequested: vi.fn(),
-    } as vscode.CancellationToken);
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
 
     workspaceFolders = [{ name: 'myproject', uri: { fsPath: '/workspace/myproject' } }];
-    provider.setSelectedWorkspace({ name: 'myproject', uri: { fsPath: '/workspace/myproject' } } as never);
+    provider.setSelectedWorkspace({
+      name: 'myproject',
+      uri: { fsPath: '/workspace/myproject' },
+    } as never);
     provider.setHasProject(true);
     provider.setPlatform('tec1', undefined, { reveal: false, tab: 'ui' });
 
@@ -300,10 +329,14 @@ describe('PlatformViewProvider', () => {
     } as never);
     const webviewView = createWebviewView();
 
-    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
-      isCancellationRequested: false,
-      onCancellationRequested: vi.fn(),
-    } as vscode.CancellationToken);
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
 
     provider.setPlatform('tec1g', undefined, { reveal: false, tab: 'ui' });
 
@@ -314,7 +347,10 @@ describe('PlatformViewProvider', () => {
 
     // Clear and switch workspace
     (webviewView.webview.postMessage as ReturnType<typeof vi.fn>).mockClear();
-    provider.setSelectedWorkspace({ name: 'proj-b', uri: { fsPath: '/workspace/proj-b' } } as never);
+    provider.setSelectedWorkspace({
+      name: 'proj-b',
+      uri: { fsPath: '/workspace/proj-b' },
+    } as never);
 
     const statusMessages = findProjectStatusMessages(getPostMessageCalls(webviewView));
     expect(statusMessages.length).toBeGreaterThanOrEqual(1);
@@ -328,10 +364,14 @@ describe('PlatformViewProvider', () => {
     } as never);
     const webviewView = createWebviewView();
 
-    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
-      isCancellationRequested: false,
-      onCancellationRequested: vi.fn(),
-    } as vscode.CancellationToken);
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
 
     workspaceFolders = [{ name: 'demo', uri: { fsPath: '/workspace/demo' } }];
     provider.setSelectedWorkspace({ name: 'demo', uri: { fsPath: '/workspace/demo' } } as never);
@@ -353,10 +393,14 @@ describe('PlatformViewProvider', () => {
     } as never);
     const webviewView = createWebviewView();
 
-    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
-      isCancellationRequested: false,
-      onCancellationRequested: vi.fn(),
-    } as vscode.CancellationToken);
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
 
     workspaceFolders = [{ name: 'demo', uri: { fsPath: '/workspace/demo' } }];
     provider.setSelectedWorkspace({ name: 'demo', uri: { fsPath: '/workspace/demo' } } as never);
@@ -381,10 +425,14 @@ describe('PlatformViewProvider', () => {
     } as never);
     const webviewView = createWebviewView();
 
-    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
-      isCancellationRequested: false,
-      onCancellationRequested: vi.fn(),
-    } as vscode.CancellationToken);
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
     provider.setPlatform('tec1g', undefined, { reveal: false, tab: 'ui' });
 
     (webviewView.webview.postMessage as ReturnType<typeof vi.fn>).mockClear();
@@ -407,10 +455,14 @@ describe('PlatformViewProvider', () => {
     } as never);
     const webviewView = createWebviewView();
 
-    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
-      isCancellationRequested: false,
-      onCancellationRequested: vi.fn(),
-    } as vscode.CancellationToken);
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
     provider.setPlatform('tec1g', { id: 'session-1' } as never, { reveal: false, tab: 'ui' });
 
     (webviewView.webview.postMessage as ReturnType<typeof vi.fn>).mockClear();
@@ -433,10 +485,14 @@ describe('PlatformViewProvider', () => {
     } as never);
     const webviewView = createWebviewView();
 
-    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
-      isCancellationRequested: false,
-      onCancellationRequested: vi.fn(),
-    } as vscode.CancellationToken);
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
 
     const handler = (webviewView.webview.onDidReceiveMessage as ReturnType<typeof vi.fn>).mock
       .calls[0]?.[0] as ((msg: { type?: string }) => Promise<void>) | undefined;
@@ -445,5 +501,32 @@ describe('PlatformViewProvider', () => {
     await handler?.({ type: 'startDebug' });
 
     expect(executeCommand).toHaveBeenCalledWith('debug80.startDebug');
+  });
+
+  it('routes createProject messages with a root path to the create command', async () => {
+    const provider = new PlatformViewProvider(extensionRoot, {
+      get: vi.fn(),
+      update: vi.fn(),
+    } as never);
+    const webviewView = createWebviewView();
+
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
+
+    const handler = (webviewView.webview.onDidReceiveMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as ((msg: { type?: string; rootPath?: string }) => Promise<void>) | undefined;
+    expect(handler).toBeTypeOf('function');
+
+    await handler?.({ type: 'createProject', rootPath: '/workspace/empty-root' });
+
+    expect(executeCommand).toHaveBeenCalledWith('debug80.createProject', {
+      rootPath: '/workspace/empty-root',
+    });
   });
 });

--- a/tests/webview/common/project-root-button.test.ts
+++ b/tests/webview/common/project-root-button.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @file Regression tests: project root button empty-state behavior.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createProjectRootButtonController } from '../../../webview/common/project-root-button';
+
+type PostedMessage = { type: string; [key: string]: unknown };
+
+function createVscodeMock(messages: PostedMessage[]) {
+  return {
+    postMessage: (message: PostedMessage) => {
+      messages.push(message);
+    },
+  };
+}
+
+describe('project root button controller', () => {
+  let rootButton: HTMLButtonElement;
+  let createButton: HTMLButtonElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <button id="selectProject" type="button"></button>
+      <button id="createProject" type="button"></button>
+    `;
+    rootButton = document.getElementById('selectProject') as HTMLButtonElement;
+    createButton = document.getElementById('createProject') as HTMLButtonElement;
+  });
+
+  it('offers an open-folder action when there are no workspace roots', () => {
+    const messages: PostedMessage[] = [];
+    const controller = createProjectRootButtonController(
+      createVscodeMock(messages),
+      rootButton,
+      createButton
+    );
+
+    controller.applyProjectStatus({ roots: [], targetCount: 0 });
+    rootButton.click();
+
+    expect(rootButton.textContent).toBe('Open Folder');
+    expect(rootButton.title).toContain('Open a folder');
+    expect(createButton.hidden).toBe(true);
+    expect(messages).toContainEqual({ type: 'createProject' });
+  });
+
+  it('offers create-project for an empty root and keeps root selection separate', () => {
+    const messages: PostedMessage[] = [];
+    const controller = createProjectRootButtonController(
+      createVscodeMock(messages),
+      rootButton,
+      createButton
+    );
+
+    controller.applyProjectStatus({
+      rootPath: '/workspace/debug80',
+      roots: [{ name: 'debug80', path: '/workspace/debug80', hasProject: false }],
+      targetCount: 0,
+    });
+
+    expect(rootButton.textContent).toBe('debug80');
+    expect(createButton.hidden).toBe(false);
+    expect(createButton.title).toContain('debug80');
+
+    createButton.click();
+    expect(messages).toContainEqual({ type: 'createProject', rootPath: '/workspace/debug80' });
+  });
+
+  it('keeps the root selector behavior for configured projects', () => {
+    const messages: PostedMessage[] = [];
+    const controller = createProjectRootButtonController(
+      createVscodeMock(messages),
+      rootButton,
+      createButton
+    );
+
+    controller.applyProjectStatus({
+      rootPath: '/workspace/debug80',
+      roots: [{ name: 'debug80', path: '/workspace/debug80', hasProject: true }],
+      targetCount: 1,
+    });
+
+    rootButton.click();
+
+    expect(createButton.hidden).toBe(true);
+    expect(messages).toContainEqual({ type: 'selectProject' });
+  });
+});

--- a/webview/common/project-root-button.ts
+++ b/webview/common/project-root-button.ts
@@ -1,0 +1,145 @@
+/**
+ * @file Shared project-root button controller for the Debug80 webviews.
+ */
+
+export type ProjectRootOption = {
+  name: string;
+  path: string;
+  hasProject: boolean;
+};
+
+type ProjectRootButtonState = {
+  roots: ProjectRootOption[];
+  rootPath?: string;
+  targetCount: number;
+};
+
+type VsCodeLike = {
+  postMessage: (message: Record<string, unknown>) => void;
+};
+
+export type ProjectRootButtonController = {
+  applyProjectStatus: (status: {
+    rootPath?: string;
+    roots: ProjectRootOption[];
+    targetCount: number;
+  }) => void;
+  dispose: () => void;
+};
+
+function selectedRoot(
+  roots: ProjectRootOption[],
+  rootPath: string | undefined
+): ProjectRootOption | undefined {
+  if (rootPath !== undefined && rootPath !== '') {
+    return roots.find((root) => root.path === rootPath);
+  }
+  return roots[0];
+}
+
+export function createProjectRootButtonController(
+  vscode: VsCodeLike,
+  rootButton: HTMLButtonElement | null,
+  createButton: HTMLButtonElement | null
+): ProjectRootButtonController {
+  let state: ProjectRootButtonState = {
+    roots: [],
+    rootPath: undefined,
+    targetCount: 0,
+  };
+
+  const syncButtons = (): void => {
+    if (!rootButton) {
+      return;
+    }
+
+    const selected = selectedRoot(state.roots, state.rootPath);
+    const rootConfigured = selected?.hasProject === true;
+    const hasRoots = state.roots.length > 0;
+    const hasSelectedRoot = selected !== undefined;
+    const isEmptyRoot = hasSelectedRoot && !rootConfigured;
+
+    if (!hasRoots) {
+      rootButton.disabled = false;
+      rootButton.textContent = 'Open Folder';
+      rootButton.title = 'Open a folder to create or find a Debug80 project.';
+      rootButton.dataset.action = 'create';
+      delete rootButton.dataset.rootPath;
+    } else if (hasSelectedRoot && !rootConfigured) {
+      rootButton.disabled = false;
+      rootButton.textContent = selected.name;
+      rootButton.title = `${selected.name} — ${selected.path} (no Debug80 project config)`;
+      rootButton.dataset.action = 'select';
+      rootButton.dataset.rootPath = selected.path;
+    } else if (hasSelectedRoot) {
+      rootButton.disabled = false;
+      rootButton.textContent = selected.name;
+      rootButton.title =
+        state.targetCount === 0
+          ? `${selected.name} — ${selected.path} (no Debug80 targets available)`
+          : `${selected.name} — ${selected.path}`;
+      rootButton.dataset.action = 'select';
+      rootButton.dataset.rootPath = selected.path;
+    } else {
+      rootButton.disabled = false;
+      rootButton.textContent = 'Select workspace root';
+      rootButton.title = 'Select workspace root';
+      rootButton.dataset.action = 'select';
+      delete rootButton.dataset.rootPath;
+    }
+
+    if (createButton) {
+      createButton.hidden = !isEmptyRoot;
+      createButton.disabled = !isEmptyRoot;
+      createButton.textContent = 'Create Project';
+      createButton.title = isEmptyRoot
+        ? `Create a Debug80 project in ${selected.name}.`
+        : 'Create a Debug80 project in this workspace root.';
+      createButton.dataset.rootPath = isEmptyRoot ? selected.path : '';
+    }
+  };
+
+  const handleRootClick = (): void => {
+    if (!rootButton) {
+      return;
+    }
+
+    if (rootButton.dataset.action === 'create') {
+      vscode.postMessage({
+        type: 'createProject',
+        ...(rootButton.dataset.rootPath ? { rootPath: rootButton.dataset.rootPath } : {}),
+      });
+      return;
+    }
+
+    vscode.postMessage({ type: 'selectProject' });
+  };
+
+  const handleCreateClick = (): void => {
+    if (!createButton || createButton.hidden) {
+      return;
+    }
+    vscode.postMessage({
+      type: 'createProject',
+      ...(createButton.dataset.rootPath ? { rootPath: createButton.dataset.rootPath } : {}),
+    });
+  };
+
+  rootButton?.addEventListener('click', handleRootClick);
+  createButton?.addEventListener('click', handleCreateClick);
+
+  return {
+    applyProjectStatus(status) {
+      state = {
+        roots: status.roots,
+        rootPath: status.rootPath,
+        targetCount: status.targetCount,
+      };
+      syncButtons();
+    },
+    dispose() {
+      rootButton?.removeEventListener('click', handleRootClick);
+      createButton?.removeEventListener('click', handleCreateClick);
+    },
+  };
+}

--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -22,6 +22,10 @@ body {
       min-width: 0;
       flex: 1;
     }
+    .project-control.actions {
+      flex: 0 0 auto;
+      align-items: stretch;
+    }
     .project-label {
       font-size: 10px;
       letter-spacing: 0.08em;
@@ -45,6 +49,25 @@ body {
       white-space: nowrap;
     }
     .project-root-button:disabled {
+      cursor: default;
+      color: #7a7a7a;
+    }
+    .project-action-button {
+      flex: 0 0 auto;
+      min-width: 0;
+      border: 1px solid #333;
+      border-radius: 6px;
+      background: #222;
+      color: #f0f0f0;
+      padding: 4px 8px;
+      font-size: 11px;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .project-action-button[hidden] {
+      display: none;
+    }
+    .project-action-button:disabled {
       cursor: default;
       color: #7a7a7a;
     }

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -13,6 +13,7 @@
       <div class="project-control">
         <span class="project-label">Project</span>
         <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
+        <button class="project-action-button" id="createProject" type="button" hidden>Create Project</button>
       </div>
       <div class="project-control">
         <span class="project-label">Target</span>

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -1,6 +1,7 @@
 import { createDigit } from '../common/digits';
 import { MemoryPanel } from '../common/memory-panel';
 import { createSessionStatusController } from '../common/session-status';
+import { createProjectRootButtonController } from '../common/project-root-button';
 import { acquireVscodeApi } from '../common/vscode';
 import { createAudioController } from './audio';
 import { createLcdRenderer } from './lcd-renderer';
@@ -14,6 +15,7 @@ const DEFAULT_TAB: PanelTab =
     ? 'memory'
     : 'ui';
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
+const createProjectButton = document.getElementById('createProject') as HTMLButtonElement | null;
 const sessionStatusButton = document.getElementById('sessionStatus') as HTMLButtonElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const displayEl = document.getElementById('display') as HTMLElement;
@@ -71,10 +73,11 @@ const audio = createAudioController(muteEl);
 const lcdRenderer = createLcdRenderer();
 const matrixRenderer = createMatrixRenderer();
 const sessionStatusController = createSessionStatusController(vscode, sessionStatusButton);
-
-selectProjectButton?.addEventListener('click', () => {
-  vscode.postMessage({ type: 'selectProject' });
-});
+const projectRootController = createProjectRootButtonController(
+  vscode,
+  selectProjectButton,
+  createProjectButton
+);
 
 homeTargetSelect?.addEventListener('change', () => {
   const targetName = homeTargetSelect.value;
@@ -101,31 +104,6 @@ function setSelectPlaceholder(select: HTMLSelectElement, label: string): void {
   option.disabled = true;
   option.selected = true;
   select.appendChild(option);
-}
-
-function setRootOptions(
-  options: Array<{ name: string; path: string; hasProject: boolean }>,
-  selectedRootPath?: string
-): void {
-  if (!selectProjectButton) {
-    return;
-  }
-  if (options.length === 0) {
-    selectProjectButton.disabled = true;
-    selectProjectButton.textContent = 'No workspace roots available';
-    selectProjectButton.title = 'No workspace roots available';
-    return;
-  }
-  const selected = options.find((option) => option.path === selectedRootPath) ?? options[0];
-  selectProjectButton.disabled = false;
-  selectProjectButton.textContent =
-    selected !== undefined ? selected.name : 'Select workspace root';
-  selectProjectButton.title =
-    selected === undefined
-      ? 'Select workspace root'
-      : selected.hasProject
-        ? `${selected.name} — ${selected.path}`
-        : `${selected.name} — ${selected.path} (no Debug80 project config)`;
 }
 
 function setTargetOptions(options: Array<{ name: string; description?: string; detail?: string }>, selectedTargetName?: string): void {
@@ -157,7 +135,11 @@ function applyProjectStatus(payload: {
   targetName?: string;
 }): void {
   currentRootPath = payload.rootPath ?? '';
-  setRootOptions(payload.roots ?? [], currentRootPath);
+  projectRootController.applyProjectStatus({
+    rootPath: payload.rootPath,
+    roots: payload.roots ?? [],
+    targetCount: payload.targets?.length ?? 0,
+  });
   setTargetOptions(payload.targets ?? [], payload.targetName);
 }
 
@@ -399,5 +381,6 @@ window.addEventListener('keydown', event => {
 window.addEventListener('beforeunload', () => {
   serialUi.dispose();
   sessionStatusController.dispose();
+  projectRootController.dispose();
 });
   

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -13,6 +13,7 @@
       <div class="project-control">
         <span class="project-label">Project</span>
         <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
+        <button class="project-action-button" id="createProject" type="button" hidden>Create Project</button>
       </div>
       <div class="project-control">
         <span class="project-label">Target</span>

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -1,6 +1,7 @@
 import { createDigit } from '../common/digits';
 import { MemoryPanel } from '../common/memory-panel';
 import { createSessionStatusController, type SessionStatus } from '../common/session-status';
+import { createProjectRootButtonController } from '../common/project-root-button';
 import { acquireVscodeApi } from '../common/vscode';
 import { createGlcdRenderer } from './glcd-renderer';
 import { createLcdRenderer } from './lcd-renderer';
@@ -103,6 +104,7 @@ const DEFAULT_TAB: PanelTab =
     ? 'memory'
     : 'ui';
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
+const createProjectButton = document.getElementById('createProject') as HTMLButtonElement | null;
 const sessionStatusButton = document.getElementById('sessionStatus') as HTMLButtonElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const displayEl = document.getElementById('display') as HTMLElement;
@@ -246,10 +248,11 @@ let shiftLatched = false;
 let audioCtx: AudioContext | null = null;
 let osc: OscillatorNode | null = null;
 let gain: GainNode | null = null;
-
-selectProjectButton?.addEventListener('click', () => {
-  vscode.postMessage({ type: 'selectProject' });
-});
+const projectRootController = createProjectRootButtonController(
+  vscode,
+  selectProjectButton,
+  createProjectButton
+);
 
 homeTargetSelect?.addEventListener('change', () => {
   const targetName = homeTargetSelect.value;
@@ -276,28 +279,6 @@ function setSelectPlaceholder(select: HTMLSelectElement, label: string): void {
   option.disabled = true;
   option.selected = true;
   select.appendChild(option);
-}
-
-function setRootOptions(options: ProjectRootOption[], selectedRootPath?: string): void {
-  if (!selectProjectButton) {
-    return;
-  }
-  if (options.length === 0) {
-    selectProjectButton.disabled = true;
-    selectProjectButton.textContent = 'No workspace roots available';
-    selectProjectButton.title = 'No workspace roots available';
-    return;
-  }
-  const selected = options.find((option) => option.path === selectedRootPath) ?? options[0];
-  selectProjectButton.disabled = false;
-  selectProjectButton.textContent =
-    selected !== undefined ? selected.name : 'Select workspace root';
-  selectProjectButton.title =
-    selected === undefined
-      ? 'Select workspace root'
-      : selected.hasProject
-        ? `${selected.name} — ${selected.path}`
-        : `${selected.name} — ${selected.path} (no Debug80 project config)`;
 }
 
 function setTargetOptions(options: ProjectTargetOption[], selectedTargetName?: string): void {
@@ -329,7 +310,11 @@ function applyProjectStatus(payload: {
   targetName?: string;
 }): void {
   currentRootPath = payload.rootPath ?? '';
-  setRootOptions(payload.roots ?? [], currentRootPath);
+  projectRootController.applyProjectStatus({
+    rootPath: payload.rootPath,
+    roots: payload.roots ?? [],
+    targetCount: payload.targets?.length ?? 0,
+  });
   setTargetOptions(payload.targets ?? [], payload.targetName);
 }
 
@@ -716,5 +701,6 @@ window.addEventListener('keyup', event => {
 });
 window.addEventListener('beforeunload', () => {
   sessionStatusController.dispose();
+  projectRootController.dispose();
 });
   


### PR DESCRIPTION
## Summary\nMake the Debug80 project header honest about empty states and give the user a direct action when there is no configured project.\n\n## What changed\n- Added a shared project-root button controller for TEC-1 and TEC-1G.\n- The Project control now shows `Open Folder` when there are no workspace roots.\n- When a selected root has no Debug80 config, the panel exposes a `Create Project` action for that root.\n- The existing create-project command now accepts an optional root path so the panel can scaffold the selected empty folder directly.\n- Added tests for the new project-root button behavior and the message routing/extension wiring.\n\n## Verification\n- `npx tsc -p tsconfig.json --noEmit`\n- `npx vitest run tests/webview/common/project-root-button.test.ts tests/extension/platform-view-messages.test.ts tests/extension/commands.test.ts tests/extension/platform-view-provider.test.ts`\n- `npx eslint webview/common/project-root-button.ts webview/tec1/index.ts webview/tec1g/index.ts src/extension/commands.ts src/extension/platform-view-provider.ts src/extension/platform-view-messages.ts tests/webview/common/project-root-button.test.ts tests/extension/commands.test.ts tests/extension/platform-view-messages.test.ts tests/extension/platform-view-provider.test.ts`\n- `npm test`\n\n## Notes\n- The empty-state treatment is intentionally narrow. It does not add a richer project settings UI yet; that remains the follow-up work for the project manifest/config flow.