### PR TITLE
Add compact debug session status indicator

### DIFF
--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -4,19 +4,29 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { executeCommand, resolveProjectStatusSummary, findProjectConfigPath, listProjectTargetChoices } = vi.hoisted(() => ({
-  executeCommand: vi.fn(() => Promise.resolve()),
-  resolveProjectStatusSummary: vi.fn(() => ({
-    projectName: 'demo',
-    targetName: 'app',
-    entrySource: 'src/main.asm',
-  })),
-  findProjectConfigPath: vi.fn((folder: { uri: { fsPath: string } }) => `${folder.uri.fsPath}/.vscode/debug80.json`),
-  listProjectTargetChoices: vi.fn(() => [
-    { name: 'app', description: 'src/main.asm', detail: 'src/main.asm' },
-    { name: 'serial', description: 'src/serial.asm', detail: 'src/serial.asm' },
-  ]),
-}));
+const {
+  executeCommand,
+  resolveProjectStatusSummary,
+  findProjectConfigPath,
+  listProjectTargetChoices,
+} = vi.hoisted(() => {
+  const executeCommand = vi.fn(() => Promise.resolve(true));
+  return {
+    executeCommand,
+    resolveProjectStatusSummary: vi.fn(() => ({
+      projectName: 'demo',
+      targetName: 'app',
+      entrySource: 'src/main.asm',
+    })),
+    findProjectConfigPath: vi.fn(
+      (folder: { uri: { fsPath: string } }) => `${folder.uri.fsPath}/.vscode/debug80.json`
+    ),
+    listProjectTargetChoices: vi.fn(() => [
+      { name: 'app', description: 'src/main.asm', detail: 'src/main.asm' },
+      { name: 'serial', description: 'src/serial.asm', detail: 'src/serial.asm' },
+    ]),
+  };
+});
 
 let workspaceFolders: Array<{ name: string; uri: { fsPath: string } }> | undefined;
 
@@ -414,5 +424,26 @@ describe('PlatformViewProvider', () => {
       type: 'sessionStatus',
       status: 'not running',
     });
+  });
+
+  it('routes startDebug messages to the existing start command', async () => {
+    const provider = new PlatformViewProvider(extensionRoot, {
+      get: vi.fn(),
+      update: vi.fn(),
+    } as never);
+    const webviewView = createWebviewView();
+
+    provider.resolveWebviewView(webviewView, {} as vscode.WebviewViewResolveContext, {
+      isCancellationRequested: false,
+      onCancellationRequested: vi.fn(),
+    } as vscode.CancellationToken);
+
+    const handler = (webviewView.webview.onDidReceiveMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as ((msg: { type?: string }) => Promise<void>) | undefined;
+    expect(handler).toBeTypeOf('function');
+
+    await handler?.({ type: 'startDebug' });
+
+    expect(executeCommand).toHaveBeenCalledWith('debug80.startDebug');
   });
 });

--- a/tests/webview/session-status.test.ts
+++ b/tests/webview/session-status.test.ts
@@ -45,6 +45,10 @@ describe('debugger session status badge', () => {
     expect(badge?.textContent).toBe('Not running');
     expect(badge?.dataset.status).toBe('not-running');
     expect(badge?.disabled).toBe(false);
+    expect(badge?.title).toBe('Click to start debugging');
+    expect(badge?.getAttribute('aria-label')).toBe(
+      'Not running. Click to start debugging'
+    );
   });
 
   it.each(HTML_PATHS)('updates the badge text for %s session states', (_label, htmlPath) => {
@@ -60,14 +64,17 @@ describe('debugger session status badge', () => {
     expect(badge?.textContent).toBe('Starting...');
     expect(badge?.dataset.status).toBe('starting');
     expect(badge?.disabled).toBe(true);
+    expect(badge?.title).toBe('Debugger session is starting');
 
     controller.setStatus('running');
     expect(badge?.textContent).toBe('Running');
     expect(badge?.dataset.status).toBe('running');
+    expect(badge?.title).toBe('Debugger session is running');
 
     controller.setStatus('paused');
     expect(badge?.textContent).toBe('Paused');
     expect(badge?.dataset.status).toBe('paused');
+    expect(badge?.title).toBe('Debugger session is paused');
 
     controller.dispose();
   });

--- a/webview/common/session-status.ts
+++ b/webview/common/session-status.ts
@@ -50,6 +50,9 @@ export function createSessionStatusController(
     element.dataset.status = status.replace(/\s+/g, '-');
     element.className = statusClass(status);
     element.title = STATUS_TITLES[status];
+    element.setAttribute('aria-label', `${STATUS_LABELS[status]}. ${STATUS_TITLES[status]}`);
+    element.setAttribute('aria-live', 'polite');
+    element.setAttribute('aria-atomic', 'true');
     element.disabled = status !== 'not running';
   };
 

--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -289,14 +289,14 @@ body {
     .session-status {
       border: 1px solid #3b3b3b;
       border-radius: 999px;
-      padding: 5px 10px;
-      font-size: 10px;
-      letter-spacing: 0.08em;
+      padding: 4px 8px;
+      font-size: 9px;
+      letter-spacing: 0.06em;
       text-transform: uppercase;
       background: #242424;
       color: #cfcfcf;
       cursor: default;
-      min-width: 108px;
+      min-width: 96px;
       text-align: center;
       white-space: nowrap;
     }

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -24,7 +24,16 @@
         <button class="tab" data-tab="ui">UI</button>
         <button class="tab" data-tab="memory">CPU</button>
       </div>
-      <button class="session-status" id="sessionStatus" type="button" data-status="not-running">Not running</button>
+      <button
+        class="session-status"
+        id="sessionStatus"
+        type="button"
+        data-status="not-running"
+        title="Click to start debugging"
+        aria-label="Not running. Click to start debugging"
+        aria-live="polite"
+        aria-atomic="true"
+      >Not running</button>
     </div>
     <div class="panel panel-ui" id="panel-ui">
       <div class="layout">

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -24,7 +24,16 @@
         <button class="tab" data-tab="ui">UI</button>
         <button class="tab" data-tab="memory">CPU</button>
       </div>
-      <button class="session-status" id="sessionStatus" type="button" data-status="not-running">Not running</button>
+      <button
+        class="session-status"
+        id="sessionStatus"
+        type="button"
+        data-status="not-running"
+        title="Click to start debugging"
+        aria-label="Not running. Click to start debugging"
+        aria-live="polite"
+        aria-atomic="true"
+      >Not running</button>
     </div>
     <div class="panel panel-ui" id="panel-ui">
       <div class="ui-controls" id="uiControls">


### PR DESCRIPTION
Implements issue #233 by wiring the debugger session badge to real session lifecycle events, keeping it compact in the top bar, and covering the idle click-to-start path with tests.