### PR TITLE
Add platform selection to Debug80 project creation flow

### DIFF
--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -7,11 +7,24 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { ensureDirExists, inferDefaultTarget } from '../debug/config-utils';
 import { listProjectSourceFiles } from './project-config';
+import { TEC1_APP_START_DEFAULT } from '../platforms/tec1/constants';
+import {
+  TEC1G_APP_START_DEFAULT,
+  TEC1G_RAM_END,
+  TEC1G_RAM_START,
+  TEC1G_ROM0_END,
+  TEC1G_ROM0_START,
+  TEC1G_ROM1_END,
+  TEC1G_ROM1_START,
+} from '../platforms/tec1g/constants';
+
+type ScaffoldPlatform = 'simple' | 'tec1' | 'tec1g';
 
 type StarterLanguage = 'asm' | 'zax';
 
 type ScaffoldPlan = {
   targetName: string;
+  platform: ScaffoldPlatform;
   sourceFile: string;
   outputDir: string;
   artifactBase: string;
@@ -26,6 +39,50 @@ type SourceChoice =
   | { kind: 'existing'; sourceFile: string }
   | { kind: 'starter'; language: StarterLanguage };
 
+function createSimpleDefaults(): Record<string, unknown> {
+  return {
+    regions: [
+      { start: 0, end: 2047, kind: 'rom' },
+      { start: 2048, end: 65535, kind: 'ram' },
+    ],
+    appStart: 0x0900,
+    entry: 0,
+  };
+}
+
+function createTec1Defaults(): Record<string, unknown> {
+  return {
+    regions: [
+      { start: 0, end: 2047, kind: 'rom' },
+      { start: 2048, end: 4095, kind: 'ram' },
+    ],
+    appStart: TEC1_APP_START_DEFAULT,
+    entry: 0,
+  };
+}
+
+function createTec1gDefaults(): Record<string, unknown> {
+  return {
+    regions: [
+      { start: TEC1G_ROM0_START, end: TEC1G_ROM0_END, kind: 'rom' },
+      { start: TEC1G_RAM_START, end: TEC1G_RAM_END, kind: 'ram' },
+      { start: TEC1G_ROM1_START, end: TEC1G_ROM1_END, kind: 'rom' },
+    ],
+    appStart: TEC1G_APP_START_DEFAULT,
+    entry: 0,
+  };
+}
+
+function platformDisplayName(platform: ScaffoldPlatform): string {
+  if (platform === 'tec1') {
+    return 'TEC-1';
+  }
+  if (platform === 'tec1g') {
+    return 'TEC-1G';
+  }
+  return 'Simple';
+}
+
 export function createStarterSourceContent(language: StarterLanguage): string {
   if (language === 'zax') {
     return ['; Debug80 starter (ZAX)', '', 'start:', '    nop', '    jr start', ''].join('\n');
@@ -35,26 +92,55 @@ export function createStarterSourceContent(language: StarterLanguage): string {
 }
 
 export function createDefaultProjectConfig(plan: ScaffoldPlan): Record<string, unknown> {
+  const targetConfig: Record<string, unknown> = {
+    sourceFile: plan.sourceFile,
+    outputDir: plan.outputDir,
+    artifactBase: plan.artifactBase,
+    platform: plan.platform,
+    ...(plan.assembler !== undefined ? { assembler: plan.assembler } : {}),
+  };
+
+  if (plan.platform === 'tec1') {
+    targetConfig.tec1 = createTec1Defaults();
+  } else if (plan.platform === 'tec1g') {
+    targetConfig.tec1g = createTec1gDefaults();
+  } else {
+    targetConfig.simple = createSimpleDefaults();
+  }
+
   return {
     defaultTarget: plan.targetName,
     targets: {
-      [plan.targetName]: {
-        sourceFile: plan.sourceFile,
-        outputDir: plan.outputDir,
-        artifactBase: plan.artifactBase,
-        platform: 'simple',
-        ...(plan.assembler !== undefined ? { assembler: plan.assembler } : {}),
-        simple: {
-          regions: [
-            { start: 0, end: 2047, kind: 'rom' },
-            { start: 2048, end: 65535, kind: 'ram' },
-          ],
-          appStart: 0x0900,
-          entry: 0,
-        },
-      },
+      [plan.targetName]: targetConfig,
     },
   };
+}
+
+async function choosePlatform(): Promise<ScaffoldPlatform | undefined> {
+  const items: Array<vscode.QuickPickItem & { platform: ScaffoldPlatform }> = [
+    {
+      label: 'Simple',
+      description: 'Generic Debug80 memory-map platform',
+      platform: 'simple',
+    },
+    {
+      label: 'TEC-1',
+      description: 'Classic TEC-1 keypad/LCD platform',
+      platform: 'tec1',
+    },
+    {
+      label: 'TEC-1G',
+      description: 'TEC-1G LCD/GLCD/matrix platform',
+      platform: 'tec1g',
+    },
+  ];
+
+  const picked = await vscode.window.showQuickPick(items, {
+    placeHolder: 'Choose the platform for this Debug80 project',
+    matchOnDescription: true,
+  });
+
+  return picked?.platform;
 }
 
 export function createDefaultLaunchConfig(): Record<string, unknown> {
@@ -118,7 +204,7 @@ export async function scaffoldProject(
       }
       fs.writeFileSync(configPath, `${JSON.stringify(defaultConfig, null, 2)}\n`);
       void vscode.window.showInformationMessage(
-        `Debug80: Created .vscode/debug80.json targeting ${scaffoldPlan.sourceFile}.`
+        `Debug80: Created ${platformDisplayName(scaffoldPlan.platform)} project in .vscode/debug80.json targeting ${scaffoldPlan.sourceFile}.`
       );
       created = true;
     } catch (err) {
@@ -160,14 +246,21 @@ async function buildScaffoldPlan(
   folder: vscode.WorkspaceFolder,
   inferred: { sourceFile: string; outputDir: string; artifactBase: string }
 ): Promise<ScaffoldPlan | undefined> {
+  const platform = await choosePlatform();
+  if (platform === undefined) {
+    return undefined;
+  }
+
   const targetName =
-    (await vscode.window.showInputBox({
-      prompt: 'Debug80 target name',
-      placeHolder: 'app',
-      value: 'app',
-      validateInput: (value) =>
-        value.trim().length === 0 ? 'Target name cannot be empty.' : undefined,
-    }))?.trim() ?? '';
+    (
+      await vscode.window.showInputBox({
+        prompt: 'Debug80 target name',
+        placeHolder: 'app',
+        value: 'app',
+        validateInput: (value) =>
+          value.trim().length === 0 ? 'Target name cannot be empty.' : undefined,
+      })
+    )?.trim() ?? '';
   if (targetName.length === 0) {
     return undefined;
   }
@@ -181,6 +274,7 @@ async function buildScaffoldPlan(
     const sourceFile = choice.sourceFile;
     return {
       targetName,
+      platform,
       sourceFile,
       outputDir: inferred.outputDir,
       artifactBase: path.basename(sourceFile, path.extname(sourceFile)) || inferred.artifactBase,
@@ -191,6 +285,7 @@ async function buildScaffoldPlan(
   const sourceFile = choice.language === 'zax' ? 'src/main.zax' : 'src/main.asm';
   return {
     targetName,
+    platform,
     sourceFile,
     outputDir: inferred.outputDir,
     artifactBase: path.basename(sourceFile, path.extname(sourceFile)) || inferred.artifactBase,

--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -1,18 +1,61 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { showQuickPick, showInputBox, showInformationMessage, showErrorMessage } = vi.hoisted(
+  () => ({
+    showQuickPick: vi.fn(),
+    showInputBox: vi.fn(),
+    showInformationMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
+  })
+);
+
 import {
   createDefaultProjectConfig,
   createDefaultLaunchConfig,
   createStarterSourceContent,
+  scaffoldProject,
 } from '../../src/extension/project-scaffolding';
 
 vi.mock('vscode', () => ({
-  window: {},
+  window: {
+    showQuickPick,
+    showInputBox,
+    showInformationMessage,
+    showErrorMessage,
+  },
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn((candidate: string) => !candidate.endsWith('/.vscode/debug80.json')),
+    writeFileSync: vi.fn(),
+  };
+});
+
+vi.mock('../../src/debug/config-utils', () => ({
+  ensureDirExists: vi.fn(),
+  inferDefaultTarget: vi.fn(() => ({
+    sourceFile: 'src/main.asm',
+    outputDir: 'build',
+    artifactBase: 'main',
+  })),
+}));
+
+vi.mock('../../src/extension/project-config', () => ({
+  listProjectSourceFiles: vi.fn(() => []),
 }));
 
 describe('project-scaffolding helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('builds a simple target config for asm sources', () => {
     const config = createDefaultProjectConfig({
       targetName: 'app',
+      platform: 'simple',
       sourceFile: 'src/main.asm',
       outputDir: 'build',
       artifactBase: 'main',
@@ -42,6 +85,7 @@ describe('project-scaffolding helpers', () => {
   it('includes the zax assembler when scaffolding a zax target', () => {
     const config = createDefaultProjectConfig({
       targetName: 'app',
+      platform: 'simple',
       sourceFile: 'src/main.zax',
       outputDir: 'build',
       artifactBase: 'main',
@@ -79,5 +123,118 @@ describe('project-scaffolding helpers', () => {
         },
       ],
     });
+  });
+
+  it('builds a tec1 target config when scaffolding for TEC-1', () => {
+    const config = createDefaultProjectConfig({
+      targetName: 'app',
+      platform: 'tec1',
+      sourceFile: 'src/main.asm',
+      outputDir: 'build',
+      artifactBase: 'main',
+    });
+
+    expect(config).toEqual({
+      defaultTarget: 'app',
+      targets: {
+        app: {
+          sourceFile: 'src/main.asm',
+          outputDir: 'build',
+          artifactBase: 'main',
+          platform: 'tec1',
+          tec1: {
+            regions: [
+              { start: 0, end: 2047, kind: 'rom' },
+              { start: 2048, end: 4095, kind: 'ram' },
+            ],
+            appStart: 0x0800,
+            entry: 0,
+          },
+        },
+      },
+    });
+  });
+
+  it('builds a tec1g target config when scaffolding for TEC-1G', () => {
+    const config = createDefaultProjectConfig({
+      targetName: 'app',
+      platform: 'tec1g',
+      sourceFile: 'src/main.asm',
+      outputDir: 'build',
+      artifactBase: 'main',
+    });
+
+    expect(config).toEqual({
+      defaultTarget: 'app',
+      targets: {
+        app: {
+          sourceFile: 'src/main.asm',
+          outputDir: 'build',
+          artifactBase: 'main',
+          platform: 'tec1g',
+          tec1g: {
+            regions: [
+              { start: 0, end: 2047, kind: 'rom' },
+              { start: 2048, end: 32767, kind: 'ram' },
+              { start: 49152, end: 65535, kind: 'rom' },
+            ],
+            appStart: 0x4000,
+            entry: 0,
+          },
+        },
+      },
+    });
+  });
+
+  it('cancels scaffolding when platform selection is dismissed', async () => {
+    showQuickPick.mockResolvedValueOnce(undefined);
+
+    const created = await scaffoldProject(
+      { name: 'demo', uri: { fsPath: '/workspace/demo' }, index: 0 } as never,
+      false
+    );
+
+    expect(created).toBe(false);
+    expect(showInputBox).not.toHaveBeenCalled();
+  });
+
+  it('writes a tec1g config after choosing platform, target name, and starter source', async () => {
+    const fs = await import('fs');
+    const writeFileSync = vi.mocked(fs.writeFileSync);
+
+    showQuickPick.mockResolvedValueOnce({ platform: 'tec1g' }).mockResolvedValueOnce({
+      choice: { kind: 'starter', language: 'asm' },
+    });
+    showInputBox.mockResolvedValueOnce('app');
+
+    const created = await scaffoldProject(
+      { name: 'demo', uri: { fsPath: '/workspace/demo' }, index: 0 } as never,
+      false
+    );
+
+    expect(created).toBe(true);
+    expect(showQuickPick).toHaveBeenCalledTimes(2);
+    expect(showInputBox).toHaveBeenCalledOnce();
+    expect(writeFileSync).toHaveBeenCalled();
+
+    const configWrite = writeFileSync.mock.calls.find(
+      ([filePath]) => filePath === '/workspace/demo/.vscode/debug80.json'
+    );
+    expect(configWrite).toBeDefined();
+
+    const writtenConfig = JSON.parse(String(configWrite?.[1] ?? '{}')) as {
+      targets?: Record<string, { platform?: string; tec1g?: Record<string, unknown> }>;
+    };
+    expect(writtenConfig.targets?.app?.platform).toBe('tec1g');
+    expect(writtenConfig.targets?.app?.tec1g).toEqual(
+      expect.objectContaining({
+        appStart: 0x4000,
+        entry: 0,
+      })
+    );
+
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      'Debug80: Created TEC-1G project in .vscode/debug80.json targeting src/main.asm.'
+    );
   });
 });

--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -29,7 +29,10 @@ vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
   return {
     ...actual,
-    existsSync: vi.fn((candidate: string) => !candidate.endsWith('/.vscode/debug80.json')),
+    existsSync: vi.fn((candidate: string) => {
+      const normalized = candidate.replace(/\\/g, '/');
+      return !normalized.endsWith('/.vscode/debug80.json');
+    }),
     writeFileSync: vi.fn(),
   };
 });


### PR DESCRIPTION
## Summary
- prompt for platform during Debug80 project creation
- scaffold platform-aware default target config for `simple`, `tec1`, and `tec1g`
- align TEC platform defaults with runtime constants and expand scaffold flow tests

## What changed
- added a platform picker to `src/extension/project-scaffolding.ts`
- carried the chosen platform through scaffold planning and config generation
- generated platform-specific target blocks instead of always hardcoding `platform: "simple"`
- tightened default `tec1` and `tec1g` memory/appStart values to match platform constants
- improved the create-project confirmation message to include the chosen platform
- expanded `tests/extension/project-scaffolding.test.ts` to cover:
  - simple / tec1 / tec1g config generation
  - zax assembler preservation
  - cancelled platform selection
  - successful scaffold write path for tec1g

## Verification
- `npx vitest run tests/extension/project-scaffolding.test.ts tests/extension/commands.test.ts tests/extension/platform-view-messages.test.ts tests/extension/platform-view-provider.test.ts`

## Notes
- left `docs/manual/` untouched because it was already untracked and unrelated to this change
- this focuses on creation-time platform selection only; richer manifest/config UX remains follow-up work under #236 / #241