### PR TITLE
Fix Windows path handling in scaffolding test

### DIFF
--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -220,8 +220,8 @@ describe('project-scaffolding helpers', () => {
     expect(showInputBox).toHaveBeenCalledOnce();
     expect(writeFileSync).toHaveBeenCalled();
 
-    const configWrite = writeFileSync.mock.calls.find(
-      ([filePath]) => filePath === '/workspace/demo/.vscode/debug80.json'
+    const configWrite = writeFileSync.mock.calls.find(([filePath]) =>
+      String(filePath).replace(/\\/g, '/').endsWith('/.vscode/debug80.json')
     );
     expect(configWrite).toBeDefined();
 


### PR DESCRIPTION
## Summary
- fix the remaining Windows-specific path assertion in the scaffolding test
- restore green CI on main after PR #244 merged with a failing windows check

## Root cause
The earlier fix normalized the mocked `existsSync` path, but the test still searched for an exact POSIX path when locating the `writeFileSync` call for `.vscode/debug80.json`. On Windows runners that path contains backslashes, so the assertion still failed.

## Fix
- normalize the captured `writeFileSync` path with `replace(/\\/g, "/")`
- match using `endsWith("/.vscode/debug80.json")`

## Verification
- `npx vitest run tests/extension/project-scaffolding.test.ts`

## Context
PR #244 was merged while `test (windows-latest)` was still failing. This PR repairs main with the missing cross-platform test fix.