### PR TITLE
Add Debug80 project manifest metadata

### DIFF
--- a/src/debug/types.ts
+++ b/src/debug/types.ts
@@ -63,6 +63,10 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
  * Configuration file structure for debug80.json.
  */
 export interface ProjectConfig {
+  /** Schema version for the Debug80 project manifest/config model */
+  projectVersion?: 1;
+  /** Project-level platform identity chosen at project creation time */
+  projectPlatform?: string;
   /** Default target to use when none specified */
   defaultTarget?: string;
   /** Alternative name for defaultTarget */
@@ -90,4 +94,3 @@ export interface ProjectConfig {
   tec1?: Tec1PlatformConfig;
   tec1g?: Tec1gPlatformConfig;
 }
-

--- a/src/extension/project-config.ts
+++ b/src/extension/project-config.ts
@@ -7,6 +7,35 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import type { ProjectConfig } from '../debug/types';
 
+export const DEBUG80_PROJECT_VERSION = 1 as const;
+
+export function isDebug80ProjectConfig(config: ProjectConfig | undefined): config is ProjectConfig {
+  return config !== undefined;
+}
+
+export function resolveProjectPlatform(config: ProjectConfig | undefined): string | undefined {
+  if (config === undefined) {
+    return undefined;
+  }
+
+  if (typeof config.projectPlatform === 'string' && config.projectPlatform.trim() !== '') {
+    return config.projectPlatform.trim().toLowerCase();
+  }
+
+  if (typeof config.platform === 'string' && config.platform.trim() !== '') {
+    return config.platform.trim().toLowerCase();
+  }
+
+  const targets = Object.values(config.targets ?? {});
+  for (const target of targets) {
+    if (typeof target?.platform === 'string' && target.platform.trim() !== '') {
+      return target.platform.trim().toLowerCase();
+    }
+  }
+
+  return undefined;
+}
+
 export const PROJECT_CONFIG_CANDIDATES = [
   path.join('.vscode', 'debug80.json'),
   'debug80.json',
@@ -36,6 +65,14 @@ export function readProjectConfig(projectConfigPath: string): ProjectConfig | un
   } catch {
     return undefined;
   }
+}
+
+export function isInitializedDebug80Project(folder: vscode.WorkspaceFolder): boolean {
+  const projectConfigPath = findProjectConfigPath(folder);
+  if (projectConfigPath === undefined) {
+    return false;
+  }
+  return isDebug80ProjectConfig(readProjectConfig(projectConfigPath));
 }
 
 /**

--- a/src/extension/project-config.ts
+++ b/src/extension/project-config.ts
@@ -10,7 +10,20 @@ import type { ProjectConfig } from '../debug/types';
 export const DEBUG80_PROJECT_VERSION = 1 as const;
 
 export function isDebug80ProjectConfig(config: ProjectConfig | undefined): config is ProjectConfig {
-  return config !== undefined;
+  if (config === undefined) {
+    return false;
+  }
+
+  const targets = config.targets;
+  if (targets === undefined || Object.keys(targets).length === 0) {
+    return false;
+  }
+
+  if (config.projectVersion !== undefined && config.projectVersion !== DEBUG80_PROJECT_VERSION) {
+    return false;
+  }
+
+  return true;
 }
 
 export function resolveProjectPlatform(config: ProjectConfig | undefined): string | undefined {

--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { ensureDirExists, inferDefaultTarget } from '../debug/config-utils';
-import { listProjectSourceFiles } from './project-config';
+import { DEBUG80_PROJECT_VERSION, listProjectSourceFiles } from './project-config';
 import { TEC1_APP_START_DEFAULT } from '../platforms/tec1/constants';
 import {
   TEC1G_APP_START_DEFAULT,
@@ -91,7 +91,12 @@ export function createStarterSourceContent(language: StarterLanguage): string {
   return ['; Debug80 starter (ASM)', '', 'start:', '    nop', '    jr start', ''].join('\n');
 }
 
-export function createDefaultProjectConfig(plan: ScaffoldPlan): Record<string, unknown> {
+export function createDefaultProjectConfig(plan: ScaffoldPlan): {
+  projectVersion: typeof DEBUG80_PROJECT_VERSION;
+  projectPlatform: ScaffoldPlatform;
+  defaultTarget: string;
+  targets: Record<string, Record<string, unknown>>;
+} {
   const targetConfig: Record<string, unknown> = {
     sourceFile: plan.sourceFile,
     outputDir: plan.outputDir,
@@ -109,6 +114,8 @@ export function createDefaultProjectConfig(plan: ScaffoldPlan): Record<string, u
   }
 
   return {
+    projectVersion: DEBUG80_PROJECT_VERSION,
+    projectPlatform: plan.platform,
     defaultTarget: plan.targetName,
     targets: {
       [plan.targetName]: targetConfig,

--- a/src/extension/project-status.ts
+++ b/src/extension/project-status.ts
@@ -3,11 +3,12 @@
  */
 
 import * as vscode from 'vscode';
-import { readProjectConfig, findProjectConfigPath } from './project-config';
+import { readProjectConfig, findProjectConfigPath, resolveProjectPlatform } from './project-config';
 import { resolvePreferredTargetName } from './project-target-selection';
 
 export type ProjectStatusSummary = {
   projectName: string;
+  projectPlatform?: string;
   targetName?: string;
   entrySource?: string;
 };
@@ -29,9 +30,9 @@ export function resolveProjectStatusSummary(
   const targetName = resolvePreferredTargetName(workspaceState, projectConfigPath);
   const entrySource =
     (targetName !== undefined
-      ? config?.targets?.[targetName]?.sourceFile ??
+      ? (config?.targets?.[targetName]?.sourceFile ??
         config?.targets?.[targetName]?.asm ??
-        config?.targets?.[targetName]?.source
+        config?.targets?.[targetName]?.source)
       : undefined) ??
     config?.sourceFile ??
     config?.asm ??
@@ -39,6 +40,10 @@ export function resolveProjectStatusSummary(
 
   return {
     projectName: folder.name,
+    ...((): Partial<ProjectStatusSummary> => {
+      const projectPlatform = resolveProjectPlatform(config);
+      return projectPlatform !== undefined ? { projectPlatform } : {};
+    })(),
     ...(targetName !== undefined ? { targetName } : {}),
     ...(entrySource !== undefined ? { entrySource } : {}),
   };

--- a/tests/extension/project-config.test.ts
+++ b/tests/extension/project-config.test.ts
@@ -3,8 +3,11 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  DEBUG80_PROJECT_VERSION,
+  isInitializedDebug80Project,
   listProjectSourceFiles,
   readProjectConfig,
+  resolveProjectPlatform,
   updateProjectTargetSource,
 } from '../../src/extension/project-config';
 
@@ -50,6 +53,52 @@ describe('project-config helpers', () => {
     expect(config?.targets?.app?.platform).toBe('simple');
   });
 
+  it('resolves project platform from explicit project manifest fields', () => {
+    expect(
+      resolveProjectPlatform({
+        projectVersion: DEBUG80_PROJECT_VERSION,
+        projectPlatform: 'tec1g',
+        targets: {
+          app: { platform: 'simple' },
+        },
+      })
+    ).toBe('tec1g');
+  });
+
+  it('falls back to target platform when project platform is absent', () => {
+    expect(
+      resolveProjectPlatform({
+        targets: {
+          app: { platform: 'tec1' },
+        },
+      })
+    ).toBe('tec1');
+  });
+
+  it('recognizes initialized debug80 projects from config presence', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-project-init-'));
+    const configPath = path.join(root, 'debug80.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        projectVersion: DEBUG80_PROJECT_VERSION,
+        projectPlatform: 'simple',
+        defaultTarget: 'app',
+        targets: {
+          app: { sourceFile: 'src/main.asm', platform: 'simple' },
+        },
+      })
+    );
+
+    expect(
+      isInitializedDebug80Project({
+        name: 'fixture',
+        uri: { fsPath: root },
+        index: 0,
+      } as never)
+    ).toBe(true);
+  });
+
   it('updates the selected target source in package.json debug80 config', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-project-package-'));
     const pkgPath = path.join(root, 'package.json');
@@ -71,7 +120,9 @@ describe('project-config helpers', () => {
     expect(updated).toBe(true);
     const raw = fs.readFileSync(pkgPath, 'utf-8');
     const pkg = JSON.parse(raw) as {
-      debug80?: { targets?: Record<string, { sourceFile?: string }> };
+      debug80?: {
+        targets?: Record<string, { sourceFile?: string; asm?: string; assembler?: string }>;
+      };
     };
     expect(pkg.debug80?.targets?.app?.sourceFile).toBe('src/new.zax');
     expect(pkg.debug80?.targets?.app?.asm).toBe('src/new.zax');

--- a/tests/extension/project-config.test.ts
+++ b/tests/extension/project-config.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   DEBUG80_PROJECT_VERSION,
+  isDebug80ProjectConfig,
   isInitializedDebug80Project,
   listProjectSourceFiles,
   readProjectConfig,
@@ -97,6 +98,27 @@ describe('project-config helpers', () => {
         index: 0,
       } as never)
     ).toBe(true);
+  });
+
+  it('rejects configs without targets as uninitialized', () => {
+    expect(
+      isDebug80ProjectConfig({
+        projectVersion: DEBUG80_PROJECT_VERSION,
+        projectPlatform: 'simple',
+      })
+    ).toBe(false);
+  });
+
+  it('rejects configs with unsupported project version', () => {
+    expect(
+      isDebug80ProjectConfig({
+        projectVersion: 999 as 1,
+        projectPlatform: 'simple',
+        targets: {
+          app: { sourceFile: 'src/main.asm', platform: 'simple' },
+        },
+      })
+    ).toBe(false);
   });
 
   it('updates the selected target source in package.json debug80 config', () => {

--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -15,6 +15,7 @@ import {
   createStarterSourceContent,
   scaffoldProject,
 } from '../../src/extension/project-scaffolding';
+import { DEBUG80_PROJECT_VERSION } from '../../src/extension/project-config';
 
 vi.mock('vscode', () => ({
   window: {
@@ -46,9 +47,15 @@ vi.mock('../../src/debug/config-utils', () => ({
   })),
 }));
 
-vi.mock('../../src/extension/project-config', () => ({
-  listProjectSourceFiles: vi.fn(() => []),
-}));
+vi.mock('../../src/extension/project-config', async () => {
+  const actual = await vi.importActual<typeof import('../../src/extension/project-config')>(
+    '../../src/extension/project-config'
+  );
+  return {
+    ...actual,
+    listProjectSourceFiles: vi.fn(() => []),
+  };
+});
 
 describe('project-scaffolding helpers', () => {
   beforeEach(() => {
@@ -65,6 +72,8 @@ describe('project-scaffolding helpers', () => {
     });
 
     expect(config).toEqual({
+      projectVersion: DEBUG80_PROJECT_VERSION,
+      projectPlatform: 'simple',
       defaultTarget: 'app',
       targets: {
         app: {
@@ -138,6 +147,8 @@ describe('project-scaffolding helpers', () => {
     });
 
     expect(config).toEqual({
+      projectVersion: DEBUG80_PROJECT_VERSION,
+      projectPlatform: 'tec1',
       defaultTarget: 'app',
       targets: {
         app: {
@@ -168,6 +179,8 @@ describe('project-scaffolding helpers', () => {
     });
 
     expect(config).toEqual({
+      projectVersion: DEBUG80_PROJECT_VERSION,
+      projectPlatform: 'tec1g',
       defaultTarget: 'app',
       targets: {
         app: {
@@ -226,8 +239,12 @@ describe('project-scaffolding helpers', () => {
     expect(configWrite).toBeDefined();
 
     const writtenConfig = JSON.parse(String(configWrite?.[1] ?? '{}')) as {
+      projectVersion?: number;
+      projectPlatform?: string;
       targets?: Record<string, { platform?: string; tec1g?: Record<string, unknown> }>;
     };
+    expect(writtenConfig.projectVersion).toBe(DEBUG80_PROJECT_VERSION);
+    expect(writtenConfig.projectPlatform).toBe('tec1g');
     expect(writtenConfig.targets?.app?.platform).toBe('tec1g');
     expect(writtenConfig.targets?.app?.tec1g).toEqual(
       expect.objectContaining({


### PR DESCRIPTION
## Summary
- add compact Debug80 project manifest fields to project config
- write explicit project-level platform identity at creation time
- add helpers for project initialization and platform detection

## What changed
- added `projectVersion` and `projectPlatform` to `ProjectConfig`
- added `DEBUG80_PROJECT_VERSION`, `resolveProjectPlatform`, and `isInitializedDebug80Project`
- updated scaffolding to write manifest metadata into generated `debug80.json`
- updated project status resolution to surface project-level platform identity
- expanded tests for manifest resolution, initialized project detection, and scaffolded manifest output

## Verification
- `npx vitest run tests/extension/project-config.test.ts tests/extension/project-scaffolding.test.ts tests/extension/commands.test.ts tests/extension/platform-view-provider.test.ts`
- `npm run build`

## Scope
This stays within #236: project manifest/config model and creation flow only. It does not add a configuration UI.