### PR TITLE
Add project configuration panel for existing Debug80 projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,6 +182,10 @@
       {
         "command": "debug80.openRomSource",
         "title": "Debug80: Open ROM Listing/Source"
+      },
+      {
+        "command": "debug80.openProjectConfigPanel",
+        "title": "Debug80: Open Project Configuration Panel"
       }
     ],
     "menus": {

--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -10,6 +10,7 @@ import {
   findProjectConfigPath,
   listProjectSourceFiles,
   readProjectConfig,
+  resolveProjectPlatform,
   writeProjectConfig,
   updateProjectTargetSource,
 } from './project-config';
@@ -93,6 +94,75 @@ function createTec1gPlatformDefaults(): Record<string, unknown> {
     appStart: TEC1G_APP_START_DEFAULT,
     entry: 0,
   };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildProjectConfigPanelHtml(config: ProjectConfig): string {
+  const currentPlatform = resolveProjectPlatform(config) ?? 'simple';
+  const targetNames = Object.keys(config.targets ?? {});
+  const currentDefault = config.defaultTarget ?? config.target ?? targetNames[0] ?? '';
+  const platformOptions = ['simple', 'tec1', 'tec1g']
+    .map(
+      (platform) =>
+        `<option value="${platform}"${
+          platform === currentPlatform ? ' selected' : ''
+        }>${platform}</option>`
+    )
+    .join('');
+  const targetOptions = targetNames
+    .map(
+      (targetName) =>
+        `<option value="${escapeHtml(targetName)}"${
+          targetName === currentDefault ? ' selected' : ''
+        }>${escapeHtml(targetName)}</option>`
+    )
+    .join('');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Debug80 Project Config</title>
+  <style>
+    body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); padding: 16px; }
+    h2 { margin-top: 0; }
+    .row { margin-bottom: 12px; display: flex; flex-direction: column; gap: 6px; max-width: 480px; }
+    label { font-size: 12px; opacity: 0.9; }
+    select, button { padding: 6px 8px; font: inherit; }
+    .hint { font-size: 12px; opacity: 0.8; margin-top: 8px; max-width: 600px; }
+  </style>
+</head>
+<body>
+  <h2>Debug80 Project Configuration</h2>
+  <div class="row">
+    <label for="platform">Project Platform</label>
+    <select id="platform">${platformOptions}</select>
+  </div>
+  <div class="row">
+    <label for="defaultTarget">Default Target</label>
+    <select id="defaultTarget">${targetOptions}</select>
+  </div>
+  <button id="save">Save Configuration</button>
+  <div class="hint">This panel edits project-level settings only. Target-specific runtime controls are unchanged.</div>
+  <script>
+    const vscode = acquireVsCodeApi();
+    document.getElementById('save')?.addEventListener('click', () => {
+      const platform = document.getElementById('platform')?.value ?? '';
+      const defaultTarget = document.getElementById('defaultTarget')?.value ?? '';
+      vscode.postMessage({ type: 'saveProjectConfig', platform, defaultTarget });
+    });
+  </script>
+</body>
+</html>`;
 }
 
 function findWorkspaceFolder(rootPath: string | undefined): vscode.WorkspaceFolder | undefined {
@@ -725,6 +795,89 @@ export function registerExtensionCommands({
         `Debug80: Set ${target} program file to ${picked}.`
       );
       return picked;
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('debug80.openProjectConfigPanel', async () => {
+      const folder = await workspaceSelection.resolveWorkspaceFolder({
+        requireProject: true,
+        prompt: true,
+        placeHolder: 'Select the Debug80 project folder to configure',
+      });
+      if (!folder) {
+        void vscode.window.showInformationMessage('Debug80: No configured Debug80 project found.');
+        return undefined;
+      }
+
+      const projectConfigPath = findProjectConfigPath(folder);
+      if (projectConfigPath === undefined) {
+        void vscode.window.showErrorMessage(
+          `Debug80: Could not find a project config in ${folder.uri.fsPath}.`
+        );
+        return undefined;
+      }
+
+      const initialConfig = readProjectConfig(projectConfigPath);
+      if (initialConfig === undefined) {
+        void vscode.window.showErrorMessage('Debug80: Failed to read project config.');
+        return undefined;
+      }
+      let config: ProjectConfig = initialConfig;
+
+      const panel = vscode.window.createWebviewPanel(
+        'debug80ProjectConfig',
+        `Debug80 Project Settings: ${folder.name}`,
+        vscode.ViewColumn.Active,
+        { enableScripts: true, retainContextWhenHidden: true }
+      );
+      panel.webview.html = buildProjectConfigPanelHtml(config);
+
+      const messageDisposable = panel.webview.onDidReceiveMessage((msg: unknown) => {
+        const payload = msg as { type?: string; platform?: string; defaultTarget?: string };
+        if (payload.type !== 'saveProjectConfig') {
+          return;
+        }
+
+        const platform = payload.platform;
+        const defaultTarget = payload.defaultTarget;
+        if (
+          (platform !== 'simple' && platform !== 'tec1' && platform !== 'tec1g') ||
+          typeof defaultTarget !== 'string'
+        ) {
+          void vscode.window.showErrorMessage('Debug80: Invalid project configuration values.');
+          return;
+        }
+
+        const targets = config.targets ?? {};
+        if (targets[defaultTarget] === undefined) {
+          void vscode.window.showErrorMessage('Debug80: Selected default target no longer exists.');
+          return;
+        }
+
+        const next: ProjectConfig = {
+          ...config,
+          projectVersion: DEBUG80_PROJECT_VERSION,
+          projectPlatform: platform,
+          defaultTarget,
+          target: defaultTarget,
+        };
+        const written = writeProjectConfig(projectConfigPath, next);
+        if (!written) {
+          void vscode.window.showErrorMessage('Debug80: Failed to update project config.');
+          return;
+        }
+
+        config = next;
+        panel.webview.html = buildProjectConfigPanelHtml(config);
+        platformViewProvider.refreshIdleView();
+        void vscode.window.showInformationMessage('Debug80: Project configuration updated.');
+      });
+      panel.onDidDispose(() => {
+        messageDisposable.dispose();
+      });
+
+      return true;
     })
   );
 

--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -3,6 +3,7 @@
  */
 
 import * as path from 'path';
+import { randomBytes } from 'crypto';
 import * as vscode from 'vscode';
 import { PlatformViewProvider } from './platform-view-provider';
 import {
@@ -105,7 +106,15 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
-function buildProjectConfigPanelHtml(config: ProjectConfig): string {
+function createNonce(): string {
+  return randomBytes(16).toString('base64');
+}
+
+function buildProjectConfigPanelHtml(
+  config: ProjectConfig,
+  cspSource: string,
+  nonce: string
+): string {
   const currentPlatform = resolveProjectPlatform(config) ?? 'simple';
   const targetNames = Object.keys(config.targets ?? {});
   const currentDefault = config.defaultTarget ?? config.target ?? targetNames[0] ?? '';
@@ -131,8 +140,9 @@ function buildProjectConfigPanelHtml(config: ProjectConfig): string {
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
   <title>Debug80 Project Config</title>
-  <style>
+  <style nonce="${nonce}">
     body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); padding: 16px; }
     h2 { margin-top: 0; }
     .row { margin-bottom: 12px; display: flex; flex-direction: column; gap: 6px; max-width: 480px; }
@@ -153,7 +163,7 @@ function buildProjectConfigPanelHtml(config: ProjectConfig): string {
   </div>
   <button id="save">Save Configuration</button>
   <div class="hint">This panel edits project-level settings only. Target-specific runtime controls are unchanged.</div>
-  <script>
+  <script nonce="${nonce}">
     const vscode = acquireVsCodeApi();
     document.getElementById('save')?.addEventListener('click', () => {
       const platform = document.getElementById('platform')?.value ?? '';
@@ -831,7 +841,7 @@ export function registerExtensionCommands({
         vscode.ViewColumn.Active,
         { enableScripts: true, retainContextWhenHidden: true }
       );
-      panel.webview.html = buildProjectConfigPanelHtml(config);
+      panel.webview.html = buildProjectConfigPanelHtml(config, panel.webview.cspSource, createNonce());
 
       const messageDisposable = panel.webview.onDidReceiveMessage((msg: unknown) => {
         const payload = msg as { type?: string; platform?: string; defaultTarget?: string };
@@ -869,7 +879,11 @@ export function registerExtensionCommands({
         }
 
         config = next;
-        panel.webview.html = buildProjectConfigPanelHtml(config);
+        panel.webview.html = buildProjectConfigPanelHtml(
+          config,
+          panel.webview.cspSource,
+          createNonce()
+        );
         platformViewProvider.refreshIdleView();
         void vscode.window.showInformationMessage('Debug80: Project configuration updated.');
       });

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -13,11 +13,14 @@ const readFileSync = vi.fn();
 const writeFileSync = vi.fn();
 const showInformationMessage = vi.fn();
 const showErrorMessage = vi.fn();
+const createWebviewPanel = vi.fn();
 const startDebugging = vi.fn();
 const stopDebugging = vi.fn();
 const executeCommand = vi.fn();
 const scaffoldProject = vi.fn();
 let workspaceFolders: Array<{ name: string; uri: { fsPath: string } }> | undefined;
+let panelMessageHandler: ((msg: unknown) => void) | undefined;
+let panelHtml = '';
 
 vi.mock('fs', () => ({
   existsSync,
@@ -41,6 +44,10 @@ vi.mock('vscode', () => ({
     showQuickPick: vi.fn(),
     showOpenDialog: vi.fn(),
     showInputBox: vi.fn(),
+    createWebviewPanel,
+  },
+  ViewColumn: {
+    Active: 1,
   },
   workspace: {
     get workspaceFolders() {
@@ -71,6 +78,30 @@ describe('registerExtensionCommands', () => {
         },
       })
     );
+    panelMessageHandler = undefined;
+    panelHtml = '';
+    createWebviewPanel.mockImplementation(() => {
+      const webview = {
+        cspSource: 'vscode-webview:',
+        get html() {
+          return panelHtml;
+        },
+        set html(value: string) {
+          panelHtml = value;
+        },
+        onDidReceiveMessage: vi.fn((handler: (msg: unknown) => void) => {
+          panelMessageHandler = handler;
+          return { dispose: vi.fn() };
+        }),
+      };
+      return {
+        webview,
+        onDidDispose: vi.fn((handler: () => void) => {
+          void handler;
+          return { dispose: vi.fn() };
+        }),
+      };
+    });
   });
 
   it(
@@ -608,6 +639,120 @@ describe('registerExtensionCommands', () => {
     expect(serialized).toContain('"target": "renamed"');
     expect(serialized).toContain('"defaultTarget": "renamed"');
     expect(serialized).toContain('"renamed"');
+  });
+
+  it('renders project config panel with manifest-selected defaults and CSP nonce', async () => {
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    const resolveWorkspaceFolder = vi.fn().mockResolvedValue({
+      name: 'tec1g-mon3',
+      uri: { fsPath: '/workspace/tec1g-mon3' },
+      index: 0,
+    });
+    readFileSync.mockReturnValueOnce(
+      JSON.stringify({
+        projectPlatform: 'tec1g',
+        defaultTarget: 'serial',
+        targets: {
+          app: { sourceFile: 'src/main.asm', platform: 'tec1g' },
+          serial: { sourceFile: 'src/serial.asm', platform: 'tec1g' },
+        },
+      })
+    );
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder,
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: { resolveTarget: vi.fn(), rememberTarget: vi.fn() } as never,
+    });
+
+    const openPanel = registeredCommands.get('debug80.openProjectConfigPanel');
+    expect(openPanel).toBeTypeOf('function');
+
+    await openPanel?.();
+
+    expect(createWebviewPanel).toHaveBeenCalled();
+    expect(panelHtml).toContain('Content-Security-Policy');
+    expect(panelHtml).toContain('script-src \'nonce-');
+    expect(panelHtml).toContain('<option value="tec1g" selected>');
+    expect(panelHtml).toContain('<option value="serial" selected>');
+  });
+
+  it('rejects invalid save payload in project config panel', async () => {
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    const resolveWorkspaceFolder = vi.fn().mockResolvedValue({
+      name: 'tec1g-mon3',
+      uri: { fsPath: '/workspace/tec1g-mon3' },
+      index: 0,
+    });
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder,
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: { resolveTarget: vi.fn(), rememberTarget: vi.fn() } as never,
+    });
+
+    const openPanel = registeredCommands.get('debug80.openProjectConfigPanel');
+    expect(openPanel).toBeTypeOf('function');
+    await openPanel?.();
+
+    panelMessageHandler?.({ type: 'saveProjectConfig', platform: 'bad-platform', defaultTarget: 'app' });
+
+    expect(showErrorMessage).toHaveBeenCalledWith(
+      'Debug80: Invalid project configuration values.'
+    );
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('saves project config panel updates and refreshes idle view', async () => {
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+    const refreshIdleView = vi.fn();
+    const resolveWorkspaceFolder = vi.fn().mockResolvedValue({
+      name: 'tec1g-mon3',
+      uri: { fsPath: '/workspace/tec1g-mon3' },
+      index: 0,
+    });
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder,
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: { resolveTarget: vi.fn(), rememberTarget: vi.fn() } as never,
+    });
+
+    const openPanel = registeredCommands.get('debug80.openProjectConfigPanel');
+    expect(openPanel).toBeTypeOf('function');
+    await openPanel?.();
+
+    panelMessageHandler?.({ type: 'saveProjectConfig', platform: 'tec1g', defaultTarget: 'serial' });
+
+    expect(writeFileSync).toHaveBeenCalled();
+    const serialized = String(writeFileSync.mock.calls.at(-1)?.[1] ?? '');
+    expect(serialized).toContain('"projectPlatform": "tec1g"');
+    expect(serialized).toContain('"defaultTarget": "serial"');
+    expect(serialized).toContain('"target": "serial"');
+    expect(refreshIdleView).toHaveBeenCalled();
   });
 
   it('restarts the active z80 session against the current project target', async () => {


### PR DESCRIPTION
## Summary
- add a dedicated `Debug80: Open Project Configuration Panel` command
- render a project settings webview panel for project-level platform and default target selection
- persist updates back to manifest and refresh the platform view after save

## Test plan
- [x] npm test


Made with [Cursor](https://cursor.com)