### PR TITLE
Add sidebar setup surface for project onboarding

### DIFF
--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -50,6 +50,10 @@ type SelectWorkspaceFolderArgs = {
   rootPath?: string;
 };
 
+type StartDebugArgs = {
+  rootPath?: string;
+};
+
 type SelectTargetArgs = {
   rootPath?: string;
   targetName?: string;
@@ -355,12 +359,17 @@ export function registerExtensionCommands({
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('debug80.startDebug', async () => {
-      const folder = await workspaceSelection.resolveWorkspaceFolder({
-        prompt: true,
-        requireProject: true,
-        placeHolder: 'Select the Debug80 project folder to debug',
-      });
+    vscode.commands.registerCommand('debug80.startDebug', async (args?: StartDebugArgs) => {
+      const directFolder = findWorkspaceFolder(args?.rootPath);
+      const folder =
+        directFolder &&
+        findProjectConfigPath(directFolder) !== undefined
+          ? directFolder
+          : await workspaceSelection.resolveWorkspaceFolder({
+              prompt: true,
+              requireProject: true,
+              placeHolder: 'Select the Debug80 project folder to debug',
+            });
       if (!folder) {
         const workspaceFolderCount = vscode.workspace.workspaceFolders?.length ?? 0;
         void vscode.window.showInformationMessage(

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -332,10 +332,18 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
         });
         return;
       }
+      if (msg?.type === 'openWorkspaceFolder') {
+        await vscode.commands.executeCommand('vscode.openFolder');
+        return;
+      }
       if (msg?.type === 'selectProject') {
         await vscode.commands.executeCommand('debug80.selectWorkspaceFolder', {
           rootPath: (msg as { rootPath?: string }).rootPath,
         });
+        return;
+      }
+      if (msg?.type === 'configureProject') {
+        await vscode.commands.executeCommand('debug80.openProjectConfigPanel');
         return;
       }
       if (msg?.type === 'selectTarget') {

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -323,7 +323,12 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
 
     webviewView.webview.onDidReceiveMessage(async (msg: Tec1Message | Tec1gMessage | { type?: string; text?: string }) => {
       if (msg?.type === 'startDebug') {
-        await vscode.commands.executeCommand('debug80.startDebug');
+        await vscode.commands.executeCommand(
+          'debug80.startDebug',
+          typeof (msg as { rootPath?: string }).rootPath === 'string'
+            ? { rootPath: (msg as { rootPath?: string }).rootPath }
+            : undefined
+        );
         return;
       }
       if (msg?.type === 'createProject') {

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -152,6 +152,42 @@ describe('registerExtensionCommands', () => {
     15000
   );
 
+  it('starts debugging directly from a provided rootPath', async () => {
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    const rememberWorkspace = vi.fn();
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder: vi.fn(),
+        rememberWorkspace,
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {} as never,
+    });
+
+    const startDebug = registeredCommands.get('debug80.startDebug');
+    expect(startDebug).toBeTypeOf('function');
+
+    startDebugging.mockResolvedValueOnce(true);
+    const result = await startDebug?.({ rootPath: '/workspace/tec1g-mon3' });
+
+    expect(result).toBe(true);
+    expect(rememberWorkspace).toHaveBeenCalled();
+    expect(startDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: { fsPath: '/workspace/tec1g-mon3' } }),
+      expect.objectContaining({
+        type: 'z80',
+        request: 'launch',
+        name: 'Debug80: Current Project',
+        projectConfig: projectConfigPath,
+      })
+    );
+  });
+
   it('creates a project directly in an already-open empty workspace root', async () => {
     const { registerExtensionCommands } = await import('../../src/extension/commands');
 

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -529,4 +529,54 @@ describe('PlatformViewProvider', () => {
       rootPath: '/workspace/empty-root',
     });
   });
+
+  it('routes configureProject messages to project config panel command', async () => {
+    const provider = new PlatformViewProvider(extensionRoot, {
+      get: vi.fn(),
+      update: vi.fn(),
+    } as never);
+    const webviewView = createWebviewView();
+
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
+
+    const handler = (webviewView.webview.onDidReceiveMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as ((msg: { type?: string }) => Promise<void>) | undefined;
+    expect(handler).toBeTypeOf('function');
+
+    await handler?.({ type: 'configureProject' });
+
+    expect(executeCommand).toHaveBeenCalledWith('debug80.openProjectConfigPanel');
+  });
+
+  it('routes openWorkspaceFolder messages to vscode open folder command', async () => {
+    const provider = new PlatformViewProvider(extensionRoot, {
+      get: vi.fn(),
+      update: vi.fn(),
+    } as never);
+    const webviewView = createWebviewView();
+
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
+
+    const handler = (webviewView.webview.onDidReceiveMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as ((msg: { type?: string }) => Promise<void>) | undefined;
+    expect(handler).toBeTypeOf('function');
+
+    await handler?.({ type: 'openWorkspaceFolder' });
+
+    expect(executeCommand).toHaveBeenCalledWith('vscode.openFolder');
+  });
 });

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -500,7 +500,34 @@ describe('PlatformViewProvider', () => {
 
     await handler?.({ type: 'startDebug' });
 
-    expect(executeCommand).toHaveBeenCalledWith('debug80.startDebug');
+    expect(executeCommand).toHaveBeenCalledWith('debug80.startDebug', undefined);
+  });
+
+  it('routes startDebug with rootPath to the start command args', async () => {
+    const provider = new PlatformViewProvider(extensionRoot, {
+      get: vi.fn(),
+      update: vi.fn(),
+    } as never);
+    const webviewView = createWebviewView();
+
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
+
+    const handler = (webviewView.webview.onDidReceiveMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as ((msg: { type?: string; rootPath?: string }) => Promise<void>) | undefined;
+    expect(handler).toBeTypeOf('function');
+
+    await handler?.({ type: 'startDebug', rootPath: '/workspace/demo' });
+
+    expect(executeCommand).toHaveBeenCalledWith('debug80.startDebug', {
+      rootPath: '/workspace/demo',
+    });
   });
 
   it('routes createProject messages with a root path to the create command', async () => {

--- a/tests/webview/common/setup-card-state.test.ts
+++ b/tests/webview/common/setup-card-state.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSetupCardState } from '../../../webview/common/setup-card-state';
+
+describe('setup card state resolver', () => {
+  it('returns open-folder action for missing workspace root', () => {
+    const state = resolveSetupCardState(undefined, 0);
+    expect(state.primaryAction).toBe('openWorkspaceFolder');
+    expect(state.primaryLabel).toBe('Open Folder');
+    expect(state.showSecondaryConfigure).toBe(false);
+  });
+
+  it('returns create-project action for uninitialized root', () => {
+    const state = resolveSetupCardState(
+      { name: 'demo', path: '/workspace/demo', hasProject: false },
+      0
+    );
+    expect(state.primaryAction).toBe('createProject');
+    expect(state.primaryLabel).toBe('Create Project');
+  });
+
+  it('returns configure action when configured root has no targets', () => {
+    const state = resolveSetupCardState(
+      { name: 'demo', path: '/workspace/demo', hasProject: true },
+      0
+    );
+    expect(state.primaryAction).toBe('configureProject');
+    expect(state.primaryLabel).toBe('Configure Project');
+  });
+
+  it('returns start-debug action with secondary configure for valid project', () => {
+    const state = resolveSetupCardState(
+      { name: 'demo', path: '/workspace/demo', hasProject: true },
+      2
+    );
+    expect(state.primaryAction).toBe('startDebug');
+    expect(state.primaryLabel).toBe('Start Debugging');
+    expect(state.showSecondaryConfigure).toBe(true);
+  });
+});

--- a/webview/common/setup-card-state.ts
+++ b/webview/common/setup-card-state.ts
@@ -1,0 +1,50 @@
+export type SetupRootOption = {
+  name: string;
+  path: string;
+  hasProject: boolean;
+};
+
+export type SetupPrimaryAction = 'openWorkspaceFolder' | 'createProject' | 'configureProject' | 'startDebug';
+
+export type SetupCardState = {
+  text: string;
+  primaryLabel: string;
+  primaryAction: SetupPrimaryAction;
+  showSecondaryConfigure: boolean;
+};
+
+export function resolveSetupCardState(
+  selectedRoot: SetupRootOption | undefined,
+  targetCount: number
+): SetupCardState {
+  if (selectedRoot === undefined) {
+    return {
+      text: 'No workspace folder is open. Open a folder to start with Debug80.',
+      primaryLabel: 'Open Folder',
+      primaryAction: 'openWorkspaceFolder',
+      showSecondaryConfigure: false,
+    };
+  }
+  if (!selectedRoot.hasProject) {
+    return {
+      text: `No Debug80 project found in ${selectedRoot.name}.`,
+      primaryLabel: 'Create Project',
+      primaryAction: 'createProject',
+      showSecondaryConfigure: false,
+    };
+  }
+  if (targetCount === 0) {
+    return {
+      text: 'Project has no targets configured yet.',
+      primaryLabel: 'Configure Project',
+      primaryAction: 'configureProject',
+      showSecondaryConfigure: false,
+    };
+  }
+  return {
+    text: 'Project is configured. Start debugging or adjust settings.',
+    primaryLabel: 'Start Debugging',
+    primaryAction: 'startDebug',
+    showSecondaryConfigure: true,
+  };
+}

--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -71,6 +71,32 @@ body {
       cursor: default;
       color: #7a7a7a;
     }
+    .setup-card {
+      margin: 0 0 10px 0;
+      padding: 8px;
+      border: 1px solid #333;
+      border-radius: 6px;
+      background: #151515;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .setup-card[hidden] {
+      display: none;
+    }
+    .setup-card-text {
+      font-size: 11px;
+      color: #bcbcbc;
+      flex: 1;
+      min-width: 200px;
+    }
+    .setup-card-actions {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+    }
     .project-select {
       flex: 1;
       min-width: 0;

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -14,10 +14,18 @@
         <span class="project-label">Project</span>
         <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
         <button class="project-action-button" id="createProject" type="button" hidden>Create Project</button>
+        <button class="project-action-button" id="configureProject" type="button" hidden>Configure</button>
       </div>
       <div class="project-control">
         <span class="project-label">Target</span>
         <select class="project-select" id="homeTargetSelect"></select>
+      </div>
+    </div>
+    <div class="setup-card" id="setupCard">
+      <div class="setup-card-text" id="setupCardText">Select a workspace root to get started.</div>
+      <div class="setup-card-actions">
+        <button class="project-action-button" id="setupPrimaryAction" type="button">Open Folder</button>
+        <button class="project-action-button" id="setupSecondaryAction" type="button" hidden>Configure</button>
       </div>
     </div>
     <div class="tabs">

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -2,6 +2,7 @@ import { createDigit } from '../common/digits';
 import { MemoryPanel } from '../common/memory-panel';
 import { createSessionStatusController } from '../common/session-status';
 import { createProjectRootButtonController } from '../common/project-root-button';
+import { resolveSetupCardState } from '../common/setup-card-state';
 import { acquireVscodeApi } from '../common/vscode';
 import { createAudioController } from './audio';
 import { createLcdRenderer } from './lcd-renderer';
@@ -75,7 +76,8 @@ let uiRevision = 0;
 let shiftLatched = false;
 let currentRootPath = '';
 let currentRoots: Array<{ name: string; path: string; hasProject: boolean }> = [];
-let currentTargetCount = 0;
+let setupPrimaryActionType: 'openWorkspaceFolder' | 'createProject' | 'configureProject' | 'startDebug' =
+  'openWorkspaceFolder';
 const audio = createAudioController(muteEl);
 const lcdRenderer = createLcdRenderer();
 const matrixRenderer = createMatrixRenderer();
@@ -92,19 +94,24 @@ configureProjectButton?.addEventListener('click', () => {
 
 setupPrimaryAction?.addEventListener('click', () => {
   const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
-  if (selected === undefined) {
+  if (setupPrimaryActionType === 'openWorkspaceFolder') {
     vscode.postMessage({ type: 'openWorkspaceFolder' });
     return;
   }
-  if (!selected.hasProject) {
-    vscode.postMessage({ type: 'createProject', rootPath: selected.path });
+  if (setupPrimaryActionType === 'createProject') {
+    if (selected !== undefined) {
+      vscode.postMessage({ type: 'createProject', rootPath: selected.path });
+    }
     return;
   }
-  if (currentTargetCount === 0) {
+  if (setupPrimaryActionType === 'configureProject') {
     vscode.postMessage({ type: 'configureProject' });
     return;
   }
-  vscode.postMessage({ type: 'startDebug' });
+  vscode.postMessage({
+    type: 'startDebug',
+    ...(selected ? { rootPath: selected.path } : {}),
+  });
 });
 
 setupSecondaryAction?.addEventListener('click', () => {
@@ -176,7 +183,6 @@ function applyProjectStatus(payload: {
   setTargetOptions(payload.targets ?? [], payload.targetName);
   const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
   const targetCount = payload.targets?.length ?? 0;
-  currentTargetCount = targetCount;
   if (configureProjectButton) {
     configureProjectButton.hidden = selected?.hasProject !== true;
   }
@@ -184,27 +190,11 @@ function applyProjectStatus(payload: {
     return;
   }
   setupCard.hidden = false;
-  if (selected === undefined) {
-    setupCardText.textContent = 'No workspace folder is open. Open a folder to start with Debug80.';
-    setupPrimaryAction.textContent = 'Open Folder';
-    setupSecondaryAction.hidden = true;
-    return;
-  }
-  if (!selected.hasProject) {
-    setupCardText.textContent = `No Debug80 project found in ${selected.name}.`;
-    setupPrimaryAction.textContent = 'Create Project';
-    setupSecondaryAction.hidden = true;
-    return;
-  }
-  if (targetCount === 0) {
-    setupCardText.textContent = 'Project has no targets configured yet.';
-    setupPrimaryAction.textContent = 'Configure Project';
-    setupSecondaryAction.hidden = true;
-    return;
-  }
-  setupCardText.textContent = 'Project is configured. Start debugging or adjust settings.';
-  setupPrimaryAction.textContent = 'Start Debugging';
-  setupSecondaryAction.hidden = false;
+  const setupState = resolveSetupCardState(selected, targetCount);
+  setupPrimaryActionType = setupState.primaryAction;
+  setupCardText.textContent = setupState.text;
+  setupPrimaryAction.textContent = setupState.primaryLabel;
+  setupSecondaryAction.hidden = !setupState.showSecondaryConfigure;
   setupSecondaryAction.textContent = 'Configure';
 }
 

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -16,6 +16,11 @@ const DEFAULT_TAB: PanelTab =
     : 'ui';
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
 const createProjectButton = document.getElementById('createProject') as HTMLButtonElement | null;
+const configureProjectButton = document.getElementById('configureProject') as HTMLButtonElement | null;
+const setupCard = document.getElementById('setupCard') as HTMLElement | null;
+const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
+const setupPrimaryAction = document.getElementById('setupPrimaryAction') as HTMLButtonElement | null;
+const setupSecondaryAction = document.getElementById('setupSecondaryAction') as HTMLButtonElement | null;
 const sessionStatusButton = document.getElementById('sessionStatus') as HTMLButtonElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const displayEl = document.getElementById('display') as HTMLElement;
@@ -69,6 +74,8 @@ let speedMode = 'fast';
 let uiRevision = 0;
 let shiftLatched = false;
 let currentRootPath = '';
+let currentRoots: Array<{ name: string; path: string; hasProject: boolean }> = [];
+let currentTargetCount = 0;
 const audio = createAudioController(muteEl);
 const lcdRenderer = createLcdRenderer();
 const matrixRenderer = createMatrixRenderer();
@@ -78,6 +85,31 @@ const projectRootController = createProjectRootButtonController(
   selectProjectButton,
   createProjectButton
 );
+
+configureProjectButton?.addEventListener('click', () => {
+  vscode.postMessage({ type: 'configureProject' });
+});
+
+setupPrimaryAction?.addEventListener('click', () => {
+  const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
+  if (selected === undefined) {
+    vscode.postMessage({ type: 'openWorkspaceFolder' });
+    return;
+  }
+  if (!selected.hasProject) {
+    vscode.postMessage({ type: 'createProject', rootPath: selected.path });
+    return;
+  }
+  if (currentTargetCount === 0) {
+    vscode.postMessage({ type: 'configureProject' });
+    return;
+  }
+  vscode.postMessage({ type: 'startDebug' });
+});
+
+setupSecondaryAction?.addEventListener('click', () => {
+  vscode.postMessage({ type: 'configureProject' });
+});
 
 homeTargetSelect?.addEventListener('change', () => {
   const targetName = homeTargetSelect.value;
@@ -135,12 +167,45 @@ function applyProjectStatus(payload: {
   targetName?: string;
 }): void {
   currentRootPath = payload.rootPath ?? '';
+  currentRoots = payload.roots ?? [];
   projectRootController.applyProjectStatus({
     rootPath: payload.rootPath,
     roots: payload.roots ?? [],
     targetCount: payload.targets?.length ?? 0,
   });
   setTargetOptions(payload.targets ?? [], payload.targetName);
+  const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
+  const targetCount = payload.targets?.length ?? 0;
+  currentTargetCount = targetCount;
+  if (configureProjectButton) {
+    configureProjectButton.hidden = selected?.hasProject !== true;
+  }
+  if (!setupCard || !setupCardText || !setupPrimaryAction || !setupSecondaryAction) {
+    return;
+  }
+  setupCard.hidden = false;
+  if (selected === undefined) {
+    setupCardText.textContent = 'No workspace folder is open. Open a folder to start with Debug80.';
+    setupPrimaryAction.textContent = 'Open Folder';
+    setupSecondaryAction.hidden = true;
+    return;
+  }
+  if (!selected.hasProject) {
+    setupCardText.textContent = `No Debug80 project found in ${selected.name}.`;
+    setupPrimaryAction.textContent = 'Create Project';
+    setupSecondaryAction.hidden = true;
+    return;
+  }
+  if (targetCount === 0) {
+    setupCardText.textContent = 'Project has no targets configured yet.';
+    setupPrimaryAction.textContent = 'Configure Project';
+    setupSecondaryAction.hidden = true;
+    return;
+  }
+  setupCardText.textContent = 'Project is configured. Start debugging or adjust settings.';
+  setupPrimaryAction.textContent = 'Start Debugging';
+  setupSecondaryAction.hidden = false;
+  setupSecondaryAction.textContent = 'Configure';
 }
 
 applyProjectStatus({});

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -14,10 +14,18 @@
         <span class="project-label">Project</span>
         <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
         <button class="project-action-button" id="createProject" type="button" hidden>Create Project</button>
+        <button class="project-action-button" id="configureProject" type="button" hidden>Configure</button>
       </div>
       <div class="project-control">
         <span class="project-label">Target</span>
         <select class="project-select" id="homeTargetSelect"></select>
+      </div>
+    </div>
+    <div class="setup-card" id="setupCard">
+      <div class="setup-card-text" id="setupCardText">Select a workspace root to get started.</div>
+      <div class="setup-card-actions">
+        <button class="project-action-button" id="setupPrimaryAction" type="button">Open Folder</button>
+        <button class="project-action-button" id="setupSecondaryAction" type="button" hidden>Configure</button>
       </div>
     </div>
     <div class="tabs">

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -2,6 +2,7 @@ import { createDigit } from '../common/digits';
 import { MemoryPanel } from '../common/memory-panel';
 import { createSessionStatusController, type SessionStatus } from '../common/session-status';
 import { createProjectRootButtonController } from '../common/project-root-button';
+import { resolveSetupCardState } from '../common/setup-card-state';
 import { acquireVscodeApi } from '../common/vscode';
 import { createGlcdRenderer } from './glcd-renderer';
 import { createLcdRenderer } from './lcd-renderer';
@@ -133,7 +134,8 @@ let sysCtrlSegs: HTMLElement[] = [];
 let sysCtrlValue = 0;
 let currentRootPath = '';
 let currentRoots: Array<{ name: string; path: string; hasProject: boolean }> = [];
-let currentTargetCount = 0;
+let setupPrimaryActionType: 'openWorkspaceFolder' | 'createProject' | 'configureProject' | 'startDebug' =
+  'openWorkspaceFolder';
 const digitEls: HTMLElement[] = [];
 const sessionStatusController = createSessionStatusController(vscode, sessionStatusButton);
 for (let i = 0; i < DIGITS; i++) {
@@ -267,19 +269,24 @@ configureProjectButton?.addEventListener('click', () => {
 
 setupPrimaryAction?.addEventListener('click', () => {
   const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
-  if (selected === undefined) {
+  if (setupPrimaryActionType === 'openWorkspaceFolder') {
     vscode.postMessage({ type: 'openWorkspaceFolder' });
     return;
   }
-  if (!selected.hasProject) {
-    vscode.postMessage({ type: 'createProject', rootPath: selected.path });
+  if (setupPrimaryActionType === 'createProject') {
+    if (selected !== undefined) {
+      vscode.postMessage({ type: 'createProject', rootPath: selected.path });
+    }
     return;
   }
-  if (currentTargetCount === 0) {
+  if (setupPrimaryActionType === 'configureProject') {
     vscode.postMessage({ type: 'configureProject' });
     return;
   }
-  vscode.postMessage({ type: 'startDebug' });
+  vscode.postMessage({
+    type: 'startDebug',
+    ...(selected ? { rootPath: selected.path } : {}),
+  });
 });
 
 setupSecondaryAction?.addEventListener('click', () => {
@@ -351,7 +358,6 @@ function applyProjectStatus(payload: {
   setTargetOptions(payload.targets ?? [], payload.targetName);
   const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
   const targetCount = payload.targets?.length ?? 0;
-  currentTargetCount = targetCount;
   if (configureProjectButton) {
     configureProjectButton.hidden = selected?.hasProject !== true;
   }
@@ -359,27 +365,11 @@ function applyProjectStatus(payload: {
     return;
   }
   setupCard.hidden = false;
-  if (selected === undefined) {
-    setupCardText.textContent = 'No workspace folder is open. Open a folder to start with Debug80.';
-    setupPrimaryAction.textContent = 'Open Folder';
-    setupSecondaryAction.hidden = true;
-    return;
-  }
-  if (!selected.hasProject) {
-    setupCardText.textContent = `No Debug80 project found in ${selected.name}.`;
-    setupPrimaryAction.textContent = 'Create Project';
-    setupSecondaryAction.hidden = true;
-    return;
-  }
-  if (targetCount === 0) {
-    setupCardText.textContent = 'Project has no targets configured yet.';
-    setupPrimaryAction.textContent = 'Configure Project';
-    setupSecondaryAction.hidden = true;
-    return;
-  }
-  setupCardText.textContent = 'Project is configured. Start debugging or adjust settings.';
-  setupPrimaryAction.textContent = 'Start Debugging';
-  setupSecondaryAction.hidden = false;
+  const setupState = resolveSetupCardState(selected, targetCount);
+  setupPrimaryActionType = setupState.primaryAction;
+  setupCardText.textContent = setupState.text;
+  setupPrimaryAction.textContent = setupState.primaryLabel;
+  setupSecondaryAction.hidden = !setupState.showSecondaryConfigure;
   setupSecondaryAction.textContent = 'Configure';
 }
 

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -105,6 +105,11 @@ const DEFAULT_TAB: PanelTab =
     : 'ui';
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
 const createProjectButton = document.getElementById('createProject') as HTMLButtonElement | null;
+const configureProjectButton = document.getElementById('configureProject') as HTMLButtonElement | null;
+const setupCard = document.getElementById('setupCard') as HTMLElement | null;
+const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
+const setupPrimaryAction = document.getElementById('setupPrimaryAction') as HTMLButtonElement | null;
+const setupSecondaryAction = document.getElementById('setupSecondaryAction') as HTMLButtonElement | null;
 const sessionStatusButton = document.getElementById('sessionStatus') as HTMLButtonElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const displayEl = document.getElementById('display') as HTMLElement;
@@ -127,6 +132,8 @@ const DIGITS = 6;
 let sysCtrlSegs: HTMLElement[] = [];
 let sysCtrlValue = 0;
 let currentRootPath = '';
+let currentRoots: Array<{ name: string; path: string; hasProject: boolean }> = [];
+let currentTargetCount = 0;
 const digitEls: HTMLElement[] = [];
 const sessionStatusController = createSessionStatusController(vscode, sessionStatusButton);
 for (let i = 0; i < DIGITS; i++) {
@@ -254,6 +261,31 @@ const projectRootController = createProjectRootButtonController(
   createProjectButton
 );
 
+configureProjectButton?.addEventListener('click', () => {
+  vscode.postMessage({ type: 'configureProject' });
+});
+
+setupPrimaryAction?.addEventListener('click', () => {
+  const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
+  if (selected === undefined) {
+    vscode.postMessage({ type: 'openWorkspaceFolder' });
+    return;
+  }
+  if (!selected.hasProject) {
+    vscode.postMessage({ type: 'createProject', rootPath: selected.path });
+    return;
+  }
+  if (currentTargetCount === 0) {
+    vscode.postMessage({ type: 'configureProject' });
+    return;
+  }
+  vscode.postMessage({ type: 'startDebug' });
+});
+
+setupSecondaryAction?.addEventListener('click', () => {
+  vscode.postMessage({ type: 'configureProject' });
+});
+
 homeTargetSelect?.addEventListener('change', () => {
   const targetName = homeTargetSelect.value;
   if (!targetName) {
@@ -310,12 +342,45 @@ function applyProjectStatus(payload: {
   targetName?: string;
 }): void {
   currentRootPath = payload.rootPath ?? '';
+  currentRoots = payload.roots ?? [];
   projectRootController.applyProjectStatus({
     rootPath: payload.rootPath,
     roots: payload.roots ?? [],
     targetCount: payload.targets?.length ?? 0,
   });
   setTargetOptions(payload.targets ?? [], payload.targetName);
+  const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
+  const targetCount = payload.targets?.length ?? 0;
+  currentTargetCount = targetCount;
+  if (configureProjectButton) {
+    configureProjectButton.hidden = selected?.hasProject !== true;
+  }
+  if (!setupCard || !setupCardText || !setupPrimaryAction || !setupSecondaryAction) {
+    return;
+  }
+  setupCard.hidden = false;
+  if (selected === undefined) {
+    setupCardText.textContent = 'No workspace folder is open. Open a folder to start with Debug80.';
+    setupPrimaryAction.textContent = 'Open Folder';
+    setupSecondaryAction.hidden = true;
+    return;
+  }
+  if (!selected.hasProject) {
+    setupCardText.textContent = `No Debug80 project found in ${selected.name}.`;
+    setupPrimaryAction.textContent = 'Create Project';
+    setupSecondaryAction.hidden = true;
+    return;
+  }
+  if (targetCount === 0) {
+    setupCardText.textContent = 'Project has no targets configured yet.';
+    setupPrimaryAction.textContent = 'Configure Project';
+    setupSecondaryAction.hidden = true;
+    return;
+  }
+  setupCardText.textContent = 'Project is configured. Start debugging or adjust settings.';
+  setupPrimaryAction.textContent = 'Start Debugging';
+  setupSecondaryAction.hidden = false;
+  setupSecondaryAction.textContent = 'Configure';
 }
 
 applyProjectStatus({});


### PR DESCRIPTION
## Summary
- add a compact state-aware setup card to TEC-1 and TEC-1G sidebar platform views
- expose explicit actions for empty workspace, uninitialized root, and configured project states
- route new webview actions to `vscode.openFolder` and `Debug80: Open Project Configuration Panel`

## Test plan
- [x] npm test


Made with [Cursor](https://cursor.com)