### PR TITLE
Clarify project-default vs target-override platform UX

### DIFF
--- a/docs/design-project-workflow.md
+++ b/docs/design-project-workflow.md
@@ -84,6 +84,21 @@ The first version of the improved model should be:
 
 This maps directly onto the current `debug80.json` structure and keeps scope under control.
 
+### Platform UX model
+
+Debug80 should use this user-facing platform model:
+
+- `Project default platform`: the baseline platform for the project (`projectPlatform`).
+- `Target platform override`: an optional per-target override (`targets.<name>.platform`).
+
+UX guidance:
+
+- project setup and project configuration panels should present and edit the project default first
+- target configuration should label per-target platform as an override, not as the primary project identity
+- debug and sidebar status should prefer project-level language by default, while still honoring target overrides at runtime
+
+This keeps config flexibility without forcing new users to think in target-level terms before they need to.
+
 ### Configuration location
 
 Debug80 project config should live in the folder:

--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -60,7 +60,7 @@ type SelectTargetArgs = {
 };
 
 type ConfigureFieldId =
-  | 'platform'
+  | 'targetPlatformOverride'
   | 'program'
   | 'assembler'
   | 'targetName'
@@ -158,7 +158,7 @@ function buildProjectConfigPanelHtml(
 <body>
   <h2>Debug80 Project Configuration</h2>
   <div class="row">
-    <label for="platform">Project Platform</label>
+    <label for="platform">Project Default Platform</label>
     <select id="platform">${platformOptions}</select>
   </div>
   <div class="row">
@@ -166,7 +166,7 @@ function buildProjectConfigPanelHtml(
     <select id="defaultTarget">${targetOptions}</select>
   </div>
   <button id="save">Save Configuration</button>
-  <div class="hint">This panel edits project-level settings only. Target-specific runtime controls are unchanged.</div>
+  <div class="hint">This panel edits project-level settings only. Per-target platform overrides remain available in target configuration flows.</div>
   <script nonce="${nonce}">
     const vscode = acquireVsCodeApi();
     document.getElementById('save')?.addEventListener('click', () => {
@@ -570,7 +570,7 @@ export function registerExtensionCommands({
 
       const pick = await vscode.window.showQuickPick(
         [
-          { label: 'Platform', value: 'platform' as ConfigureFieldId },
+          { label: 'Target Platform Override', value: 'targetPlatformOverride' as ConfigureFieldId },
           { label: 'Program File', value: 'program' as ConfigureFieldId },
           { label: 'Assembler', value: 'assembler' as ConfigureFieldId },
           { label: 'Target Name', value: 'targetName' as ConfigureFieldId },
@@ -595,14 +595,14 @@ export function registerExtensionCommands({
       const updatedTarget: Record<string, unknown> = { ...currentTarget };
       let nextTargetName = target;
 
-      if (pick.value === 'platform') {
+      if (pick.value === 'targetPlatformOverride') {
         const platformPick = await vscode.window.showQuickPick(
           [
             { label: 'simple', detail: 'Generic Debug80 memory-map platform' },
             { label: 'tec1', detail: 'Classic TEC-1 keypad/LCD platform' },
             { label: 'tec1g', detail: 'TEC-1G LCD/GLCD/matrix platform' },
           ],
-          { placeHolder: 'Select target platform' }
+          { placeHolder: 'Select a platform override for this target' }
         );
         if (!platformPick) {
           return undefined;

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -541,7 +541,10 @@ describe('registerExtensionCommands', () => {
       })
     );
     const showQuickPickMock = vscode.window.showQuickPick as ReturnType<typeof vi.fn>;
-    showQuickPickMock.mockResolvedValueOnce({ label: 'Platform', value: 'platform' });
+    showQuickPickMock.mockResolvedValueOnce({
+      label: 'Target Platform Override',
+      value: 'targetPlatformOverride',
+    });
     showQuickPickMock.mockResolvedValueOnce({ label: 'tec1g' });
 
     registerExtensionCommands({
@@ -593,7 +596,10 @@ describe('registerExtensionCommands', () => {
       })
     );
     const showQuickPickMock = vscode.window.showQuickPick as ReturnType<typeof vi.fn>;
-    showQuickPickMock.mockResolvedValueOnce({ label: 'Platform', value: 'platform' });
+    showQuickPickMock.mockResolvedValueOnce({
+      label: 'Target Platform Override',
+      value: 'targetPlatformOverride',
+    });
     showQuickPickMock.mockResolvedValueOnce({ label: 'tec1g' });
 
     registerExtensionCommands({


### PR DESCRIPTION
## Summary
- rename target configuration language to `Target Platform Override` to reduce project-vs-target ambiguity
- clarify project configuration panel language as `Project Default Platform`
- document the UX model in the project workflow design notes

## Test plan
- [x] npm test


Made with [Cursor](https://cursor.com)