### PR TITLE
Define shared platform-view message contracts

### DIFF
--- a/src/contracts/platform-view.ts
+++ b/src/contracts/platform-view.ts
@@ -1,0 +1,40 @@
+import type { Tec1Message } from '../platforms/tec1/ui-panel-messages';
+import type { Tec1gMessage } from '../platforms/tec1g/ui-panel-messages';
+
+export type PlatformId = 'simple' | 'tec1' | 'tec1g';
+
+export type ProjectStatusPayload = {
+  rootName?: string;
+  rootPath?: string;
+  hasProject?: boolean;
+  targetName?: string;
+  entrySource?: string;
+  roots: Array<{
+    name: string;
+    path: string;
+    hasProject: boolean;
+  }>;
+  targets: Array<{
+    name: string;
+    description?: string;
+    detail?: string;
+  }>;
+};
+
+export type PlatformViewControlMessage =
+  | { type: 'startDebug'; rootPath?: string }
+  | { type: 'createProject'; rootPath?: string }
+  | { type: 'openWorkspaceFolder' }
+  | { type: 'selectProject'; rootPath?: string }
+  | { type: 'configureProject' }
+  | { type: 'selectTarget'; rootPath?: string; targetName?: string }
+  | { type: 'setEntrySource' }
+  | { type: 'serialSendFile' }
+  | { type: 'serialSave'; text: string }
+  | { type: 'serialClear' };
+
+export type PlatformViewInboundMessage =
+  | PlatformViewControlMessage
+  | Tec1Message
+  | Tec1gMessage
+  | { type?: string; [key: string]: unknown };

--- a/src/extension/platform-view-messages.ts
+++ b/src/extension/platform-view-messages.ts
@@ -2,22 +2,32 @@
  * @file Message routing helpers for the Debug80 platform view webview.
  */
 
-export type PlatformViewPlatform = string;
+import type {
+  PlatformId as PlatformViewPlatform,
+  PlatformViewInboundMessage as PlatformViewMessage,
+} from '../contracts/platform-view';
+export type { PlatformViewPlatform, PlatformViewMessage };
 
-export type PlatformViewMessage = {
-  type?: string;
-  text?: string;
-  [key: string]: unknown;
-};
+function rootPathFrom(msg: PlatformViewMessage): string | undefined {
+  const value = (msg as { rootPath?: unknown }).rootPath;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function targetNameFrom(msg: PlatformViewMessage): string | undefined {
+  const value = (msg as { targetName?: unknown }).targetName;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
 
 export interface PlatformViewMessageDependencies {
   handleCreateProject: (args?: { rootPath?: string }) => PromiseLike<void>;
+  handleOpenWorkspaceFolder: () => PromiseLike<void>;
   handleSelectProject: (args?: { rootPath?: string }) => PromiseLike<void>;
+  handleConfigureProject: () => PromiseLike<void>;
   handleSelectTarget: (args?: { rootPath?: string; targetName?: string }) => PromiseLike<void>;
   handleRestartDebug: () => PromiseLike<void>;
   handleSetEntrySource: () => PromiseLike<void>;
   currentPlatform: () => PlatformViewPlatform | undefined;
-  handleStartDebug: () => PromiseLike<void>;
+  handleStartDebug: (args?: { rootPath?: string }) => PromiseLike<void>;
   handleSerialSendFile: () => PromiseLike<void>;
   handleSerialSave: (text: string) => PromiseLike<void>;
   clearSerialBuffer: (platform: PlatformViewPlatform) => void;
@@ -32,29 +42,29 @@ export async function handlePlatformViewMessage(
   deps: PlatformViewMessageDependencies
 ): Promise<void> {
   if (msg?.type === 'createProject') {
-    await deps.handleCreateProject(
-      typeof msg.rootPath === 'string' && msg.rootPath.length > 0
-        ? { rootPath: msg.rootPath }
-        : undefined
-    );
+    const rootPath = rootPathFrom(msg);
+    await deps.handleCreateProject(rootPath !== undefined ? { rootPath } : undefined);
     return;
   }
   if (msg?.type === 'selectProject') {
-    await deps.handleSelectProject(
-      typeof msg.rootPath === 'string' && msg.rootPath.length > 0
-        ? { rootPath: msg.rootPath }
-        : undefined
-    );
+    const rootPath = rootPathFrom(msg);
+    await deps.handleSelectProject(rootPath !== undefined ? { rootPath } : undefined);
+    return;
+  }
+  if (msg?.type === 'openWorkspaceFolder') {
+    await deps.handleOpenWorkspaceFolder();
+    return;
+  }
+  if (msg?.type === 'configureProject') {
+    await deps.handleConfigureProject();
     return;
   }
   if (msg?.type === 'selectTarget') {
+    const rootPath = rootPathFrom(msg);
+    const targetName = targetNameFrom(msg);
     await deps.handleSelectTarget({
-      ...(typeof msg.rootPath === 'string' && msg.rootPath.length > 0
-        ? { rootPath: msg.rootPath }
-        : {}),
-      ...(typeof msg.targetName === 'string' && msg.targetName.length > 0
-        ? { targetName: msg.targetName }
-        : {}),
+      ...(rootPath !== undefined ? { rootPath } : {}),
+      ...(targetName !== undefined ? { targetName } : {}),
     });
     return;
   }
@@ -67,7 +77,8 @@ export async function handlePlatformViewMessage(
     return;
   }
   if (msg?.type === 'startDebug') {
-    await deps.handleStartDebug();
+    const rootPath = rootPathFrom(msg);
+    await deps.handleStartDebug(rootPath !== undefined ? { rootPath } : undefined);
     return;
   }
   if (msg?.type === 'serialSendFile') {

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -39,26 +39,12 @@ import type { Tec1gUpdatePayload } from '../platforms/tec1g/types';
 import { listProjectTargetChoices } from './project-target-selection';
 import { resolveProjectStatusSummary } from './project-status';
 import { findProjectConfigPath } from './project-config';
-
-type PlatformId = 'tec1' | 'tec1g' | 'simple';
-
-type ProjectStatusPayload = {
-  rootName?: string;
-  rootPath?: string;
-  hasProject?: boolean;
-  targetName?: string;
-  entrySource?: string;
-  roots: Array<{
-    name: string;
-    path: string;
-    hasProject: boolean;
-  }>;
-  targets: Array<{
-    name: string;
-    description?: string;
-    detail?: string;
-  }>;
-};
+import { handlePlatformViewMessage } from './platform-view-messages';
+import type {
+  PlatformId,
+  PlatformViewInboundMessage,
+  ProjectStatusPayload,
+} from '../contracts/platform-view';
 
 export class PlatformViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'debug80.platformView';
@@ -321,88 +307,74 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'out', 'webview')],
     };
 
-    webviewView.webview.onDidReceiveMessage(async (msg: Tec1Message | Tec1gMessage | { type?: string; text?: string }) => {
-      if (msg?.type === 'startDebug') {
-        await vscode.commands.executeCommand(
-          'debug80.startDebug',
-          typeof (msg as { rootPath?: string }).rootPath === 'string'
-            ? { rootPath: (msg as { rootPath?: string }).rootPath }
-            : undefined
-        );
-        return;
-      }
-      if (msg?.type === 'createProject') {
-        await vscode.commands.executeCommand('debug80.createProject', {
-          rootPath: (msg as { rootPath?: string }).rootPath,
-        });
-        return;
-      }
-      if (msg?.type === 'openWorkspaceFolder') {
-        await vscode.commands.executeCommand('vscode.openFolder');
-        return;
-      }
-      if (msg?.type === 'selectProject') {
-        await vscode.commands.executeCommand('debug80.selectWorkspaceFolder', {
-          rootPath: (msg as { rootPath?: string }).rootPath,
-        });
-        return;
-      }
-      if (msg?.type === 'configureProject') {
-        await vscode.commands.executeCommand('debug80.openProjectConfigPanel');
-        return;
-      }
-      if (msg?.type === 'selectTarget') {
-        await vscode.commands.executeCommand('debug80.selectTarget', {
-          rootPath: (msg as { rootPath?: string }).rootPath,
-          targetName: (msg as { targetName?: string }).targetName,
-        });
-        return;
-      }
-      if (msg?.type === 'setEntrySource') {
-        await vscode.commands.executeCommand('debug80.setEntrySource');
-        return;
-      }
-      if (msg?.type === 'serialSendFile') {
-        await this.handleSerialSendFile();
-        return;
-      }
-      if (msg?.type === 'serialSave' && typeof msg.text === 'string') {
-        await this.handleSerialSave(msg.text);
-        return;
-      }
-      if (msg?.type === 'serialClear') {
-        if (this.currentPlatform === 'tec1') {
-          clearSerialBuffer(this.tec1SerialBuffer);
-        } else if (this.currentPlatform === 'tec1g') {
-          clearTec1gSerialBuffer(this.tec1gSerialBuffer);
-        }
-        return;
-      }
-      if (this.currentPlatform === 'tec1') {
-        await handleTec1Message(msg as Tec1Message, {
-          getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
-          refreshController: this.tec1RefreshController,
-          autoRefreshMs: 150,
-          setActiveTab: (tab) => {
-            this.tec1ActiveTab = tab;
-          },
-          getActiveTab: () => this.tec1ActiveTab,
-          isPanelVisible: () => this.view?.visible === true,
-          memoryViews: this.tec1MemoryViews,
-        });
-      } else if (this.currentPlatform === 'tec1g') {
-        await handleTec1gMessage(msg as Tec1gMessage, {
-          getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
-          refreshController: this.tec1gRefreshController,
-          autoRefreshMs: 150,
-          setActiveTab: (tab) => {
-            this.tec1gActiveTab = tab;
-          },
-          getActiveTab: () => this.tec1gActiveTab,
-          isPanelVisible: () => this.view?.visible === true,
-          memoryViews: this.tec1gMemoryViews,
-        });
-      }
+    webviewView.webview.onDidReceiveMessage(async (msg: PlatformViewInboundMessage) => {
+      await handlePlatformViewMessage(msg, {
+        handleCreateProject: async (args) => {
+          await vscode.commands.executeCommand('debug80.createProject', args);
+        },
+        handleOpenWorkspaceFolder: async () => {
+          await vscode.commands.executeCommand('vscode.openFolder');
+        },
+        handleSelectProject: async (args) => {
+          await vscode.commands.executeCommand('debug80.selectWorkspaceFolder', args);
+        },
+        handleConfigureProject: async () => {
+          await vscode.commands.executeCommand('debug80.openProjectConfigPanel');
+        },
+        handleSelectTarget: async (args) => {
+          await vscode.commands.executeCommand('debug80.selectTarget', args);
+        },
+        handleRestartDebug: async () => {
+          await vscode.commands.executeCommand('debug80.restartDebug');
+        },
+        handleSetEntrySource: async () => {
+          await vscode.commands.executeCommand('debug80.setEntrySource');
+        },
+        currentPlatform: () => this.currentPlatform,
+        handleStartDebug: async (args) => {
+          await vscode.commands.executeCommand('debug80.startDebug', args);
+        },
+        handleSerialSendFile: async () => {
+          await this.handleSerialSendFile();
+        },
+        handleSerialSave: async (text) => {
+          await this.handleSerialSave(text);
+        },
+        clearSerialBuffer: (platform) => {
+          if (platform === 'tec1') {
+            clearSerialBuffer(this.tec1SerialBuffer);
+          } else if (platform === 'tec1g') {
+            clearTec1gSerialBuffer(this.tec1gSerialBuffer);
+          }
+        },
+        handlePlatformMessage: async (platform, platformMsg) => {
+          if (platform === 'tec1') {
+            await handleTec1Message(platformMsg as Tec1Message, {
+              getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
+              refreshController: this.tec1RefreshController,
+              autoRefreshMs: 150,
+              setActiveTab: (tab) => {
+                this.tec1ActiveTab = tab;
+              },
+              getActiveTab: () => this.tec1ActiveTab,
+              isPanelVisible: () => this.view?.visible === true,
+              memoryViews: this.tec1MemoryViews,
+            });
+            return;
+          }
+          await handleTec1gMessage(platformMsg as Tec1gMessage, {
+            getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
+            refreshController: this.tec1gRefreshController,
+            autoRefreshMs: 150,
+            setActiveTab: (tab) => {
+              this.tec1gActiveTab = tab;
+            },
+            getActiveTab: () => this.tec1gActiveTab,
+            isPanelVisible: () => this.view?.visible === true,
+            memoryViews: this.tec1gMemoryViews,
+          });
+        },
+      });
     });
 
     webviewView.onDidDispose(() => {

--- a/tests/extension/platform-view-messages.test.ts
+++ b/tests/extension/platform-view-messages.test.ts
@@ -8,7 +8,9 @@ import { handlePlatformViewMessage } from '../../src/extension/platform-view-mes
 function createDependencies(platform: 'simple' | 'tec1' | 'tec1g' | undefined) {
   return {
     handleCreateProject: vi.fn(() => undefined),
+    handleOpenWorkspaceFolder: vi.fn(() => undefined),
     handleSelectProject: vi.fn(() => undefined),
+    handleConfigureProject: vi.fn(() => undefined),
     handleSelectTarget: vi.fn(() => undefined),
     handleRestartDebug: vi.fn(() => undefined),
     handleSetEntrySource: vi.fn(() => undefined),
@@ -33,7 +35,9 @@ describe('platform-view message routing', () => {
     );
     await handlePlatformViewMessage({ type: 'restartDebug' }, deps);
     await handlePlatformViewMessage({ type: 'setEntrySource' }, deps);
-    await handlePlatformViewMessage({ type: 'startDebug' }, deps);
+    await handlePlatformViewMessage({ type: 'startDebug', rootPath: '/workspace/a' }, deps);
+    await handlePlatformViewMessage({ type: 'openWorkspaceFolder' }, deps);
+    await handlePlatformViewMessage({ type: 'configureProject' }, deps);
     await handlePlatformViewMessage({ type: 'serialSendFile' }, deps);
     await handlePlatformViewMessage({ type: 'serialSave', text: 'hello' }, deps);
 
@@ -45,7 +49,9 @@ describe('platform-view message routing', () => {
     });
     expect(deps.handleRestartDebug).toHaveBeenCalledTimes(1);
     expect(deps.handleSetEntrySource).toHaveBeenCalledTimes(1);
-    expect(deps.handleStartDebug).toHaveBeenCalledTimes(1);
+    expect(deps.handleStartDebug).toHaveBeenCalledWith({ rootPath: '/workspace/a' });
+    expect(deps.handleOpenWorkspaceFolder).toHaveBeenCalledTimes(1);
+    expect(deps.handleConfigureProject).toHaveBeenCalledTimes(1);
     expect(deps.handleSerialSendFile).toHaveBeenCalledTimes(1);
     expect(deps.handleSerialSave).toHaveBeenCalledWith('hello');
   });

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -4,6 +4,7 @@ import { createSessionStatusController } from '../common/session-status';
 import { createProjectRootButtonController } from '../common/project-root-button';
 import { resolveSetupCardState } from '../common/setup-card-state';
 import { acquireVscodeApi } from '../common/vscode';
+import type { ProjectStatusPayload } from '../../src/contracts/platform-view';
 import { createAudioController } from './audio';
 import { createLcdRenderer } from './lcd-renderer';
 import { createMatrixRenderer } from './matrix-renderer';
@@ -168,10 +169,10 @@ function setTargetOptions(options: Array<{ name: string; description?: string; d
 }
 
 function applyProjectStatus(payload: {
-  rootPath?: string;
-  roots?: Array<{ name: string; path: string; hasProject: boolean }>;
-  targets?: Array<{ name: string; description?: string; detail?: string }>;
-  targetName?: string;
+  rootPath?: ProjectStatusPayload['rootPath'];
+  roots?: ProjectStatusPayload['roots'];
+  targets?: ProjectStatusPayload['targets'];
+  targetName?: ProjectStatusPayload['targetName'];
 }): void {
   currentRootPath = payload.rootPath ?? '';
   currentRoots = payload.roots ?? [];

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -309,7 +309,10 @@ function setSelectPlaceholder(select: HTMLSelectElement, label: string): void {
   select.appendChild(option);
 }
 
-function setTargetOptions(options: ProjectTargetOption[], selectedTargetName?: string): void {
+function setTargetOptions(
+  options: ProjectStatusPayload['targets'],
+  selectedTargetName?: string
+): void {
   if (!homeTargetSelect) {
     return;
   }

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -4,6 +4,7 @@ import { createSessionStatusController, type SessionStatus } from '../common/ses
 import { createProjectRootButtonController } from '../common/project-root-button';
 import { resolveSetupCardState } from '../common/setup-card-state';
 import { acquireVscodeApi } from '../common/vscode';
+import type { ProjectStatusPayload } from '../../src/contracts/platform-view';
 import { createGlcdRenderer } from './glcd-renderer';
 import { createLcdRenderer } from './lcd-renderer';
 import { createMatrixUiController } from './matrix-ui';
@@ -69,18 +70,6 @@ type MemorySnapshotPayload = {
   }>;
 };
 
-type ProjectRootOption = {
-  name: string;
-  path: string;
-  hasProject: boolean;
-};
-
-type ProjectTargetOption = {
-  name: string;
-  description?: string;
-  detail?: string;
-};
-
 type IncomingMessage =
   | { type: 'selectTab'; tab: string }
   | { type: 'sessionStatus'; status: SessionStatus }
@@ -91,8 +80,8 @@ type IncomingMessage =
       hasProject?: boolean;
       targetName?: string;
       entrySource?: string;
-      roots: ProjectRootOption[];
-      targets: ProjectTargetOption[];
+      roots: ProjectStatusPayload['roots'];
+      targets: ProjectStatusPayload['targets'];
     }
   | { type: 'uiVisibility'; visibility: Record<string, boolean>; persist?: boolean }
   | ({ type: 'update'; uiRevision?: number } & Tec1gUpdatePayload)
@@ -343,10 +332,10 @@ function setTargetOptions(options: ProjectTargetOption[], selectedTargetName?: s
 }
 
 function applyProjectStatus(payload: {
-  rootPath?: string;
-  roots?: ProjectRootOption[];
-  targets?: ProjectTargetOption[];
-  targetName?: string;
+  rootPath?: ProjectStatusPayload['rootPath'];
+  roots?: ProjectStatusPayload['roots'];
+  targets?: ProjectStatusPayload['targets'];
+  targetName?: ProjectStatusPayload['targetName'];
 }): void {
   currentRootPath = payload.rootPath ?? '';
   currentRoots = payload.roots ?? [];


### PR DESCRIPTION
## Summary
- add a shared `src/contracts/platform-view.ts` module for platform-view control messages and project status payloads
- route `PlatformViewProvider` message handling through `handlePlatformViewMessage` with contract-driven dependencies
- align webview project-status typing and extend platform-view message routing tests

## Test plan
- [x] npm test


Made with [Cursor](https://cursor.com)