### PR TITLE
Add cross-layer contract tests for payloads and routing

### DIFF
--- a/src/debug/message-types.ts
+++ b/src/debug/message-types.ts
@@ -20,6 +20,8 @@ export type CustomRequestType =
   | 'debug80/tec1gSerialInput'
   | 'debug80/tec1MemorySnapshot'
   | 'debug80/tec1gMemorySnapshot'
+  | 'debug80/registerWrite'
+  | 'debug80/memoryWrite'
   | 'debug80/rebuildWarm'
   | 'debug80/romSources';
 

--- a/tests/contracts/cross-layer-contracts.test.ts
+++ b/tests/contracts/cross-layer-contracts.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const MESSAGE_TYPES_PATH = path.join(REPO_ROOT, 'src/debug/message-types.ts');
+const ADAPTER_PATH = path.join(REPO_ROOT, 'src/debug/adapter.ts');
+const EXTENSION_COMMANDS_PATH = path.join(REPO_ROOT, 'src/extension/commands.ts');
+const EXTENSION_ROM_SOURCES_PATH = path.join(REPO_ROOT, 'src/extension/rom-sources.ts');
+const EXTENSION_AUTO_REBUILD_PATH = path.join(REPO_ROOT, 'src/extension/auto-rebuild.ts');
+const TEC1_MESSAGES_PATH = path.join(REPO_ROOT, 'src/platforms/tec1/ui-panel-messages.ts');
+const TEC1G_MESSAGES_PATH = path.join(REPO_ROOT, 'src/platforms/tec1g/ui-panel-messages.ts');
+
+function extractDebug80Literals(source: string, pattern: RegExp): Set<string> {
+  const values = new Set<string>();
+  for (const match of source.matchAll(pattern)) {
+    const literal = match[1];
+    if (typeof literal === 'string' && literal.length > 0) {
+      values.add(literal);
+    }
+  }
+  return values;
+}
+
+describe('cross-layer request contracts', () => {
+  it('keeps CustomRequestType aligned with registered adapter commands', () => {
+    const messageTypesSource = fs.readFileSync(MESSAGE_TYPES_PATH, 'utf8');
+    const adapterSource = fs.readFileSync(ADAPTER_PATH, 'utf8');
+
+    const customRequestTypes = extractDebug80Literals(
+      messageTypesSource,
+      /'((?:debug80\/)[^']+)'/g
+    );
+    const registeredCommands = extractDebug80Literals(
+      adapterSource,
+      /commandRouter\.register\('((?:debug80\/)[^']+)'/g
+    );
+
+    for (const command of registeredCommands) {
+      expect(
+        customRequestTypes.has(command),
+        `CustomRequestType missing adapter command: ${command}`
+      ).toBe(true);
+    }
+  });
+
+  it('keeps extension/webview customRequest usage in CustomRequestType', () => {
+    const messageTypesSource = fs.readFileSync(MESSAGE_TYPES_PATH, 'utf8');
+    const customRequestTypes = extractDebug80Literals(
+      messageTypesSource,
+      /'((?:debug80\/)[^']+)'/g
+    );
+
+    const callSites = [
+      EXTENSION_COMMANDS_PATH,
+      EXTENSION_ROM_SOURCES_PATH,
+      EXTENSION_AUTO_REBUILD_PATH,
+      TEC1_MESSAGES_PATH,
+      TEC1G_MESSAGES_PATH,
+    ];
+    const requestNames = new Set<string>();
+    for (const filePath of callSites) {
+      const src = fs.readFileSync(filePath, 'utf8');
+      const names = extractDebug80Literals(src, /customRequest\('((?:debug80\/)[^']+)'/g);
+      for (const name of names) {
+        requestNames.add(name);
+      }
+    }
+
+    for (const requestName of requestNames) {
+      expect(
+        customRequestTypes.has(requestName),
+        `CustomRequestType missing extension/webview callsite request: ${requestName}`
+      ).toBe(true);
+    }
+  });
+});

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -73,6 +73,8 @@ import * as path from 'path';
 
 import type * as vscode from 'vscode';
 import { PlatformViewProvider } from '../../src/extension/platform-view-provider';
+import type { Tec1UpdatePayload } from '../../src/platforms/tec1/types';
+import type { Tec1gUpdatePayload } from '../../src/platforms/tec1g/types';
 
 /** Extension root must contain built `webview/` assets (see panel-html). */
 const extensionRoot = { fsPath: path.resolve(process.cwd()) } as vscode.Uri;
@@ -555,6 +557,82 @@ describe('PlatformViewProvider', () => {
     expect(executeCommand).toHaveBeenCalledWith('debug80.createProject', {
       rootPath: '/workspace/empty-root',
     });
+  });
+
+  it('posts Tec1 update payload with contract-critical fields', () => {
+    const provider = new PlatformViewProvider(extensionRoot);
+    const webviewView = createWebviewView();
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
+    provider.setPlatform('tec1', undefined, { reveal: false, tab: 'ui' });
+
+    (webviewView.webview.postMessage as ReturnType<typeof vi.fn>).mockClear();
+    const payload: Tec1UpdatePayload = {
+      digits: [0, 0, 0, 0, 0, 0],
+      matrix: [0, 0, 0, 0, 0, 0, 0, 0],
+      speaker: 1,
+      speedMode: 'fast',
+      lcd: [0],
+      speakerHz: 440,
+    };
+    provider.updateTec1(payload);
+
+    const updateCall = getPostMessageCalls(webviewView).find(([msg]) => msg.type === 'update');
+    expect(updateCall?.[0]).toMatchObject({
+      type: 'update',
+      digits: payload.digits,
+      matrix: payload.matrix,
+      speedMode: payload.speedMode,
+      lcd: payload.lcd,
+      speakerHz: payload.speakerHz,
+    });
+  });
+
+  it('posts Tec1g update payload with matrix and glcd contract fields', () => {
+    const provider = new PlatformViewProvider(extensionRoot);
+    const webviewView = createWebviewView();
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
+    provider.setPlatform('tec1g', undefined, { reveal: false, tab: 'ui' });
+
+    (webviewView.webview.postMessage as ReturnType<typeof vi.fn>).mockClear();
+    const payload: Tec1gUpdatePayload = {
+      digits: [0, 0, 0, 0, 0, 0],
+      matrix: [0, 0, 0, 0, 0, 0, 0, 0],
+      glcd: [0, 0],
+      speaker: 1,
+      speedMode: 'fast',
+      lcd: [0],
+      matrixGreen: [1],
+      matrixBlue: [2],
+      speakerHz: 880,
+    };
+    provider.updateTec1g(payload);
+
+    const updateCall = getPostMessageCalls(webviewView).find(([msg]) => msg.type === 'update');
+    const update = updateCall?.[0];
+    expect(update?.type).toBe('update');
+    expect(update?.digits).toEqual(payload.digits);
+    expect(update?.matrix).toEqual(payload.matrix);
+    expect(Array.isArray(update?.matrixGreen)).toBe(true);
+    expect((update?.matrixGreen as number[] | undefined)?.[0]).toBe(1);
+    expect(Array.isArray(update?.matrixBlue)).toBe(true);
+    expect((update?.matrixBlue as number[] | undefined)?.[0]).toBe(2);
+    expect(update?.glcd).toEqual(payload.glcd);
+    expect(update?.speedMode).toBe(payload.speedMode);
+    expect(update?.speakerHz).toBe(payload.speakerHz);
   });
 
   it('routes configureProject messages to project config panel command', async () => {


### PR DESCRIPTION
## Summary
- add new cross-layer contract tests for `debug80/*` custom request naming consistency
- add provider payload routing checks for TEC-1 and TEC-1G update message contract fields
- align `CustomRequestType` literals with adapter-registered request commands

## Test plan
- [x] npm test


Made with [Cursor](https://cursor.com)