### PR TITLE
Centralize platform update payload serialization (#229)

### DIFF
--- a/src/extension/debug-session-events.ts
+++ b/src/extension/debug-session-events.ts
@@ -3,6 +3,8 @@
  */
 
 import * as vscode from 'vscode';
+import { tec1UpdatePayloadFromDebugEventBody } from '../platforms/tec1/serialize-update-payload';
+import { tec1gUpdatePayloadFromDebugEventBody } from '../platforms/tec1g/serialize-ui-update-payload';
 import { PlatformViewProvider } from './platform-view-provider';
 import { openRomSourcesForSession } from './rom-sources';
 import { SessionStateManager } from './session-state-manager';
@@ -194,30 +196,11 @@ export function registerDebugSessionHandlers({
         return;
       }
       if (evt.event === 'debug80/tec1Update') {
-        const payload = evt.body as {
-          digits?: number[];
-          matrix?: number[];
-          lcd?: number[];
-          sysCtrl?: number;
-          speaker?: number;
-          speakerHz?: number;
-          speedMode?: 'slow' | 'fast';
-        } | undefined;
-        if (!payload?.digits || !payload?.lcd || !payload?.matrix) {
+        const payload = tec1UpdatePayloadFromDebugEventBody(evt.body);
+        if (payload === undefined) {
           return;
         }
-        const update = {
-          digits: payload.digits,
-          matrix: payload.matrix,
-          speaker: payload.speaker ?? 0,
-          speedMode: payload.speedMode ?? 'slow',
-          lcd: payload.lcd,
-        };
-        if (payload.speakerHz !== undefined) {
-          platformViewProvider.updateTec1({ ...update, speakerHz: payload.speakerHz }, evt.session.id);
-        } else {
-          platformViewProvider.updateTec1(update, evt.session.id);
-        }
+        platformViewProvider.updateTec1(payload, evt.session.id);
         return;
       }
       if (evt.event === 'debug80/tec1Serial') {
@@ -230,65 +213,11 @@ export function registerDebugSessionHandlers({
         return;
       }
       if (evt.event === 'debug80/tec1gUpdate') {
-        const payload = evt.body as {
-          digits?: number[];
-          matrix?: number[];
-          matrixGreen?: number[];
-          matrixBlue?: number[];
-          matrixBrightness?: number[];
-          matrixBrightnessG?: number[];
-          matrixBrightnessB?: number[];
-          glcd?: number[];
-          glcdDdram?: number[];
-          glcdState?: {
-            displayOn?: boolean;
-            graphicsOn?: boolean;
-            cursorOn?: boolean;
-            cursorBlink?: boolean;
-            blinkVisible?: boolean;
-            ddramAddr?: number;
-            ddramPhase?: number;
-            textShift?: number;
-            scroll?: number;
-            reverseMask?: number;
-          };
-          lcd?: number[];
-          speaker?: number;
-          speakerHz?: number;
-          speedMode?: 'slow' | 'fast';
-        } | undefined;
-        if (!payload?.digits || !payload?.lcd || !payload?.matrix || !payload?.glcd) {
+        const payload = tec1gUpdatePayloadFromDebugEventBody(evt.body);
+        if (payload === undefined) {
           return;
         }
-        const update = {
-          digits: payload.digits,
-          matrix: payload.matrix,
-          ...(payload.matrixGreen !== undefined ? { matrixGreen: payload.matrixGreen } : {}),
-          ...(payload.matrixBlue !== undefined ? { matrixBlue: payload.matrixBlue } : {}),
-          ...(payload.matrixBrightness !== undefined
-            ? { matrixBrightness: payload.matrixBrightness }
-            : {}),
-          ...(payload.matrixBrightnessG !== undefined
-            ? { matrixBrightnessG: payload.matrixBrightnessG }
-            : {}),
-          ...(payload.matrixBrightnessB !== undefined
-            ? { matrixBrightnessB: payload.matrixBrightnessB }
-            : {}),
-          glcd: payload.glcd,
-          speaker: payload.speaker ?? 0,
-          speedMode: payload.speedMode ?? 'slow',
-          lcd: payload.lcd,
-          ...(payload.glcdDdram !== undefined ? { glcdDdram: payload.glcdDdram } : {}),
-          ...(payload.glcdState !== undefined ? { glcdState: payload.glcdState } : {}),
-        };
-        if (payload.speakerHz !== undefined) {
-          platformViewProvider.updateTec1g(
-            { ...update, speakerHz: payload.speakerHz },
-            evt.session.id
-          );
-        } else {
-          platformViewProvider.updateTec1g(update, evt.session.id);
-        }
+        platformViewProvider.updateTec1g(payload, evt.session.id);
         return;
       }
       if (evt.event === 'debug80/tec1gSerial') {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -26,6 +26,14 @@ import {
   type PlatformUiEntry,
   type PlatformUiModules,
 } from './platform-view-manifest';
+import {
+  serializeTec1ClearFromUiState,
+  serializeTec1UpdateFromUiState,
+} from '../platforms/tec1/serialize-update-payload';
+import {
+  serializeTec1gClearPanelUpdateFromUiState,
+  serializeTec1gUpdateFromUiState,
+} from '../platforms/tec1g/serialize-ui-update-payload';
 
 export interface Debug80Api {
   registerPlatform: (entry: PlatformManifestEntry) => void;
@@ -54,13 +62,6 @@ function createTec1PlatformUiEntry(): PlatformUiEntry {
         import('../platforms/tec1/ui-panel-state.js'),
       ]);
       type Tec1UiState = ReturnType<typeof state.createTec1UiState>;
-      const serializeState = (uiState: Tec1UiState): Record<string, unknown> => ({
-        digits: uiState.digits,
-        matrix: uiState.matrix,
-        speaker: uiState.speaker,
-        speedMode: uiState.speedMode,
-        lcd: uiState.lcd,
-      });
       return {
         getHtml: html.getTec1Html,
         createUiState: state.createTec1UiState,
@@ -69,30 +70,23 @@ function createTec1PlatformUiEntry(): PlatformUiEntry {
           const tec1State = uiState as Tec1UiState;
           const tec1Payload = payload as Parameters<typeof state.applyTec1Update>[1];
           state.applyTec1Update(tec1State, tec1Payload);
-          return {
-            ...serializeState(tec1State),
-            ...(tec1Payload.speakerHz !== undefined ? { speakerHz: tec1Payload.speakerHz } : {}),
-          };
+          return serializeTec1UpdateFromUiState(tec1State, tec1Payload.speakerHz) as unknown as Record<
+            string,
+            unknown
+          >;
         },
         createMemoryViewState: memory.createMemoryViewState,
         handleMessage: (message, context): Promise<void> => messages.handleTec1Message(message, context),
         buildUpdateMessage: (uiState, uiRevision): Record<string, unknown> => ({
           type: 'update',
           uiRevision,
-          ...serializeState(uiState as Tec1UiState),
+          ...serializeTec1UpdateFromUiState(uiState as Tec1UiState),
         }),
-        buildClearMessage: (uiState, uiRevision): Record<string, unknown> => {
-          const tec1State = uiState as Tec1UiState;
-          return {
-            type: 'update',
-            uiRevision,
-            digits: tec1State.digits,
-            matrix: tec1State.matrix,
-            speaker: false,
-            speedMode: tec1State.speedMode,
-            lcd: tec1State.lcd,
-          };
-        },
+        buildClearMessage: (uiState, uiRevision): Record<string, unknown> => ({
+          type: 'update',
+          uiRevision,
+          ...serializeTec1ClearFromUiState(uiState as Tec1UiState),
+        }),
         snapshotCommand: 'debug80/tec1MemorySnapshot',
       };
     },
@@ -113,26 +107,6 @@ function createTec1gPlatformUiEntry(): PlatformUiEntry {
         import('../platforms/tec1g/ui-panel-state.js'),
       ]);
       type Tec1gUiState = ReturnType<typeof state.createTec1gUiState>;
-      const serializeState = (uiState: Tec1gUiState): Record<string, unknown> => ({
-        digits: uiState.digits,
-        matrix: uiState.matrix,
-        matrixGreen: uiState.matrixGreen,
-        matrixBlue: uiState.matrixBlue,
-        matrixBrightness: uiState.matrixBrightness,
-        matrixBrightnessG: uiState.matrixBrightnessG,
-        matrixBrightnessB: uiState.matrixBrightnessB,
-        glcd: uiState.glcd,
-        glcdDdram: uiState.glcdDdram,
-        glcdState: uiState.glcdState,
-        speaker: uiState.speaker,
-        speedMode: uiState.speedMode,
-        sysCtrl: uiState.sysCtrlValue,
-        bankA14: uiState.bankA14,
-        capsLock: uiState.capsLock,
-        lcdState: uiState.lcdState,
-        lcdCgram: uiState.lcdCgram,
-        lcd: uiState.lcd,
-      });
       return {
         getHtml: html.getTec1gHtml,
         createUiState: state.createTec1gUiState,
@@ -141,36 +115,23 @@ function createTec1gPlatformUiEntry(): PlatformUiEntry {
           const tec1gState = uiState as Tec1gUiState;
           const tec1gPayload = payload as Parameters<typeof state.applyTec1gUpdate>[1];
           state.applyTec1gUpdate(tec1gState, tec1gPayload);
-          return {
-            ...serializeState(tec1gState),
-            ...(tec1gPayload.speakerHz !== undefined ? { speakerHz: tec1gPayload.speakerHz } : {}),
-          };
+          return serializeTec1gUpdateFromUiState(tec1gState, tec1gPayload.speakerHz) as unknown as Record<
+            string,
+            unknown
+          >;
         },
         createMemoryViewState: memory.createMemoryViewState,
         handleMessage: (message, context): Promise<void> => messages.handleTec1gMessage(message, context),
         buildUpdateMessage: (uiState, uiRevision): Record<string, unknown> => ({
           type: 'update',
           uiRevision,
-          ...serializeState(uiState as Tec1gUiState),
+          ...serializeTec1gUpdateFromUiState(uiState as Tec1gUiState),
         }),
-        buildClearMessage: (uiState, uiRevision): Record<string, unknown> => {
-          const tec1gState = uiState as Tec1gUiState;
-          return {
-            type: 'update',
-            uiRevision,
-            digits: tec1gState.digits,
-            matrix: tec1gState.matrix,
-            matrixGreen: tec1gState.matrixGreen,
-            matrixBlue: tec1gState.matrixBlue,
-            matrixBrightness: tec1gState.matrixBrightness,
-            matrixBrightnessG: tec1gState.matrixBrightnessG,
-            matrixBrightnessB: tec1gState.matrixBrightnessB,
-            glcd: tec1gState.glcd,
-            speaker: false,
-            speedMode: tec1gState.speedMode,
-            lcd: tec1gState.lcd,
-          };
-        },
+        buildClearMessage: (uiState, uiRevision): Record<string, unknown> => ({
+          type: 'update',
+          uiRevision,
+          ...serializeTec1gClearPanelUpdateFromUiState(uiState as Tec1gUiState),
+        }),
         snapshotCommand: 'debug80/tec1gMemorySnapshot',
       };
     },

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -20,6 +20,10 @@ import {
 } from '../platforms/tec1/ui-panel-state';
 import { appendSerialText, clearSerialBuffer, createSerialBuffer } from '../platforms/tec1/ui-panel-serial';
 import type { Tec1UpdatePayload } from '../platforms/tec1/types';
+import {
+  serializeTec1ClearFromUiState,
+  serializeTec1UpdateFromUiState,
+} from '../platforms/tec1/serialize-update-payload';
 import { Tec1gPanelTab, getTec1gHtml } from '../platforms/tec1g/ui-panel-html';
 import { createMemoryViewState as createTec1gMemoryViewState } from '../platforms/tec1g/ui-panel-memory';
 import { handleTec1gMessage, Tec1gMessage } from '../platforms/tec1g/ui-panel-messages';
@@ -36,6 +40,10 @@ import {
 } from '../platforms/tec1g/ui-panel-state';
 import { appendSerialText as appendTec1gSerialText, clearSerialBuffer as clearTec1gSerialBuffer, createSerialBuffer as createTec1gSerialBuffer } from '../platforms/tec1g/ui-panel-serial';
 import type { Tec1gUpdatePayload } from '../platforms/tec1g/types';
+import {
+  serializeTec1gClearPanelUpdateFromUiState,
+  serializeTec1gUpdateFromUiState,
+} from '../platforms/tec1g/serialize-ui-update-payload';
 import { listProjectTargetChoices } from './project-target-selection';
 import { resolveProjectStatusSummary } from './project-status';
 import { findProjectConfigPath } from './project-config';
@@ -177,12 +185,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     this.postMessage({
       type: 'update',
       uiRevision: this.nextUiRevision(),
-      digits: this.tec1UiState.digits,
-      matrix: this.tec1UiState.matrix,
-      speaker: this.tec1UiState.speaker,
-      speedMode: this.tec1UiState.speedMode,
-      lcd: this.tec1UiState.lcd,
-      speakerHz: payload.speakerHz,
+      ...serializeTec1UpdateFromUiState(this.tec1UiState, payload.speakerHz),
     });
   }
 
@@ -197,25 +200,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     this.postMessage({
       type: 'update',
       uiRevision: this.nextUiRevision(),
-      digits: this.tec1gUiState.digits,
-      matrix: this.tec1gUiState.matrix,
-      matrixGreen: this.tec1gUiState.matrixGreen,
-      matrixBlue: this.tec1gUiState.matrixBlue,
-      glcd: this.tec1gUiState.glcd,
-      glcdDdram: this.tec1gUiState.glcdDdram,
-      glcdState: this.tec1gUiState.glcdState,
-      speaker: this.tec1gUiState.speaker,
-      matrixBrightness: this.tec1gUiState.matrixBrightness,
-      matrixBrightnessG: this.tec1gUiState.matrixBrightnessG,
-      matrixBrightnessB: this.tec1gUiState.matrixBrightnessB,
-      speedMode: this.tec1gUiState.speedMode,
-      sysCtrl: this.tec1gUiState.sysCtrlValue,
-      bankA14: this.tec1gUiState.bankA14,
-      capsLock: this.tec1gUiState.capsLock,
-      lcdState: this.tec1gUiState.lcdState,
-      lcdCgram: this.tec1gUiState.lcdCgram,
-      lcd: this.tec1gUiState.lcd,
-      speakerHz: payload.speakerHz,
+      ...serializeTec1gUpdateFromUiState(this.tec1gUiState, payload.speakerHz),
     });
   }
 
@@ -256,28 +241,14 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       this.postMessage({
         type: 'update',
         uiRevision: this.nextUiRevision(),
-        digits: this.tec1UiState.digits,
-        matrix: this.tec1UiState.matrix,
-        speaker: false,
-        speedMode: this.tec1UiState.speedMode,
-        lcd: this.tec1UiState.lcd,
+        ...serializeTec1ClearFromUiState(this.tec1UiState),
       });
       this.postMessage({ type: 'serialClear' });
     } else if (this.currentPlatform === 'tec1g') {
       this.postMessage({
         type: 'update',
         uiRevision: this.nextUiRevision(),
-        digits: this.tec1gUiState.digits,
-        matrix: this.tec1gUiState.matrix,
-        matrixGreen: this.tec1gUiState.matrixGreen,
-        matrixBlue: this.tec1gUiState.matrixBlue,
-        glcd: this.tec1gUiState.glcd,
-        speaker: false,
-        speedMode: this.tec1gUiState.speedMode,
-        lcd: this.tec1gUiState.lcd,
-        matrixBrightness: this.tec1gUiState.matrixBrightness,
-        matrixBrightnessG: this.tec1gUiState.matrixBrightnessG,
-        matrixBrightnessB: this.tec1gUiState.matrixBrightnessB,
+        ...serializeTec1gClearPanelUpdateFromUiState(this.tec1gUiState),
       });
       this.postMessage({ type: 'serialClear' });
     }

--- a/src/platforms/tec1/runtime.ts
+++ b/src/platforms/tec1/runtime.ts
@@ -12,6 +12,7 @@ import { BitbangUartDecoder } from '../serial/bitbang-uart';
 import { Tec1PlatformConfig, Tec1PlatformConfigNormalized } from '../types';
 import { normalizeSimpleRegions } from '../simple/runtime';
 import { Tec1SpeedMode, Tec1UpdatePayload } from './types';
+import { serializeTec1UpdateFromRuntimeState } from './serialize-update-payload';
 import {
   TEC1_ADDR_MAX,
   TEC1_APP_START_DEFAULT,
@@ -192,14 +193,7 @@ export function createTec1Runtime(
   };
 
   const sendUpdate = (): void => {
-    onUpdate({
-      digits: [...state.digits],
-      matrix: [...state.matrix],
-      speaker: state.speaker ? 1 : 0,
-      speedMode: state.speedMode,
-      lcd: [...state.lcd],
-      speakerHz: state.speakerHz,
-    });
+    onUpdate(serializeTec1UpdateFromRuntimeState(state));
   };
 
   let serialLevel: 0 | 1 = 1;

--- a/src/platforms/tec1/serialize-update-payload.ts
+++ b/src/platforms/tec1/serialize-update-payload.ts
@@ -1,0 +1,92 @@
+/**
+ * @file Central serialization for TEC-1 UI update payloads (runtime, webview, DAP events).
+ */
+
+import type { Tec1State } from './runtime';
+import type { Tec1UiState } from './ui-panel-state';
+import type { Tec1SpeedMode, Tec1UpdatePayload } from './types';
+
+/**
+ * Snapshot payload from emulator runtime state (adapter → extension / UI).
+ */
+export function serializeTec1UpdateFromRuntimeState(state: Tec1State): Tec1UpdatePayload {
+  return {
+    digits: [...state.digits],
+    matrix: [...state.matrix],
+    speaker: state.speaker ? 1 : 0,
+    speedMode: state.speedMode,
+    lcd: [...state.lcd],
+    speakerHz: state.speakerHz,
+  };
+}
+
+/**
+ * Snapshot payload from sidebar UI state after applying an update (extension → webview).
+ */
+export function serializeTec1UpdateFromUiState(state: Tec1UiState, speakerHz?: number): Tec1UpdatePayload {
+  const payload: Tec1UpdatePayload = {
+    digits: [...state.digits],
+    matrix: [...state.matrix],
+    speaker: state.speaker ? 1 : 0,
+    speedMode: state.speedMode,
+    lcd: [...state.lcd],
+  };
+  if (speakerHz !== undefined) {
+    payload.speakerHz = speakerHz;
+  }
+  return payload;
+}
+
+/**
+ * Partial update with speaker forced off (session clear / idle reset).
+ */
+export function serializeTec1ClearFromUiState(state: Tec1UiState): Tec1UpdatePayload {
+  return {
+    digits: [...state.digits],
+    matrix: [...state.matrix],
+    speaker: 0,
+    speedMode: state.speedMode,
+    lcd: [...state.lcd],
+  };
+}
+
+/** Type guard for TEC-1 speed mode literals in unknown event data. */
+function isTec1SpeedMode(value: unknown): value is Tec1SpeedMode {
+  return value === 'slow' || value === 'fast';
+}
+
+/** True when `value` is an array of numbers (for DAP event body parsing). */
+function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'number');
+}
+
+/**
+ * Normalizes a `debug80/tec1Update` custom event body to a UI payload, or `undefined` if invalid.
+ */
+export function tec1UpdatePayloadFromDebugEventBody(body: unknown): Tec1UpdatePayload | undefined {
+  if (body === null || typeof body !== 'object') {
+    return undefined;
+  }
+  const raw = body as Record<string, unknown>;
+  const digits = raw.digits;
+  const matrix = raw.matrix;
+  const lcd = raw.lcd;
+  if (!isNumberArray(digits) || !isNumberArray(matrix) || !isNumberArray(lcd)) {
+    return undefined;
+  }
+  const speakerRaw = raw.speaker;
+  const speaker = typeof speakerRaw === 'number' ? speakerRaw : 0;
+  const speedMode = isTec1SpeedMode(raw.speedMode) ? raw.speedMode : 'slow';
+  const payload: Tec1UpdatePayload = {
+    digits,
+    matrix,
+    speaker,
+    speedMode,
+    lcd,
+  };
+  const hz = raw.speakerHz;
+  if (typeof hz === 'number') {
+    payload.speakerHz = hz;
+  }
+  return payload;
+}

--- a/src/platforms/tec1g/serialize-ui-update-payload.ts
+++ b/src/platforms/tec1g/serialize-ui-update-payload.ts
@@ -1,0 +1,148 @@
+/**
+ * @file Central serialization for TEC-1G UI update payloads (webview rehydration, DAP events).
+ *
+ * Runtime snapshots use {@link serializeTec1gUpdateFromRuntimeState} in `update-controller.ts`
+ * (same field layout; keep changes in sync).
+ */
+
+import type { Tec1gUiState } from './ui-panel-state';
+import type { Tec1gSpeedMode, Tec1gUpdatePayload } from './types';
+
+/**
+ * Sidebar UI state → webview message body after `applyTec1gUpdate`.
+ */
+export function serializeTec1gUpdateFromUiState(state: Tec1gUiState, speakerHz?: number): Tec1gUpdatePayload {
+  const payload: Tec1gUpdatePayload = {
+    digits: [...state.digits],
+    matrix: [...state.matrix],
+    matrixGreen: [...state.matrixGreen],
+    matrixBlue: [...state.matrixBlue],
+    matrixBrightness: [...state.matrixBrightness],
+    matrixBrightnessG: [...state.matrixBrightnessG],
+    matrixBrightnessB: [...state.matrixBrightnessB],
+    matrixMode: state.matrixMode,
+    glcd: [...state.glcd],
+    glcdDdram: [...state.glcdDdram],
+    glcdState: { ...state.glcdState },
+    sysCtrl: state.sysCtrlValue,
+    bankA14: state.bankA14,
+    capsLock: state.capsLock,
+    lcdState: { ...state.lcdState },
+    lcdCgram: [...state.lcdCgram],
+    speaker: state.speaker ? 1 : 0,
+    speedMode: state.speedMode,
+    lcd: [...state.lcd],
+  };
+  if (speakerHz !== undefined) {
+    payload.speakerHz = speakerHz;
+  }
+  return payload;
+}
+
+/**
+ * Partial update when clearing serial / resetting speaker (matches legacy sidebar clear payload).
+ */
+export function serializeTec1gClearPanelUpdateFromUiState(state: Tec1gUiState): Tec1gUpdatePayload {
+  return {
+    digits: [...state.digits],
+    matrix: [...state.matrix],
+    matrixGreen: [...state.matrixGreen],
+    matrixBlue: [...state.matrixBlue],
+    matrixBrightness: [...state.matrixBrightness],
+    matrixBrightnessG: [...state.matrixBrightnessG],
+    matrixBrightnessB: [...state.matrixBrightnessB],
+    glcd: [...state.glcd],
+    speaker: 0,
+    speedMode: state.speedMode,
+    lcd: [...state.lcd],
+  };
+}
+
+/** Type guard for TEC-1G speed mode literals in unknown event data. */
+function isTec1gSpeedMode(value: unknown): value is Tec1gSpeedMode {
+  return value === 'slow' || value === 'fast';
+}
+
+/** True when `value` is an array of numbers (for DAP event body parsing). */
+function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'number');
+}
+
+/**
+ * Normalizes a `debug80/tec1gUpdate` custom event body to a UI payload, or `undefined` if invalid.
+ */
+export function tec1gUpdatePayloadFromDebugEventBody(body: unknown): Tec1gUpdatePayload | undefined {
+  if (body === null || typeof body !== 'object') {
+    return undefined;
+  }
+  const payload = body as Record<string, unknown>;
+  const digits = payload.digits;
+  const matrix = payload.matrix;
+  const lcd = payload.lcd;
+  const glcd = payload.glcd;
+  if (!isNumberArray(digits) || !isNumberArray(matrix) || !isNumberArray(lcd) || !isNumberArray(glcd)) {
+    return undefined;
+  }
+  const speakerRaw = payload.speaker;
+  const speaker = typeof speakerRaw === 'number' ? speakerRaw : 0;
+  const speedMode = isTec1gSpeedMode(payload.speedMode) ? payload.speedMode : 'slow';
+  const update: Tec1gUpdatePayload = {
+    digits,
+    matrix,
+    glcd,
+    speaker,
+    speedMode,
+    lcd,
+  };
+  const matrixGreen = payload.matrixGreen;
+  if (isNumberArray(matrixGreen)) {
+    update.matrixGreen = matrixGreen;
+  }
+  const matrixBlue = payload.matrixBlue;
+  if (isNumberArray(matrixBlue)) {
+    update.matrixBlue = matrixBlue;
+  }
+  const matrixBrightness = payload.matrixBrightness;
+  if (isNumberArray(matrixBrightness)) {
+    update.matrixBrightness = matrixBrightness;
+  }
+  const matrixBrightnessG = payload.matrixBrightnessG;
+  if (isNumberArray(matrixBrightnessG)) {
+    update.matrixBrightnessG = matrixBrightnessG;
+  }
+  const matrixBrightnessB = payload.matrixBrightnessB;
+  if (isNumberArray(matrixBrightnessB)) {
+    update.matrixBrightnessB = matrixBrightnessB;
+  }
+  if (typeof payload.matrixMode === 'boolean') {
+    update.matrixMode = payload.matrixMode;
+  }
+  const glcdDdram = payload.glcdDdram;
+  if (isNumberArray(glcdDdram)) {
+    update.glcdDdram = glcdDdram;
+  }
+  if (payload.glcdState !== null && typeof payload.glcdState === 'object') {
+    update.glcdState = payload.glcdState as NonNullable<Tec1gUpdatePayload['glcdState']>;
+  }
+  if (typeof payload.sysCtrl === 'number') {
+    update.sysCtrl = payload.sysCtrl;
+  }
+  if (typeof payload.bankA14 === 'boolean') {
+    update.bankA14 = payload.bankA14;
+  }
+  if (typeof payload.capsLock === 'boolean') {
+    update.capsLock = payload.capsLock;
+  }
+  if (payload.lcdState !== null && typeof payload.lcdState === 'object') {
+    update.lcdState = payload.lcdState as NonNullable<Tec1gUpdatePayload['lcdState']>;
+  }
+  const lcdCgram = payload.lcdCgram;
+  if (isNumberArray(lcdCgram)) {
+    update.lcdCgram = lcdCgram;
+  }
+  const hz = payload.speakerHz;
+  if (typeof hz === 'number') {
+    update.speakerHz = hz;
+  }
+  return update;
+}

--- a/src/platforms/tec1g/update-controller.ts
+++ b/src/platforms/tec1g/update-controller.ts
@@ -30,7 +30,7 @@ interface Tec1gUpdateControllerDeps {
  * @param state - Current TEC-1G runtime state.
  * @returns Snapshot payload for the UI.
  */
-function buildUpdatePayload(state: Tec1gState): Tec1gUpdatePayload {
+export function serializeTec1gUpdateFromRuntimeState(state: Tec1gState): Tec1gUpdatePayload {
   const { display, input, audio, lcdCtrl, timing, system } = state;
   return {
     digits: [...display.digits],
@@ -91,7 +91,7 @@ export function createTec1gUpdateController(
   const { timing } = state;
 
   const sendUpdate = (): void => {
-    onUpdate(buildUpdatePayload(state));
+    onUpdate(serializeTec1gUpdateFromRuntimeState(state));
   };
 
   const queueUpdate = (): void => {

--- a/tests/platforms/serialize-update-payload.test.ts
+++ b/tests/platforms/serialize-update-payload.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @file Tests for centralized TEC-1 / TEC-1G update payload serialization.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  serializeTec1ClearFromUiState,
+  serializeTec1UpdateFromRuntimeState,
+  serializeTec1UpdateFromUiState,
+  tec1UpdatePayloadFromDebugEventBody,
+} from '../../src/platforms/tec1/serialize-update-payload';
+import { createTec1Runtime, normalizeTec1Config } from '../../src/platforms/tec1/runtime';
+import { createTec1UiState } from '../../src/platforms/tec1/ui-panel-state';
+import { serializeTec1gUpdateFromRuntimeState } from '../../src/platforms/tec1g/update-controller';
+import {
+  serializeTec1gClearPanelUpdateFromUiState,
+  serializeTec1gUpdateFromUiState,
+  tec1gUpdatePayloadFromDebugEventBody,
+} from '../../src/platforms/tec1g/serialize-ui-update-payload';
+import { createTec1gUiState } from '../../src/platforms/tec1g/ui-panel-state';
+
+describe('TEC-1 update payload serialization', () => {
+  it('matches runtime snapshot shape', () => {
+    const rt = createTec1Runtime(normalizeTec1Config({}), () => undefined);
+    rt.state.digits[0] = 3;
+    rt.state.matrix[1] = 5;
+    rt.state.speaker = true;
+    rt.state.speakerHz = 123;
+    const fromRt = serializeTec1UpdateFromRuntimeState(rt.state);
+    expect(fromRt.speaker).toBe(1);
+    expect(fromRt.speakerHz).toBe(123);
+  });
+
+  it('maps UI state to payload with optional speaker Hz', () => {
+    const ui = createTec1UiState();
+    ui.speaker = true;
+    const a = serializeTec1UpdateFromUiState(ui);
+    expect(a.speakerHz).toBeUndefined();
+    const b = serializeTec1UpdateFromUiState(ui, 999);
+    expect(b.speakerHz).toBe(999);
+  });
+
+  it('parses debug event bodies', () => {
+    expect(tec1UpdatePayloadFromDebugEventBody(null)).toBeUndefined();
+    expect(
+      tec1UpdatePayloadFromDebugEventBody({
+        digits: [1],
+        matrix: [2],
+        lcd: [3],
+        speaker: 1,
+        speedMode: 'fast',
+        speakerHz: 440,
+      })
+    ).toMatchObject({
+      speaker: 1,
+      speedMode: 'fast',
+      speakerHz: 440,
+    });
+  });
+
+  it('clear panel snapshot forces speaker off', () => {
+    const ui = createTec1UiState();
+    ui.speaker = true;
+    const cleared = serializeTec1ClearFromUiState(ui);
+    expect(cleared.speaker).toBe(0);
+  });
+});
+
+describe('TEC-1G update payload serialization', () => {
+  it('keeps runtime and UI serializers aligned on required keys', () => {
+    const ui = createTec1gUiState();
+    ui.matrixMode = true;
+    ui.sysCtrlValue = 0x42;
+    const fromUi = serializeTec1gUpdateFromUiState(ui, 1000);
+    expect(fromUi.matrixMode).toBe(true);
+    expect(fromUi.sysCtrl).toBe(0x42);
+    expect(fromUi.speakerHz).toBe(1000);
+
+    const cleared = serializeTec1gClearPanelUpdateFromUiState(ui);
+    expect(cleared.speaker).toBe(0);
+    expect(cleared.matrixGreen).toBeDefined();
+  });
+
+  it('parses debug80/tec1gUpdate bodies', () => {
+    const payload = tec1gUpdatePayloadFromDebugEventBody({
+      digits: [0, 0, 0, 0, 0, 0],
+      matrix: [1],
+      glcd: [2],
+      lcd: [3],
+      speaker: 0,
+      speedMode: 'slow',
+      matrixGreen: [9],
+      glcdDdram: [0x20],
+    });
+    expect(payload).toMatchObject({
+      matrixGreen: [9],
+      glcdDdram: [0x20],
+    });
+  });
+
+  it('exports runtime serializer used by update controller', () => {
+    expect(typeof serializeTec1gUpdateFromRuntimeState).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
Consolidates TEC-1 and TEC-1G UI update shaping so runtime, sidebar webview posts, platform UI manifest, and `debug80/*Update` custom events share one definition per concern.

## Changes
- **TEC-1**: `serialize-update-payload.ts` — runtime snapshot, UI → webview, clear/speaker-off partial, and `debug80/tec1Update` body parsing
- **TEC-1G**: export `serializeTec1gUpdateFromRuntimeState` from `update-controller.ts`; new `serialize-ui-update-payload.ts` for UI → webview, clear panel partial, and `debug80/tec1gUpdate` parsing (typed number-array guards)
- **Wiring**: `PlatformViewProvider`, `extension.ts` built-in platform UI entries, `debug-session-events.ts`

## Tests
- `tests/platforms/serialize-update-payload.test.ts`

Fixes #229

Made with [Cursor](https://cursor.com)