### PR TITLE
Extract serial send/save from PlatformViewProvider (#230)

### DIFF
--- a/docs/manual/part5/12-the-extension-host-ui.md
+++ b/docs/manual/part5/12-the-extension-host-ui.md
@@ -262,7 +262,7 @@ This payload is posted as a `projectStatus` message. The webview renders it as a
 
 ## Serial file send
 
-`handleSerialSendFile()` handles the `serialSendFile` webview message. It:
+`handlePlatformSerialSendFile()` in `platform-view-serial-actions.ts` handles the `serialSendFile` webview message (the provider delegates to it). It:
 
 1. Opens a file picker filtered to `.hex`, `.txt`, and all files.
 2. Reads the file as UTF-8 text.
@@ -271,6 +271,8 @@ This payload is posted as a `projectStatus` message. The webview renders it as a
 5. Shows a cancellable progress notification.
 
 The character-by-character sending mirrors the timing of a real terminal, giving the program time to process each byte. Intel HEX files sent this way are loaded by the MON-1B or MON-3 monitor's load routine.
+
+`handlePlatformSerialSave()` handles `serialSave`: it warns on an empty buffer, picks `.hex` vs `.txt` filters when the buffer looks like Intel HEX, then writes UTF-8 bytes via `vscode.workspace.fs.writeFile`.
 
 ---
 

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -48,6 +48,10 @@ import { listProjectTargetChoices } from './project-target-selection';
 import { resolveProjectStatusSummary } from './project-status';
 import { findProjectConfigPath } from './project-config';
 import { handlePlatformViewMessage } from './platform-view-messages';
+import {
+  handlePlatformSerialSave,
+  handlePlatformSerialSendFile,
+} from './platform-view-serial-actions';
 import type {
   PlatformId,
   PlatformViewInboundMessage,
@@ -306,10 +310,13 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
           await vscode.commands.executeCommand('debug80.startDebug', args);
         },
         handleSerialSendFile: async () => {
-          await this.handleSerialSendFile();
+          await handlePlatformSerialSendFile({
+            getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
+            getPlatform: () => this.currentPlatform,
+          });
         },
         handleSerialSave: async (text) => {
-          await this.handleSerialSave(text);
+          await handlePlatformSerialSave(text);
         },
         clearSerialBuffer: (platform) => {
           if (platform === 'tec1') {
@@ -608,112 +615,6 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       return true;
     }
     return this.currentSessionId === sessionId;
-  }
-
-  private async handleSerialSendFile(): Promise<void> {
-    const uris = await vscode.window.showOpenDialog({
-      canSelectMany: false,
-      filters: {
-        'Intel HEX': ['hex'],
-        'Text Files': ['txt'],
-        'All Files': ['*'],
-      },
-      title: 'Select file to send',
-    });
-    if (!uris || uris.length === 0) {
-      return;
-    }
-    const fileUri = uris[0]!;
-    const fileName = fileUri.path.split('/').pop() ?? 'file';
-    const fileBytes = await vscode.workspace.fs.readFile(fileUri);
-    const fileText = new TextDecoder('utf-8').decode(fileBytes);
-
-    const session = this.currentSession ?? vscode.debug.activeDebugSession;
-    if (!session || session.type !== 'z80') {
-      void vscode.window.showErrorMessage('Debug80: No active debug session.');
-      return;
-    }
-
-    const command =
-      this.currentPlatform === 'tec1g' ? 'debug80/tec1gSerialInput' : 'debug80/tec1SerialInput';
-
-    // Stream characters with a small delay between each for reliable reception
-    const charDelayMs = 2;
-    const lineDelayMs = 10;
-
-    void vscode.window.withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-        title: `Sending ${fileName}...`,
-        cancellable: true,
-      },
-      async (progress, token) => {
-        const lines = fileText.split(/\r?\n/);
-        let charsSent = 0;
-        const totalChars = fileText.length;
-
-        for (const line of lines) {
-          if (token.isCancellationRequested) {
-            void vscode.window.showWarningMessage('Debug80: File send cancelled.');
-            return;
-          }
-          for (const char of line) {
-            if (token.isCancellationRequested) {
-              return;
-            }
-            try {
-              await session.customRequest(command, { text: char });
-            } catch {
-              void vscode.window.showErrorMessage('Debug80: Failed to send character.');
-              return;
-            }
-            charsSent += 1;
-            if (charDelayMs > 0) {
-              await new Promise((r) => setTimeout(r, charDelayMs));
-            }
-          }
-          // Send CR at end of line
-          try {
-            await session.customRequest(command, { text: '\r' });
-          } catch {
-            /* ignore */
-          }
-          charsSent += 1;
-          progress.report({ increment: (100 * (line.length + 1)) / totalChars });
-          if (lineDelayMs > 0) {
-            await new Promise((r) => setTimeout(r, lineDelayMs));
-          }
-        }
-        void vscode.window.showInformationMessage(`Debug80: Sent ${charsSent} characters.`);
-      }
-    );
-  }
-
-  private async handleSerialSave(text: string): Promise<void> {
-    if (!text || text.length === 0) {
-      void vscode.window.showWarningMessage('Debug80: Serial buffer is empty.');
-      return;
-    }
-
-    // Detect if content is Intel HEX format
-    const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
-    const isHex = lines.length > 0 && lines.every((l) => l.startsWith(':') || l.trim() === '');
-
-    const filters: Record<string, string[]> = isHex
-      ? { 'Intel HEX': ['hex'], 'Text Files': ['txt'] }
-      : { 'Text Files': ['txt'], 'All Files': ['*'] };
-
-    const uri = await vscode.window.showSaveDialog({
-      filters,
-      title: 'Save serial output',
-    });
-    if (!uri) {
-      return;
-    }
-
-    const encoder = new TextEncoder();
-    await vscode.workspace.fs.writeFile(uri, encoder.encode(text));
-    void vscode.window.showInformationMessage(`Debug80: Saved to ${uri.path.split('/').pop()}`);
   }
 
   private nextUiRevision(): number {

--- a/src/extension/platform-view-serial-actions.ts
+++ b/src/extension/platform-view-serial-actions.ts
@@ -13,6 +13,8 @@ export interface PlatformSerialActionsContext {
 
 /**
  * Sends a file to the active serial input one character at a time.
+ * Awaits `vscode.window.withProgress` until the transfer completes (the webview message handler
+ * stays in flight for the duration), which differs from a fire-and-forget `void withProgress(...)`.
  */
 export async function handlePlatformSerialSendFile(
   ctx: PlatformSerialActionsContext

--- a/tests/extension/platform-view-serial-actions.test.ts
+++ b/tests/extension/platform-view-serial-actions.test.ts
@@ -114,4 +114,52 @@ describe('platform-view serial actions', () => {
     expect(mocks.showWarningMessage).toHaveBeenCalledWith('Debug80: Serial buffer is empty.');
     expect(mocks.showSaveDialog).not.toHaveBeenCalled();
   });
+
+  it('uses TEC-1G serial input when platform is tec1g', async () => {
+    const fileUri = { path: '/tmp/x.txt' };
+    mocks.showOpenDialog.mockResolvedValueOnce([fileUri]);
+    mocks.readFile.mockResolvedValueOnce(new TextEncoder().encode('Z'));
+    mocks.withProgress.mockImplementationOnce(async (_opts, callback) => {
+      await callback({ report: vi.fn() }, { isCancellationRequested: false });
+    });
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: TimerHandler) => {
+      if (typeof callback === 'function') {
+        callback();
+      }
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+
+    await handlePlatformSerialSendFile({
+      getSession: () => mocks.activeDebugSession,
+      getPlatform: () => 'tec1g',
+    });
+
+    expect(mocks.customRequest).toHaveBeenCalledWith('debug80/tec1gSerialInput', { text: 'Z' });
+    expect(mocks.customRequest).toHaveBeenCalledWith('debug80/tec1gSerialInput', { text: '\r' });
+  });
+
+  it('shows an error when there is no z80 session for send file', async () => {
+    mocks.showOpenDialog.mockResolvedValueOnce([{ path: '/tmp/a.txt' }]);
+    mocks.readFile.mockResolvedValueOnce(new TextEncoder().encode('x'));
+
+    await handlePlatformSerialSendFile({
+      getSession: () => undefined,
+      getPlatform: () => 'tec1',
+    });
+
+    expect(mocks.showErrorMessage).toHaveBeenCalledWith('Debug80: No active debug session.');
+    expect(mocks.customRequest).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the open dialog is cancelled', async () => {
+    mocks.showOpenDialog.mockResolvedValueOnce(undefined);
+
+    await handlePlatformSerialSendFile({
+      getSession: () => mocks.activeDebugSession,
+      getPlatform: () => 'tec1',
+    });
+
+    expect(mocks.readFile).not.toHaveBeenCalled();
+    expect(mocks.customRequest).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
Completes [#230](https://github.com/jhlagado/debug80/issues/230): `platform-view-serial-actions.ts` already held the workflows; `PlatformViewProvider` still duplicated them. The provider now delegates so view lifecycle stays separate from file-transfer UX.

## Changes
- **`platform-view-provider.ts`**: wire `serialSendFile` / `serialSave` message handlers to `handlePlatformSerialSendFile` / `handlePlatformSerialSave` with `currentSession ?? activeDebugSession` and `currentPlatform`.
- **Tests**: TEC-1G custom request, no z80 session error path, cancelled open dialog.
- **Docs**: `12-the-extension-host-ui.md` names the shared handlers and briefly documents save.

Fixes #230

Made with [Cursor](https://cursor.com)