### PR TITLE
Decompose TEC-1G runtime into focused modules (#227)

### DIFF
--- a/src/platforms/tec1g/runtime-config.ts
+++ b/src/platforms/tec1g/runtime-config.ts
@@ -1,0 +1,83 @@
+/**
+ * @file TEC-1G runtime configuration normalization.
+ */
+
+import type { Tec1gPlatformConfig, Tec1gPlatformConfigNormalized } from '../types';
+import { normalizeSimpleRegions } from '../simple/runtime';
+import {
+  TEC1G_ADDR_MAX,
+  TEC1G_APP_START_DEFAULT,
+  TEC1G_ENTRY_DEFAULT,
+  TEC1G_RAM_END,
+  TEC1G_RAM_START,
+  TEC1G_ROM0_END,
+  TEC1G_ROM0_START,
+  TEC1G_ROM1_END,
+  TEC1G_ROM1_START,
+} from './constants';
+
+/**
+ * Normalizes TEC-1G configuration with defaults and bounds.
+ */
+export function normalizeTec1gConfig(cfg?: Tec1gPlatformConfig): Tec1gPlatformConfigNormalized {
+  const config: Tec1gPlatformConfig = cfg ?? {};
+  const regions = normalizeSimpleRegions(config.regions, [
+    { start: TEC1G_ROM0_START, end: TEC1G_ROM0_END, kind: 'rom' },
+    { start: TEC1G_RAM_START, end: TEC1G_RAM_END, kind: 'ram' },
+    { start: TEC1G_ROM1_START, end: TEC1G_ROM1_END, kind: 'rom' },
+  ]);
+  const romRanges = regions
+    .filter((region) => region.kind === 'rom' || region.readOnly === true)
+    .map((region) => ({ start: region.start, end: region.end }));
+  const appStart =
+    Number.isFinite(config.appStart) && config.appStart !== undefined
+      ? config.appStart
+      : TEC1G_APP_START_DEFAULT;
+  const entry =
+    Number.isFinite(config.entry) && config.entry !== undefined ? config.entry : TEC1G_ENTRY_DEFAULT;
+  const romHex = typeof config.romHex === 'string' && config.romHex !== '' ? config.romHex : undefined;
+  const ramInitHex =
+    typeof config.ramInitHex === 'string' && config.ramInitHex !== '' ? config.ramInitHex : undefined;
+  const cartridgeHex =
+    typeof config.cartridgeHex === 'string' && config.cartridgeHex !== ''
+      ? config.cartridgeHex
+      : undefined;
+  const updateMs =
+    Number.isFinite(config.updateMs) && config.updateMs !== undefined ? config.updateMs : 16;
+  const yieldMs = Number.isFinite(config.yieldMs) && config.yieldMs !== undefined ? config.yieldMs : 0;
+  const extraListings = Array.isArray(config.extraListings)
+    ? config.extraListings
+        .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+        .filter((entry) => entry !== '')
+    : undefined;
+  const gimpSignal = config.gimpSignal === true;
+  const expansionBankHi = config.expansionBankHi === true;
+  const matrixMode = config.matrixMode === true;
+  const protectOnReset = config.protectOnReset === true;
+  const rtcEnabled = config.rtcEnabled === true;
+  const sdEnabled = config.sdEnabled === true;
+  const sdHighCapacity = config.sdHighCapacity !== false;
+  const sdImagePath =
+    typeof config.sdImagePath === 'string' && config.sdImagePath !== '' ? config.sdImagePath : undefined;
+  return {
+    regions,
+    romRanges,
+    appStart: Math.max(0, Math.min(TEC1G_ADDR_MAX, appStart)),
+    entry: Math.max(0, Math.min(TEC1G_ADDR_MAX, entry)),
+    ...(romHex !== undefined ? { romHex } : {}),
+    ...(ramInitHex !== undefined ? { ramInitHex } : {}),
+    updateMs: Math.max(0, updateMs),
+    yieldMs: Math.max(0, yieldMs),
+    gimpSignal,
+    expansionBankHi,
+    matrixMode,
+    protectOnReset,
+    rtcEnabled,
+    sdEnabled,
+    sdHighCapacity,
+    ...(sdImagePath !== undefined ? { sdImagePath } : {}),
+    ...(cartridgeHex !== undefined ? { cartridgeHex } : {}),
+    ...(extraListings ? { extraListings } : {}),
+    ...(cfg?.uiVisibility ? { uiVisibility: cfg.uiVisibility } : {}),
+  };
+}

--- a/src/platforms/tec1g/runtime-lifecycle.ts
+++ b/src/platforms/tec1g/runtime-lifecycle.ts
@@ -1,0 +1,82 @@
+/**
+ * @file TEC-1G runtime lifecycle helpers (speaker silence and reset orchestration).
+ */
+
+import { decodeSysCtrl } from './sysctrl';
+import { TEC1G_MASK_BYTE } from './constants';
+import type { Tec1gState } from './runtime-state';
+
+type ResetControllers = {
+  lcd: { reset: () => void };
+  glcd: { reset: () => void };
+  serial: { reset: () => void };
+};
+
+/**
+ * Clears speaker state and cancels pending silence timer.
+ */
+export function silenceTec1gSpeaker(state: Tec1gState, queueUpdate: () => void): void {
+  const { audio, timing } = state;
+  if (audio.speakerHz === 0 && !audio.speaker) {
+    return;
+  }
+  audio.speakerHz = 0;
+  audio.speaker = false;
+  audio.lastEdgeCycle = null;
+  if (audio.silenceEventId !== null) {
+    timing.cycleClock.cancel(audio.silenceEventId);
+    audio.silenceEventId = null;
+  }
+  queueUpdate();
+}
+
+/**
+ * Resets display/input/system state while preserving configured defaults.
+ */
+export function resetTec1gRuntimeState(
+  state: Tec1gState,
+  defaults: { matrixMode: boolean; sysCtrl: number; gimpSignal: boolean; cartridgePresent: boolean },
+  controllers: ResetControllers,
+  queueUpdate: () => void
+): void {
+  const { display, input, audio, timing, system } = state;
+  audio.speaker = false;
+  audio.speakerHz = 0;
+  audio.lastEdgeCycle = null;
+  controllers.lcd.reset();
+  display.ledMatrixRedRows.fill(0);
+  display.ledMatrixGreenRows.fill(0);
+  display.ledMatrixBlueRows.fill(0);
+  display.ledMatrixBrightnessR.fill(0);
+  display.ledMatrixBrightnessG.fill(0);
+  display.ledMatrixBrightnessB.fill(0);
+  display.matrixStagingR.fill(0);
+  display.matrixStagingG.fill(0);
+  display.matrixStagingB.fill(0);
+  display.matrixRowsVisitedMask = 0;
+  display.matrixLastActivityCycle = -1;
+  display.ledMatrixRowLatch = 0;
+  display.ledMatrixRedLatch = 0;
+  display.ledMatrixGreenLatch = 0;
+  display.ledMatrixBlueLatch = 0;
+  input.matrixKeyStates.fill(TEC1G_MASK_BYTE);
+  input.matrixModeEnabled = defaults.matrixMode;
+  controllers.glcd.reset();
+  system.sysCtrl = defaults.sysCtrl;
+  const decoded = decodeSysCtrl(system.sysCtrl);
+  system.shadowEnabled = decoded.shadowEnabled;
+  system.protectEnabled = decoded.protectEnabled;
+  system.expandEnabled = decoded.expandEnabled;
+  system.bankA14 = decoded.bankA14;
+  system.capsLock = decoded.capsLock;
+  input.shiftKeyActive = false;
+  input.rawKeyActive = false;
+  system.gimpSignal = defaults.gimpSignal;
+  system.cartridgePresent = defaults.cartridgePresent;
+  if (audio.silenceEventId !== null) {
+    timing.cycleClock.cancel(audio.silenceEventId);
+    audio.silenceEventId = null;
+  }
+  controllers.serial.reset();
+  queueUpdate();
+}

--- a/src/platforms/tec1g/runtime-matrix.ts
+++ b/src/platforms/tec1g/runtime-matrix.ts
@@ -1,0 +1,98 @@
+/**
+ * @file TEC-1G LED matrix staging and commit behavior.
+ */
+
+import { millisecondsToClocks } from '../tec-common';
+import { TEC1G_MASK_BYTE } from './constants';
+import type { Tec1gState } from './runtime-state';
+
+/** If no matrix port OUT for this long, commit partial staging (~25 fps). */
+const TEC1G_MATRIX_IDLE_FLUSH_MS = 40;
+
+/**
+ * Matrix display: accumulate row RGB into staging; commit when all rows visited.
+ */
+export function handleMatrixPortWrite(
+  display: Tec1gState['display'],
+  timing: Tec1gState['timing'],
+  kind: 'row' | 'rgb',
+  queueUpdate: () => void
+): void {
+  accumulateMatrixStagingFromRows(display);
+  display.matrixLastActivityCycle = timing.cycleClock.now();
+  if (kind !== 'row') {
+    return;
+  }
+  const rowSel = display.ledMatrixRowLatch & TEC1G_MASK_BYTE;
+  if (rowSel !== 0) {
+    display.matrixRowsVisitedMask |= rowSel;
+  }
+  if (display.matrixRowsVisitedMask === TEC1G_MASK_BYTE) {
+    commitMatrixStaging(display);
+    display.matrixRowsVisitedMask = 0;
+    display.matrixLastActivityCycle = -1;
+    queueUpdate();
+  }
+}
+
+/**
+ * Commits matrix staging on activity timeout to avoid partial-frame stalling.
+ */
+export function maybeCommitMatrixOnIdle(
+  display: Tec1gState['display'],
+  timing: Tec1gState['timing'],
+  queueUpdate: () => void
+): void {
+  if (display.matrixLastActivityCycle < 0) {
+    return;
+  }
+  const idleCycles = millisecondsToClocks(timing.clockHz, TEC1G_MATRIX_IDLE_FLUSH_MS);
+  if (idleCycles <= 0) {
+    return;
+  }
+  if (timing.cycleClock.now() - display.matrixLastActivityCycle < idleCycles) {
+    return;
+  }
+  commitMatrixStaging(display);
+  display.matrixRowsVisitedMask = 0;
+  display.matrixLastActivityCycle = -1;
+  queueUpdate();
+}
+
+/**
+ *
+ */
+function accumulateMatrixStagingFromRows(display: Tec1gState['display']): void {
+  const rowMask = display.ledMatrixRowLatch & TEC1G_MASK_BYTE;
+  const { ledMatrixRedRows, ledMatrixGreenRows, ledMatrixBlueRows } = display;
+  for (let row = 0; row < 8; row += 1) {
+    if ((rowMask & (1 << row)) === 0) {
+      continue;
+    }
+    const base = row * 8;
+    const rPlane = ledMatrixRedRows[row] ?? 0;
+    const gPlane = ledMatrixGreenRows[row] ?? 0;
+    const bPlane = ledMatrixBlueRows[row] ?? 0;
+    for (let col = 0; col < 8; col += 1) {
+      const bit = 1 << col;
+      const idx = base + col;
+      display.matrixStagingR[idx] = (rPlane & bit) !== 0 ? 255 : 0;
+      display.matrixStagingG[idx] = (gPlane & bit) !== 0 ? 255 : 0;
+      display.matrixStagingB[idx] = (bPlane & bit) !== 0 ? 255 : 0;
+    }
+  }
+}
+
+/**
+ *
+ */
+function commitMatrixStaging(display: Tec1gState['display']): void {
+  for (let i = 0; i < 64; i += 1) {
+    display.ledMatrixBrightnessR[i] = display.matrixStagingR[i] ?? 0;
+    display.ledMatrixBrightnessG[i] = display.matrixStagingG[i] ?? 0;
+    display.ledMatrixBrightnessB[i] = display.matrixStagingB[i] ?? 0;
+  }
+  display.matrixStagingR.fill(0);
+  display.matrixStagingG.fill(0);
+  display.matrixStagingB.fill(0);
+}

--- a/src/platforms/tec1g/runtime-state.ts
+++ b/src/platforms/tec1g/runtime-state.ts
@@ -1,0 +1,195 @@
+/**
+ * @file TEC-1G runtime state definitions and initialization helpers.
+ */
+
+import { CycleClock } from '../cycle-clock';
+import type { Tec1gPlatformConfigNormalized } from '../types';
+import { TEC_FAST_HZ } from '../tec-common';
+import {
+  TEC1G_LCD_ARROW_LEFT,
+  TEC1G_LCD_ARROW_RIGHT,
+  TEC1G_LCD_ROW0_START,
+  TEC1G_LCD_SPACE,
+  TEC1G_MASK_BYTE,
+  TEC1G_MASK_LOW7,
+} from './constants';
+import { createGlcdState, type GlcdState } from './glcd';
+import type { Tec1gLcdState } from './lcd';
+import type { Tec1gSpeedMode } from './types';
+
+/**
+ * Mutable runtime state for TEC-1G hardware emulation.
+ */
+export interface Tec1gState {
+  display: {
+    digits: number[];
+    ledMatrixRedRows: number[];
+    ledMatrixGreenRows: number[];
+    ledMatrixBlueRows: number[];
+    ledMatrixBrightnessR: number[];
+    ledMatrixBrightnessG: number[];
+    ledMatrixBrightnessB: number[];
+    matrixStagingR: number[];
+    matrixStagingG: number[];
+    matrixStagingB: number[];
+    matrixRowsVisitedMask: number;
+    matrixLastActivityCycle: number;
+    digitLatch: number;
+    segmentLatch: number;
+    ledMatrixRowLatch: number;
+    ledMatrixRedLatch: number;
+    ledMatrixGreenLatch: number;
+    ledMatrixBlueLatch: number;
+    glcdCtrl: GlcdState;
+  };
+  input: {
+    matrixKeyStates: Uint8Array;
+    matrixModeEnabled: boolean;
+    keyValue: number;
+    keyReleaseEventId: number | null;
+    nmiPending: boolean;
+    shiftKeyActive: boolean;
+    rawKeyActive: boolean;
+  };
+  audio: {
+    speaker: boolean;
+    speakerHz: number;
+    lastEdgeCycle: number | null;
+    silenceEventId: number | null;
+  };
+  lcdCtrl: Tec1gLcdState;
+  timing: {
+    cycleClock: CycleClock;
+    lastUpdateMs: number;
+    pendingUpdate: boolean;
+    clockHz: number;
+    speedMode: Tec1gSpeedMode;
+    updateMs: number;
+    yieldMs: number;
+  };
+  system: {
+    sysCtrl: number;
+    shadowEnabled: boolean;
+    protectEnabled: boolean;
+    expandEnabled: boolean;
+    bankA14: boolean;
+    capsLock: boolean;
+    cartridgePresent: boolean;
+    gimpSignal: boolean;
+  };
+}
+
+/**
+ * Creates the initial mutable TEC-1G runtime state object.
+ */
+export function createTec1gInitialState(params: {
+  config: Tec1gPlatformConfigNormalized;
+  matrixMode: boolean;
+  initialSysCtrl: number;
+  initialSysCtrlDecoded: {
+    shadowEnabled: boolean;
+    protectEnabled: boolean;
+    expandEnabled: boolean;
+    bankA14: boolean;
+    capsLock: boolean;
+  };
+  cartridgePresentDefault: boolean;
+}): Tec1gState {
+  const { config, matrixMode, initialSysCtrl, initialSysCtrlDecoded, cartridgePresentDefault } = params;
+  const state: Tec1gState = {
+    display: {
+      digits: Array.from({ length: 6 }, () => 0),
+      ledMatrixRedRows: Array.from({ length: 8 }, () => 0),
+      ledMatrixGreenRows: Array.from({ length: 8 }, () => 0),
+      ledMatrixBlueRows: Array.from({ length: 8 }, () => 0),
+      ledMatrixBrightnessR: Array.from({ length: 64 }, () => 0),
+      ledMatrixBrightnessG: Array.from({ length: 64 }, () => 0),
+      ledMatrixBrightnessB: Array.from({ length: 64 }, () => 0),
+      matrixStagingR: Array.from({ length: 64 }, () => 0),
+      matrixStagingG: Array.from({ length: 64 }, () => 0),
+      matrixStagingB: Array.from({ length: 64 }, () => 0),
+      matrixRowsVisitedMask: 0,
+      matrixLastActivityCycle: -1,
+      digitLatch: 0,
+      segmentLatch: 0,
+      ledMatrixRowLatch: 0,
+      ledMatrixRedLatch: 0,
+      ledMatrixGreenLatch: 0,
+      ledMatrixBlueLatch: 0,
+      glcdCtrl: createGlcdState(),
+    },
+    input: {
+      matrixKeyStates: new Uint8Array(16).fill(TEC1G_MASK_BYTE),
+      matrixModeEnabled: matrixMode,
+      keyValue: TEC1G_MASK_LOW7,
+      keyReleaseEventId: null,
+      nmiPending: false,
+      shiftKeyActive: false,
+      rawKeyActive: false,
+    },
+    audio: {
+      speaker: false,
+      speakerHz: 0,
+      lastEdgeCycle: null,
+      silenceEventId: null,
+    },
+    lcdCtrl: {
+      lcd: Array.from({ length: 80 }, () => TEC1G_LCD_SPACE),
+      lcdAddr: TEC1G_LCD_ROW0_START,
+      lcdAddrMode: 'ddram',
+      lcdEntryIncrement: true,
+      lcdEntryShift: false,
+      lcdDisplayOn: true,
+      lcdCursorOn: false,
+      lcdCursorBlink: false,
+      lcdDisplayShift: 0,
+      lcdCgram: new Uint8Array(64),
+      lcdCgramAddr: 0,
+      lcdFunction: {
+        dataLength8: true,
+        lines2: true,
+        font5x8: true,
+      },
+    },
+    timing: {
+      cycleClock: new CycleClock(),
+      lastUpdateMs: 0,
+      pendingUpdate: false,
+      clockHz: TEC_FAST_HZ,
+      speedMode: 'fast',
+      updateMs: config.updateMs,
+      yieldMs: config.yieldMs,
+    },
+    system: {
+      sysCtrl: initialSysCtrl,
+      shadowEnabled: initialSysCtrlDecoded.shadowEnabled,
+      protectEnabled: initialSysCtrlDecoded.protectEnabled,
+      expandEnabled: initialSysCtrlDecoded.expandEnabled,
+      bankA14: initialSysCtrlDecoded.bankA14,
+      capsLock: initialSysCtrlDecoded.capsLock,
+      cartridgePresent: cartridgePresentDefault,
+      gimpSignal: config.gimpSignal,
+    },
+  };
+  primeTec1gLcdTestLine(state.lcdCtrl);
+  return state;
+}
+
+/**
+ *
+ */
+function primeTec1gLcdTestLine(lcdState: Tec1gLcdState): void {
+  const lcdTest = 'ARROWS: ';
+  for (let i = 0; i < lcdTest.length && i < lcdState.lcd.length; i += 1) {
+    lcdState.lcd[i] = lcdTest.charCodeAt(i);
+  }
+  if (lcdState.lcd.length > lcdTest.length) {
+    lcdState.lcd[lcdTest.length] = TEC1G_LCD_ARROW_LEFT;
+  }
+  if (lcdState.lcd.length > lcdTest.length + 1) {
+    lcdState.lcd[lcdTest.length + 1] = TEC1G_LCD_SPACE;
+  }
+  if (lcdState.lcd.length > lcdTest.length + 2) {
+    lcdState.lcd[lcdTest.length + 2] = TEC1G_LCD_ARROW_RIGHT;
+  }
+}

--- a/src/platforms/tec1g/runtime-storage.ts
+++ b/src/platforms/tec1g/runtime-storage.ts
@@ -1,0 +1,48 @@
+/**
+ * @file TEC-1G SD card image load/persistence wiring.
+ */
+
+import * as fs from 'fs';
+import type { Tec1gPlatformConfigNormalized } from '../types';
+import { SdSpi } from './sd-spi';
+
+/**
+ * Builds SD SPI controller and optional image-backed persistence callbacks.
+ */
+export function createTec1gSdSpi(config: Tec1gPlatformConfigNormalized): {
+  sdEnabled: boolean;
+  sdSpi: SdSpi | null;
+} {
+  const sdEnabled = config.sdEnabled;
+  const sdImagePath = config.sdImagePath;
+  const sdHighCapacity = config.sdHighCapacity;
+
+  let sdImage: Uint8Array | undefined;
+  if (sdEnabled && typeof sdImagePath === 'string' && sdImagePath !== '') {
+    try {
+      sdImage = new Uint8Array(fs.readFileSync(sdImagePath));
+    } catch {
+      sdImage = undefined;
+    }
+  }
+
+  const sdSpi = sdEnabled
+    ? new SdSpi({
+        highCapacity: sdHighCapacity,
+        ...(sdImage ? { image: sdImage } : {}),
+        ...(sdImagePath !== undefined && sdImagePath !== '' && sdImage
+          ? {
+              onWrite: (image): void => {
+                try {
+                  fs.writeFileSync(sdImagePath, image);
+                } catch {
+                  // Ignore persistence failures; runtime continues with in-memory image.
+                }
+              },
+            }
+          : {}),
+      })
+    : null;
+
+  return { sdEnabled, sdSpi };
+}

--- a/src/platforms/tec1g/runtime.ts
+++ b/src/platforms/tec1g/runtime.ts
@@ -7,112 +7,35 @@
  */
 
 import { IoHandlers } from '../../z80/runtime';
-import { CycleClock } from '../cycle-clock';
-import { Tec1gPlatformConfig, Tec1gPlatformConfigNormalized } from '../types';
-import { normalizeSimpleRegions } from '../simple/runtime';
+import { Tec1gPlatformConfigNormalized } from '../types';
 import { Tec1gSpeedMode, Tec1gUpdatePayload } from './types';
 import { decodeSysCtrl } from './sysctrl';
 import { Ds1302 } from './ds1302';
-import { SdSpi } from './sd-spi';
-import { createTec1gLcdController, type Tec1gLcdState } from './lcd';
+import { createTec1gLcdController } from './lcd';
 import { createTec1gSerialController } from './serial';
-import { createGlcdController, createGlcdState, type GlcdState } from './glcd';
+import { createGlcdController } from './glcd';
 import { createTec1gUpdateController, type Tec1gUpdateController } from './update-controller';
 import {
   TEC1G_SYSCTRL_PROTECT,
   TEC1G_SYSCTRL_BANK_A14,
   TEC1G_KEY_SHIFT_MASK,
-  TEC1G_LCD_ARROW_LEFT,
-  TEC1G_LCD_ARROW_RIGHT,
-  TEC1G_ROM0_END,
-  TEC1G_ROM0_START,
-  TEC1G_ROM1_END,
-  TEC1G_ROM1_START,
-  TEC1G_RAM_END,
-  TEC1G_RAM_START,
-  TEC1G_APP_START_DEFAULT,
-  TEC1G_ENTRY_DEFAULT,
-  TEC1G_LCD_ROW0_START,
-  TEC1G_LCD_SPACE,
   TEC1G_MASK_BYTE,
   TEC1G_MASK_LOW7,
-  TEC1G_ADDR_MAX,
   TEC1G_NMI_VECTOR,
 } from './constants';
-import * as fs from 'fs';
 import {
   TEC_SLOW_HZ,
   TEC_FAST_HZ,
   TEC_KEY_HOLD_MS,
   calculateKeyHoldCycles,
-  millisecondsToClocks,
 } from '../tec-common';
 import { createTec1gIoHandlers } from './io-handlers';
-
-/**
- * Mutable runtime state for TEC-1G hardware emulation.
- */
-export interface Tec1gState {
-  display: {
-    digits: number[];
-    ledMatrixRedRows: number[];
-    ledMatrixGreenRows: number[];
-    ledMatrixBlueRows: number[];
-    ledMatrixBrightnessR: number[];
-    ledMatrixBrightnessG: number[];
-    ledMatrixBrightnessB: number[];
-    /** Staging buffer for multiplexed RGB; committed to brightness on 8 row writes or idle flush. */
-    matrixStagingR: number[];
-    matrixStagingG: number[];
-    matrixStagingB: number[];
-    /** Bits 0–7 set when each physical row has been selected at least once since last commit; 0xFF = full raster. */
-    matrixRowsVisitedMask: number;
-    /** Cycle-clock time of last matrix port OUT; -1 = no pending activity window. */
-    matrixLastActivityCycle: number;
-    digitLatch: number;
-    segmentLatch: number;
-    ledMatrixRowLatch: number;
-    ledMatrixRedLatch: number;
-    ledMatrixGreenLatch: number;
-    ledMatrixBlueLatch: number;
-    glcdCtrl: GlcdState;
-  };
-  input: {
-    matrixKeyStates: Uint8Array;
-    matrixModeEnabled: boolean;
-    keyValue: number;
-    keyReleaseEventId: number | null;
-    nmiPending: boolean;
-    shiftKeyActive: boolean;
-    rawKeyActive: boolean;
-  };
-  audio: {
-    speaker: boolean;
-    speakerHz: number;
-    lastEdgeCycle: number | null;
-    silenceEventId: number | null;
-  };
-  lcdCtrl: Tec1gLcdState;
-  timing: {
-    cycleClock: CycleClock;
-    lastUpdateMs: number;
-    pendingUpdate: boolean;
-    clockHz: number;
-    speedMode: Tec1gSpeedMode;
-    updateMs: number;
-    yieldMs: number;
-  };
-  system: {
-    sysCtrl: number;
-    shadowEnabled: boolean;
-    protectEnabled: boolean;
-    expandEnabled: boolean;
-    bankA14: boolean;
-    capsLock: boolean;
-    cartridgePresent: boolean;
-    gimpSignal: boolean;
-  };
-}
+import { handleMatrixPortWrite, maybeCommitMatrixOnIdle } from './runtime-matrix';
+import { createTec1gSdSpi } from './runtime-storage';
+import { createTec1gInitialState } from './runtime-state';
+import type { Tec1gState } from './runtime-state';
+import { resetTec1gRuntimeState, silenceTec1gSpeaker } from './runtime-lifecycle';
+export { normalizeTec1gConfig } from './runtime-config';
 
 /**
  * Runtime facade for TEC-1G IO handlers and lifecycle controls.
@@ -135,173 +58,7 @@ export interface Tec1gRuntime {
 export const TEC1G_SLOW_HZ = TEC_SLOW_HZ;
 export const TEC1G_FAST_HZ = TEC_FAST_HZ;
 const TEC1G_KEY_HOLD_MS = TEC_KEY_HOLD_MS;
-/** If no matrix port OUT for this long, commit partial staging (~25 fps). */
-const TEC1G_MATRIX_IDLE_FLUSH_MS = 40;
-
-/**
- * Copies the selected row's column pattern from row planes into staging (latched snapshot).
- */
-function accumulateMatrixStagingFromRows(display: Tec1gState['display']): void {
-  const rowMask = display.ledMatrixRowLatch & TEC1G_MASK_BYTE;
-  const { ledMatrixRedRows, ledMatrixGreenRows, ledMatrixBlueRows } = display;
-  for (let row = 0; row < 8; row += 1) {
-    if ((rowMask & (1 << row)) === 0) {
-      continue;
-    }
-    const base = row * 8;
-    const rPlane = ledMatrixRedRows[row] ?? 0;
-    const gPlane = ledMatrixGreenRows[row] ?? 0;
-    const bPlane = ledMatrixBlueRows[row] ?? 0;
-    for (let col = 0; col < 8; col += 1) {
-      const bit = 1 << col;
-      const idx = base + col;
-      display.matrixStagingR[idx] = (rPlane & bit) !== 0 ? 255 : 0;
-      display.matrixStagingG[idx] = (gPlane & bit) !== 0 ? 255 : 0;
-      display.matrixStagingB[idx] = (bPlane & bit) !== 0 ? 255 : 0;
-    }
-  }
-}
-
-/**
- * Commits staging buffers to visible brightness and clears staging.
- */
-function commitMatrixStaging(display: Tec1gState['display']): void {
-  for (let i = 0; i < 64; i += 1) {
-    display.ledMatrixBrightnessR[i] = display.matrixStagingR[i] ?? 0;
-    display.ledMatrixBrightnessG[i] = display.matrixStagingG[i] ?? 0;
-    display.ledMatrixBrightnessB[i] = display.matrixStagingB[i] ?? 0;
-  }
-  display.matrixStagingR.fill(0);
-  display.matrixStagingG.fill(0);
-  display.matrixStagingB.fill(0);
-}
-
-/**
- * Matrix display: accumulate row RGB into staging; commit when all 8 rows have been
- * selected at least once (visit mask 0xFF), or via idle (recordCycles).
- * Row port 0 = blanking — does not set visit bits.
- */
-function handleMatrixPortWrite(
-  display: Tec1gState['display'],
-  timing: Tec1gState['timing'],
-  kind: 'row' | 'rgb',
-  queueUpdate: () => void,
-): void {
-  accumulateMatrixStagingFromRows(display);
-  display.matrixLastActivityCycle = timing.cycleClock.now();
-  if (kind === 'row') {
-    const rowSel = display.ledMatrixRowLatch & TEC1G_MASK_BYTE;
-    if (rowSel !== 0) {
-      display.matrixRowsVisitedMask |= rowSel;
-    }
-    if (display.matrixRowsVisitedMask === TEC1G_MASK_BYTE) {
-      commitMatrixStaging(display);
-      display.matrixRowsVisitedMask = 0;
-      display.matrixLastActivityCycle = -1;
-      queueUpdate();
-    }
-  }
-}
-
-/**
- *
- */
-function maybeCommitMatrixOnIdle(
-  display: Tec1gState['display'],
-  timing: Tec1gState['timing'],
-  queueUpdate: () => void,
-): void {
-  if (display.matrixLastActivityCycle < 0) {
-    return;
-  }
-  const idleCycles = millisecondsToClocks(timing.clockHz, TEC1G_MATRIX_IDLE_FLUSH_MS);
-  if (idleCycles <= 0) {
-    return;
-  }
-  if (timing.cycleClock.now() - display.matrixLastActivityCycle < idleCycles) {
-    return;
-  }
-  commitMatrixStaging(display);
-  display.matrixRowsVisitedMask = 0;
-  display.matrixLastActivityCycle = -1;
-  queueUpdate();
-}
-
-/**
- * Normalizes TEC-1G configuration with defaults and bounds.
- * @param cfg - Optional TEC-1G config from project settings.
- * @returns Normalized config for runtime construction.
- */
-export function normalizeTec1gConfig(cfg?: Tec1gPlatformConfig): Tec1gPlatformConfigNormalized {
-  const config: Tec1gPlatformConfig = cfg ?? {};
-  const regions = normalizeSimpleRegions(config.regions, [
-    { start: TEC1G_ROM0_START, end: TEC1G_ROM0_END, kind: 'rom' },
-    { start: TEC1G_RAM_START, end: TEC1G_RAM_END, kind: 'ram' },
-    { start: TEC1G_ROM1_START, end: TEC1G_ROM1_END, kind: 'rom' },
-  ]);
-  const romRanges = regions
-    .filter((region) => region.kind === 'rom' || region.readOnly === true)
-    .map((region) => ({ start: region.start, end: region.end }));
-  const appStart =
-    Number.isFinite(config.appStart) && config.appStart !== undefined
-      ? config.appStart
-      : TEC1G_APP_START_DEFAULT;
-  const entry =
-    Number.isFinite(config.entry) && config.entry !== undefined
-      ? config.entry
-      : TEC1G_ENTRY_DEFAULT;
-  const romHex =
-    typeof config.romHex === 'string' && config.romHex !== '' ? config.romHex : undefined;
-  const ramInitHex =
-    typeof config.ramInitHex === 'string' && config.ramInitHex !== ''
-      ? config.ramInitHex
-      : undefined;
-  const cartridgeHex =
-    typeof config.cartridgeHex === 'string' && config.cartridgeHex !== ''
-      ? config.cartridgeHex
-      : undefined;
-  const updateMs =
-    Number.isFinite(config.updateMs) && config.updateMs !== undefined ? config.updateMs : 16;
-  const yieldMs =
-    Number.isFinite(config.yieldMs) && config.yieldMs !== undefined ? config.yieldMs : 0;
-  const extraListings = Array.isArray(config.extraListings)
-    ? config.extraListings
-        .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
-        .filter((entry) => entry !== '')
-    : undefined;
-  const gimpSignal = config.gimpSignal === true;
-  const expansionBankHi = config.expansionBankHi === true;
-  const matrixMode = config.matrixMode === true;
-  const protectOnReset = config.protectOnReset === true;
-  const rtcEnabled = config.rtcEnabled === true;
-  const sdEnabled = config.sdEnabled === true;
-  const sdHighCapacity = config.sdHighCapacity !== false;
-  const sdImagePath =
-    typeof config.sdImagePath === 'string' && config.sdImagePath !== ''
-      ? config.sdImagePath
-      : undefined;
-  return {
-    regions,
-    romRanges,
-    appStart: Math.max(0, Math.min(TEC1G_ADDR_MAX, appStart)),
-    entry: Math.max(0, Math.min(TEC1G_ADDR_MAX, entry)),
-    ...(romHex !== undefined ? { romHex } : {}),
-    ...(ramInitHex !== undefined ? { ramInitHex } : {}),
-    updateMs: Math.max(0, updateMs),
-    yieldMs: Math.max(0, yieldMs),
-    gimpSignal,
-    expansionBankHi,
-    matrixMode,
-    protectOnReset,
-    rtcEnabled,
-    sdEnabled,
-    sdHighCapacity,
-    ...(sdImagePath !== undefined ? { sdImagePath } : {}),
-    ...(cartridgeHex !== undefined ? { cartridgeHex } : {}),
-    ...(extraListings ? { extraListings } : {}),
-    ...(cfg?.uiVisibility ? { uiVisibility: cfg.uiVisibility } : {}),
-  };
-}
+export type { Tec1gState };
 
 /**
  * Builds the TEC-1G runtime IO handlers and state.
@@ -323,131 +80,22 @@ export function createTec1gRuntime(
   const matrixMode = config.matrixMode;
   const rtcEnabled = config.rtcEnabled;
   const rtc = rtcEnabled ? new Ds1302() : null;
-  const sdEnabled = config.sdEnabled;
-  const sdImagePath = config.sdImagePath;
-  const sdHighCapacity = config.sdHighCapacity;
-  let sdImage: Uint8Array | undefined;
-  if (sdEnabled && typeof sdImagePath === 'string' && sdImagePath !== '') {
-    try {
-      sdImage = new Uint8Array(fs.readFileSync(sdImagePath));
-    } catch {
-      sdImage = undefined;
-    }
-  }
-  const sdSpi = sdEnabled
-    ? new SdSpi({
-        highCapacity: sdHighCapacity,
-        ...(sdImage ? { image: sdImage } : {}),
-        ...(sdImagePath !== undefined && sdImagePath !== '' && sdImage
-          ? {
-              onWrite: (image): void => {
-                try {
-                  fs.writeFileSync(sdImagePath, image);
-                } catch {
-                  // Ignore persistence failures; runtime continues with in-memory image.
-                }
-              },
-            }
-          : {}),
-      })
-    : null;
+  const { sdEnabled, sdSpi } = createTec1gSdSpi(config);
   let cartridgePresentDefault = config.cartridgeHex !== undefined;
-  const state: Tec1gState = {
-    display: {
-      digits: Array.from({ length: 6 }, () => 0),
-      ledMatrixRedRows: Array.from({ length: 8 }, () => 0),
-      ledMatrixGreenRows: Array.from({ length: 8 }, () => 0),
-      ledMatrixBlueRows: Array.from({ length: 8 }, () => 0),
-      ledMatrixBrightnessR: Array.from({ length: 64 }, () => 0),
-      ledMatrixBrightnessG: Array.from({ length: 64 }, () => 0),
-      ledMatrixBrightnessB: Array.from({ length: 64 }, () => 0),
-      matrixStagingR: Array.from({ length: 64 }, () => 0),
-      matrixStagingG: Array.from({ length: 64 }, () => 0),
-      matrixStagingB: Array.from({ length: 64 }, () => 0),
-      matrixRowsVisitedMask: 0,
-      matrixLastActivityCycle: -1,
-      digitLatch: 0,
-      segmentLatch: 0,
-      ledMatrixRowLatch: 0,
-      ledMatrixRedLatch: 0,
-      ledMatrixGreenLatch: 0,
-      ledMatrixBlueLatch: 0,
-      glcdCtrl: createGlcdState(),
-    },
-    input: {
-      matrixKeyStates: new Uint8Array(16).fill(TEC1G_MASK_BYTE),
-      matrixModeEnabled: matrixMode,
-      keyValue: TEC1G_MASK_LOW7,
-      keyReleaseEventId: null,
-      nmiPending: false,
-      shiftKeyActive: false,
-      rawKeyActive: false,
-    },
-    audio: {
-      speaker: false,
-      speakerHz: 0,
-      lastEdgeCycle: null,
-      silenceEventId: null,
-    },
-    lcdCtrl: {
-      lcd: Array.from({ length: 80 }, () => TEC1G_LCD_SPACE),
-      lcdAddr: TEC1G_LCD_ROW0_START,
-      lcdAddrMode: 'ddram',
-      lcdEntryIncrement: true,
-      lcdEntryShift: false,
-      lcdDisplayOn: true,
-      lcdCursorOn: false,
-      lcdCursorBlink: false,
-      lcdDisplayShift: 0,
-      lcdCgram: new Uint8Array(64),
-      lcdCgramAddr: 0,
-      lcdFunction: {
-        dataLength8: true,
-        lines2: true,
-        font5x8: true,
-      },
-    },
-    timing: {
-      cycleClock: new CycleClock(),
-      lastUpdateMs: 0,
-      pendingUpdate: false,
-      clockHz: TEC1G_FAST_HZ,
-      speedMode: 'fast',
-      updateMs: config.updateMs,
-      yieldMs: config.yieldMs,
-    },
-    system: {
-      sysCtrl: initialSysCtrl,
-      shadowEnabled: initialSysCtrlDecoded.shadowEnabled,
-      protectEnabled: initialSysCtrlDecoded.protectEnabled,
-      expandEnabled: initialSysCtrlDecoded.expandEnabled,
-      bankA14: initialSysCtrlDecoded.bankA14,
-      capsLock: initialSysCtrlDecoded.capsLock,
-      cartridgePresent: cartridgePresentDefault,
-      gimpSignal: config.gimpSignal,
-    },
-  };
+  const state = createTec1gInitialState({
+    config,
+    matrixMode,
+    initialSysCtrl,
+    initialSysCtrlDecoded,
+    cartridgePresentDefault,
+  });
   const defaultGimpSignal = config.gimpSignal;
   const defaultSysCtrl = initialSysCtrl;
   const display = state.display;
   const input = state.input;
-  const audio = state.audio;
   const lcdState = state.lcdCtrl;
   const timing = state.timing;
   const system = state.system;
-  const lcdTest = 'ARROWS: ';
-  for (let i = 0; i < lcdTest.length && i < lcdState.lcd.length; i += 1) {
-    lcdState.lcd[i] = lcdTest.charCodeAt(i);
-  }
-  if (lcdState.lcd.length > lcdTest.length) {
-    lcdState.lcd[lcdTest.length] = TEC1G_LCD_ARROW_LEFT;
-  }
-  if (lcdState.lcd.length > lcdTest.length + 1) {
-    lcdState.lcd[lcdTest.length + 1] = TEC1G_LCD_SPACE;
-  }
-  if (lcdState.lcd.length > lcdTest.length + 2) {
-    lcdState.lcd[lcdTest.length + 2] = TEC1G_LCD_ARROW_RIGHT;
-  }
 
   const updateControllerRef: { current: Tec1gUpdateController | undefined } = {
     current: undefined,
@@ -558,16 +206,7 @@ export function createTec1gRuntime(
   };
 
   const silenceSpeaker = (): void => {
-    if (audio.speakerHz !== 0 || audio.speaker) {
-      audio.speakerHz = 0;
-      audio.speaker = false;
-      audio.lastEdgeCycle = null;
-      if (audio.silenceEventId !== null) {
-        timing.cycleClock.cancel(audio.silenceEventId);
-        audio.silenceEventId = null;
-      }
-      queueUpdate();
-    }
+    silenceTec1gSpeaker(state, queueUpdate);
   };
 
   const setSpeed = (mode: Tec1gSpeedMode): void => {
@@ -575,45 +214,17 @@ export function createTec1gRuntime(
   };
 
   const resetState = (): void => {
-    audio.speaker = false;
-    audio.speakerHz = 0;
-    audio.lastEdgeCycle = null;
-    lcd.reset();
-    display.ledMatrixRedRows.fill(0);
-    display.ledMatrixGreenRows.fill(0);
-    display.ledMatrixBlueRows.fill(0);
-    display.ledMatrixBrightnessR.fill(0);
-    display.ledMatrixBrightnessG.fill(0);
-    display.ledMatrixBrightnessB.fill(0);
-    display.matrixStagingR.fill(0);
-    display.matrixStagingG.fill(0);
-    display.matrixStagingB.fill(0);
-    display.matrixRowsVisitedMask = 0;
-    display.matrixLastActivityCycle = -1;
-    display.ledMatrixRowLatch = 0;
-    display.ledMatrixRedLatch = 0;
-    display.ledMatrixGreenLatch = 0;
-    display.ledMatrixBlueLatch = 0;
-    input.matrixKeyStates.fill(TEC1G_MASK_BYTE);
-    input.matrixModeEnabled = matrixMode;
-    glcd.reset();
-    system.sysCtrl = defaultSysCtrl;
-    const decoded = decodeSysCtrl(system.sysCtrl);
-    system.shadowEnabled = decoded.shadowEnabled;
-    system.protectEnabled = decoded.protectEnabled;
-    system.expandEnabled = decoded.expandEnabled;
-    system.bankA14 = decoded.bankA14;
-    system.capsLock = decoded.capsLock;
-    input.shiftKeyActive = false;
-    input.rawKeyActive = false;
-    system.gimpSignal = defaultGimpSignal;
-    system.cartridgePresent = cartridgePresentDefault;
-    if (audio.silenceEventId !== null) {
-      timing.cycleClock.cancel(audio.silenceEventId);
-      audio.silenceEventId = null;
-    }
-    serial.reset();
-    queueUpdate();
+    resetTec1gRuntimeState(
+      state,
+      {
+        matrixMode,
+        sysCtrl: defaultSysCtrl,
+        gimpSignal: defaultGimpSignal,
+        cartridgePresent: cartridgePresentDefault,
+      },
+      { lcd, glcd, serial },
+      queueUpdate
+    );
   };
 
   return {


### PR DESCRIPTION
## Summary
Completes [#227](https://github.com/jhlagado/debug80/issues/227) by splitting  into focused modules while keeping runtime behavior unchanged.

## What moved
- : 
- :  + initial state construction
- : matrix staging/row-visit/idle commit logic
- : SD image load + optional persistence callback wiring
- : reset and speaker-silence helpers

## Runtime orchestration
 now composes those modules, keeps command handlers/IO wiring in one place, and re-exports  +  for existing call sites.

## Validation
- 
> debug80@0.0.1 build
> tsc && npm run build:webview


> debug80@0.0.1 build:webview
> node scripts/build-webview.js
- 
> debug80@0.0.1 pretest
> npm run build


> debug80@0.0.1 build
> tsc && npm run build:webview


> debug80@0.0.1 build:webview
> node scripts/build-webview.js


> debug80@0.0.1 test
> vitest run && npm run test:webview


 RUN  v0.33.0 /Users/johnhardy/Documents/projects/debug80

 ✓ tests/debug/assembler.test.ts  (9 tests) 53ms
 ✓ tests/mapping/d8-schema.test.ts  (6 tests) 16ms
 ✓ tests/extension/commands.test.ts  (17 tests) 317ms
 ✓ tests/debug/mapping-service.test.ts  (9 tests) 115ms
 ✓ tests/extension/project-target-selection.test.ts  (4 tests) 37ms
 ✓ tests/debug/platform-requests.test.ts  (5 tests) 8ms
 ✓ tests/debug/errors.test.ts  (11 tests) 12ms
 ✓ tests/platforms/tec1g/port03.test.ts  (13 tests) 23ms
 ✓ tests/platforms/provider.test.ts  (5 tests) 873ms
 ✓ tests/debug/zax-backend.test.ts  (8 tests) 42ms
 ✓ tests/platforms/tec1g/ds1302.test.ts  (5 tests) 6ms
 ✓ tests/extension/debug-configuration-provider.test.ts  (5 tests) 26ms
 ✓ tests/platforms/tec1g/matrix-keymap.test.ts  (2 tests) 21ms
 ✓ tests/platforms/tec1g/sd-spi.test.ts  (10 tests) 23ms
 ✓ tests/platforms/tec1g/matrix.test.ts  (10 tests) 24ms
 ✓ tests/debug/launch-args.test.ts  (16 tests) 20ms
 ✓ tests/debug/custom-request-types.test.ts  (53 tests) 27ms
 ✓ tests/z80/decode-utils-flow.test.ts  (7 tests) 9ms
 ✓ tests/extension/platform-view-provider.test.ts  (18 tests) 153ms
 ✓ tests/extension/platform-view-messages.test.ts  (4 tests) 13ms
 ✓ tests/debug/launch-pipeline.test.ts  (8 tests) 52ms
 ✓ tests/extension/extension.test.ts  (3 tests) 2480ms
 ✓ tests/debug/adapter-integration.test.ts  (6 tests) 1070ms
 ✓ tests/debug/adapter-ui.test.ts  (2 tests) 8ms
 ✓ tests/platforms/tec1g/sd-spi-runtime.test.ts  (2 tests) 83ms
 ✓ tests/platforms/tec1g/ui-panel-messages.test.ts  (4 tests) 53ms
 ✓ tests/debug/source-manager.test.ts  (3 tests) 53ms
 ✓ tests/debug/path-resolver.test.ts  (10 tests) 109ms
 ✓ tests/contracts/cross-layer-contracts.test.ts  (2 tests) 13ms
 ✓ tests/debug/rom-requests.test.ts  (1 test) 3ms
 ✓ tests/platforms/panel-messages.test.ts  (4 tests) 55ms
 ✓ tests/debug/config-validation.test.ts  (55 tests) 81ms
 ✓ tests/mapping/mapping-layer2.test.ts  (7 tests) 10ms
 ✓ tests/platforms/tec1g/glcd.test.ts  (10 tests) 48ms
 ✓ tests/debug/runtime-control.test.ts  (19 tests) 80ms
 ✓ tests/platforms/tec1g/portfd.test.ts  (2 tests) 14ms
 ✓ tests/debug/stack-service.test.ts  (6 tests) 24ms
 ✓ tests/mapping/d8-map.test.ts  (12 tests) 20ms
 ✓ tests/debug/program-loader.test.ts  (6 tests) 106ms
 ✓ tests/z80/decode-utils-special.test.ts  (5 tests) 14ms
 ✓ tests/z80/decode-cb.test.ts  (11 tests) 25ms
 ✓ tests/platforms/tec1g/sysctrl.test.ts  (7 tests) 5ms
 ✓ tests/extension/project-config.test.ts  (10 tests) 78ms
 ✓ tests/debug/config-utils.test.ts  (7 tests) 19ms
 ✓ tests/platforms/tec1g/ui-panel-html.test.ts  (2 tests) 6ms
 ✓ tests/z80/z80-rotate.test.ts  (8 tests) 3ms
 ✓ tests/z80/decode-utils-flags.test.ts  (6 tests) 14ms
 ✓ tests/z80/z80.test.ts  (6 tests) 45ms
 ✓ tests/mapping/mapping-parser.test.ts  (6 tests) 9ms
 ✓ tests/debug/path-utils.test.ts  (19 tests | 3 skipped) 14ms
 ✓ tests/z80/z80-runtime.test.ts  (4 tests) 11ms
 ✓ tests/mapping/d8-pipeline.test.ts  (7 tests) 67ms
 ✓ tests/mapping/source-map.test.ts  (8 tests) 6ms
 ✓ tests/z80/decode-utils-alu8.test.ts  (17 tests) 8ms
 ✓ tests/extension/workspace-selection.test.ts  (4 tests) 14ms
 ✓ tests/debug/tec1g-cartridge.test.ts  (2 tests) 7ms
 ✓ tests/extension/debug-session-events.test.ts  (1 test) 5ms
 ✓ tests/platforms/tec1g/lcd.test.ts  (10 tests) 14ms
 ✓ tests/platforms/tec1g/portfc.test.ts  (2 tests) 7ms
 ✓ tests/platforms/tec-common.test.ts  (32 tests) 78ms
 ✓ tests/extension/project-scaffolding.test.ts  (8 tests) 12ms
 ✓ tests/debug/tec1g-memory.test.ts  (4 tests) 80ms
 ✓ tests/platforms/serialize-update-payload.test.ts  (7 tests) 9ms
 ✓ tests/debug/assembler-backend.test.ts  (8 tests) 6ms
 ✓ tests/extension/project-status.test.ts  (1 test) 6ms
 ✓ tests/z80/decode-utils-alu16.test.ts  (4 tests) 5ms
 ✓ tests/platforms/tec1/ui-panel-messages.test.ts  (4 tests) 19ms
 ✓ tests/debug/register-request.test.ts  (5 tests) 5ms
 ✓ tests/debug/memory-write.test.ts  (2 tests) 10ms
 ✓ tests/extension/platform-view-serial-actions.test.ts  (6 tests) 48ms
 ✓ tests/mapping/d8-validate.test.ts  (8 tests) 8ms
 ✓ tests/debug/matrix-request.test.ts  (18 tests) 19ms
 ✓ tests/z80/z80-loaders.test.ts  (5 tests) 12ms
 ✓ tests/platforms/tec1g/speaker-clock.test.ts  (1 test) 7ms
 ✓ tests/debug/breakpoint-manager.test.ts  (7 tests) 6ms
 ✓ tests/debug/platform-host.test.ts  (5 tests) 6ms
 ✓ tests/debug/symbol-service.test.ts  (3 tests) 5ms
 ✓ tests/debug/adapter-request-controller.test.ts  (4 tests) 19ms
 ✓ tests/platforms/tec1/ui-panel-html.test.ts  (2 tests) 5ms
 ✓ tests/debug/variable-service.test.ts  (4 tests) 13ms
 ✓ tests/platforms/ui-panel-helpers.test.ts  (8 tests) 12ms
 ✓ tests/platforms/tec1g/ui-panel-memory.test.ts  (2 tests) 5ms
 ✓ tests/debug/source-state-manager.test.ts  (2 tests) 6ms
 ✓ tests/debug/io-requests.test.ts  (3 tests) 5ms
 ✓ tests/debug/memory-snapshot.test.ts  (1 test) 8ms
 ✓ tests/debug/tec1g-shadow.test.ts  (3 tests) 6ms
 ✓ tests/z80/z80-constants.test.ts  (2 tests) 15ms
 ✓ tests/z80/decode-utils-rotate.test.ts  (8 tests) 8ms
 ✓ tests/debug/memory-view.test.ts  (5 tests) 6ms
 ✓ tests/platforms/tec1g/serial.test.ts  (1 test) 10ms
 ✓ tests/debug/session-state.test.ts  (1 test) 5ms
 ✓ tests/z80/z80-core-helpers.test.ts  (5 tests) 32ms
 ✓ tests/debug/debug-addressing.test.ts  (5 tests) 4ms
 ✓ tests/z80/decode-utils-stack.test.ts  (2 tests) 6ms
 ✓ tests/platforms/tec1g/memory-banking.test.ts  (3 tests) 23ms
 ✓ tests/extension/terminal-panel-html.test.ts  (2 tests) 50ms
 ✓ tests/platforms/tec1/memory-panel-html.test.ts  (4 tests) 225ms

 Test Files  97 passed (97)
      Tests  713 passed | 3 skipped (716)
   Start at  16:11:07
   Duration  9.80s (transform 2.50s, setup 12ms, collect 10.40s, tests 7.36s, environment 2.12s, prepare 16.73s)


> debug80@0.0.1 test:webview
> vitest run -c vitest.webview.config.ts


 RUN  v0.33.0 /Users/johnhardy/Documents/projects/debug80

 ✓ tests/webview/tec1-display-renderers.test.ts  (3 tests) 318ms
 ✓ tests/webview/tec1g-visibility-controller.test.ts  (3 tests) 434ms
 ✓ tests/webview/tec1g-serial-ui.test.ts  (2 tests) 186ms
 ✓ tests/webview/session-status.test.ts  (6 tests) 402ms
 ✓ tests/webview/tec1g-display-renderers.test.ts  (4 tests) 392ms
 ✓ tests/webview/tec1g-matrix-ui.test.ts  (6 tests) 1133ms
 ✓ tests/webview/tec1g-visibility.test.ts  (4 tests) 1552ms
 ✓ tests/webview/common/setup-card-state.test.ts  (4 tests) 121ms
 ✓ tests/webview/common/project-root-button.test.ts  (3 tests) 35ms
 ✓ tests/webview/tec1g-font-asset.test.ts  (1 test) 19ms
 ✓ tests/webview/common/memory-panel.test.ts  (2 tests) 349ms
 ✓ tests/webview/tec1-serial-ui.test.ts  (2 tests) 453ms
 ✓ tests/webview/tec1g-keypad-layout.test.ts  (3 tests) 12ms
 ✓ tests/webview/language-contracts.test.ts  (9 tests) 9ms

 Test Files  14 passed (14)
      Tests  52 passed (52)
   Start at  16:11:18
   Duration  8.44s (transform 2.46s, setup 6ms, collect 4.89s, tests 5.42s, environment 32.97s, prepare 3.04s)

Fixes #227

Made with [Cursor](https://cursor.com)