### PR TITLE
Refactor debug session state into domain-specific views (#226)

### DIFF
--- a/src/debug/adapter.ts
+++ b/src/debug/adapter.ts
@@ -119,7 +119,7 @@ export class Z80DebugSession extends DebugSession {
     const respondError = (response: DebugProtocol.Response, id: number, message: string): void =>
       this.sendErrorResponse(response, id, message);
     const terminalDeps = {
-      getTerminalState: () => this.sessionState.terminalState,
+      getTerminalState: () => this.sessionState.ui.terminalState,
       sendResponse: respond,
       sendErrorResponse: respondError,
     };
@@ -130,11 +130,11 @@ export class Z80DebugSession extends DebugSession {
       handleTerminalBreak(response, terminalDeps)
     );
     const memoryDeps = {
-      getRuntime: () => this.sessionState.runtime,
+      getRuntime: () => this.sessionState.runtimeState.execution,
       getRunning: () => this.sessionState.runState.isRunning,
-      getSymbolAnchors: () => this.sessionState.symbolAnchors,
+      getSymbolAnchors: () => this.sessionState.source.symbolAnchors,
       getLookupAnchors: () => this.sourceState.lookupAnchors,
-      getSymbolList: () => this.sessionState.symbolList,
+      getSymbolList: () => this.sessionState.source.symbolList,
       sendResponse: respond,
       sendErrorResponse: respondError,
     };
@@ -164,7 +164,7 @@ export class Z80DebugSession extends DebugSession {
     });
     this.commandRouter.register('debug80/romSources', (response) => {
       response.body = buildRomSourcesResponse(
-        this.sourceState.collectRomSources(this.sessionState.extraListingPaths)
+        this.sourceState.collectRomSources(this.sessionState.source.extraListingPaths)
       );
       this.sendResponse(response);
       return true;
@@ -213,7 +213,7 @@ export class Z80DebugSession extends DebugSession {
     const merged: LaunchRequestArguments = populateFromConfig(args, {
       resolveBaseDir: (requestArgs) => resolveBaseDir(requestArgs),
     });
-    this.sessionState.launchArgs = merged;
+    this.sessionState.launch.launchArgs = merged;
     this.sessionState.runState.stopOnEntry = merged.stopOnEntry === true;
     setDiagnosticsEnabled(merged.diagnostics === true);
 

--- a/src/debug/runtime-control.ts
+++ b/src/debug/runtime-control.ts
@@ -167,25 +167,31 @@ export function applyLaunchSessionArtifacts(
   target: LaunchArtifactsTarget,
   artifacts: LaunchSessionArtifacts
 ): void {
+  const source = target.sessionState.source;
+  const runtimeState = target.sessionState.runtimeState;
+  const platform = target.sessionState.platform;
+  const launch = target.sessionState.launch;
+  const ui = target.sessionState.ui;
+
   target.platformState.active = artifacts.platform;
-  target.sessionState.listing = artifacts.listing;
-  target.sessionState.listingPath = artifacts.listingPath;
-  target.sessionState.mapping = artifacts.mapping;
-  target.sessionState.mappingIndex = artifacts.mappingIndex;
-  target.sessionState.sourceRoots = artifacts.sourceRoots;
-  target.sessionState.extraListingPaths = artifacts.extraListingPaths;
-  target.sessionState.symbolAnchors = artifacts.symbolAnchors;
-  target.sessionState.symbolList = artifacts.symbolList;
-  target.sessionState.runtime = artifacts.runtime;
-  target.sessionState.terminalState = artifacts.terminalState;
-  target.sessionState.tec1Runtime = artifacts.tec1Runtime;
-  target.sessionState.tec1gRuntime = artifacts.tec1gRuntime;
-  target.sessionState.platformRuntime = artifacts.platformRuntime;
-  target.sessionState.tec1gConfig = artifacts.tec1gConfig;
-  target.sessionState.loadedProgram = artifacts.loadedProgram;
-  target.sessionState.loadedEntry = artifacts.loadedEntry;
-  target.sessionState.restartCaptureAddress = artifacts.restartCaptureAddress;
-  target.sessionState.entryCpuState = undefined;
+  source.listing = artifacts.listing;
+  source.listingPath = artifacts.listingPath;
+  source.mapping = artifacts.mapping;
+  source.mappingIndex = artifacts.mappingIndex;
+  source.sourceRoots = artifacts.sourceRoots;
+  source.extraListingPaths = artifacts.extraListingPaths;
+  source.symbolAnchors = artifacts.symbolAnchors;
+  source.symbolList = artifacts.symbolList;
+  runtimeState.execution = artifacts.runtime;
+  ui.terminalState = artifacts.terminalState;
+  platform.tec1Runtime = artifacts.tec1Runtime;
+  platform.tec1gRuntime = artifacts.tec1gRuntime;
+  platform.platformRuntime = artifacts.platformRuntime;
+  platform.tec1gConfig = artifacts.tec1gConfig;
+  launch.loadedProgram = artifacts.loadedProgram;
+  launch.loadedEntry = artifacts.loadedEntry;
+  launch.restartCaptureAddress = artifacts.restartCaptureAddress;
+  launch.entryCpuState = undefined;
   target.sessionState.runState.callDepth = 0;
   target.sessionState.runState.stepOverMaxInstructions = artifacts.stepOverMaxInstructions;
   target.sessionState.runState.stepOutMaxInstructions = artifacts.stepOutMaxInstructions;

--- a/src/debug/session-state.ts
+++ b/src/debug/session-state.ts
@@ -23,6 +23,41 @@ export type ActivePlatformRuntime = Pick<
   'recordCycles' | 'silenceSpeaker'
 >;
 
+export interface SessionSourceState {
+  listing: ListingInfo | undefined;
+  listingPath: string | undefined;
+  mapping: MappingParseResult | undefined;
+  mappingIndex: SourceMapIndex | undefined;
+  symbolAnchors: SourceMapAnchor[];
+  symbolList: Array<{ name: string; address: number }>;
+  sourceRoots: string[];
+  extraListingPaths: string[];
+}
+
+export interface SessionLaunchState {
+  baseDir: string;
+  loadedProgram: HexProgram | undefined;
+  loadedEntry: number | undefined;
+  restartCaptureAddress: number | undefined;
+  entryCpuState: CpuStateSnapshot | undefined;
+  launchArgs: LaunchRequestArguments | undefined;
+}
+
+export interface SessionRuntimeState {
+  execution: Z80Runtime | undefined;
+}
+
+export interface SessionPlatformState {
+  tec1Runtime: Tec1Runtime | undefined;
+  tec1gRuntime: Tec1gRuntime | undefined;
+  platformRuntime: ActivePlatformRuntime | undefined;
+  tec1gConfig: Tec1gPlatformConfigNormalized | undefined;
+}
+
+export interface SessionUiState {
+  terminalState: TerminalState | undefined;
+}
+
 /**
  * Subset of Z80DebugSession fields that are reset per launch.
  */
@@ -47,6 +82,15 @@ export interface SessionStateShape {
   entryCpuState: CpuStateSnapshot | undefined;
   launchArgs: LaunchRequestArguments | undefined;
   extraListingPaths: string[];
+  /**
+   * Domain-scoped mutable views over the same backing fields.
+   * New code should prefer these grouped objects to reduce coupling.
+   */
+  source: SessionSourceState;
+  launch: SessionLaunchState;
+  runtimeState: SessionRuntimeState;
+  platform: SessionPlatformState;
+  ui: SessionUiState;
   runState: RunState;
 }
 
@@ -72,7 +116,7 @@ export interface RunState {
  * Creates a fresh session state object with default values.
  */
 export function createSessionState(): SessionStateShape {
-  return {
+  const state = {
     runtime: undefined,
     listing: undefined,
     listingPath: undefined,
@@ -93,6 +137,11 @@ export function createSessionState(): SessionStateShape {
     entryCpuState: undefined,
     launchArgs: undefined,
     extraListingPaths: [],
+    source: undefined as unknown as SessionSourceState,
+    launch: undefined as unknown as SessionLaunchState,
+    runtimeState: undefined as unknown as SessionRuntimeState,
+    platform: undefined as unknown as SessionPlatformState,
+    ui: undefined as unknown as SessionUiState,
     runState: {
       stopOnEntry: false,
       launchComplete: false,
@@ -107,7 +156,144 @@ export function createSessionState(): SessionStateShape {
       stepOutMaxInstructions: 0,
       pauseRequested: false,
     },
+  } as SessionStateShape;
+
+  state.source = {
+    get listing(): ListingInfo | undefined {
+      return state.listing;
+    },
+    set listing(value) {
+      state.listing = value;
+    },
+    get listingPath(): string | undefined {
+      return state.listingPath;
+    },
+    set listingPath(value) {
+      state.listingPath = value;
+    },
+    get mapping(): MappingParseResult | undefined {
+      return state.mapping;
+    },
+    set mapping(value) {
+      state.mapping = value;
+    },
+    get mappingIndex(): SourceMapIndex | undefined {
+      return state.mappingIndex;
+    },
+    set mappingIndex(value) {
+      state.mappingIndex = value;
+    },
+    get symbolAnchors(): SourceMapAnchor[] {
+      return state.symbolAnchors;
+    },
+    set symbolAnchors(value) {
+      state.symbolAnchors = value;
+    },
+    get symbolList(): Array<{ name: string; address: number }> {
+      return state.symbolList;
+    },
+    set symbolList(value) {
+      state.symbolList = value;
+    },
+    get sourceRoots(): string[] {
+      return state.sourceRoots;
+    },
+    set sourceRoots(value) {
+      state.sourceRoots = value;
+    },
+    get extraListingPaths(): string[] {
+      return state.extraListingPaths;
+    },
+    set extraListingPaths(value) {
+      state.extraListingPaths = value;
+    },
   };
+
+  state.launch = {
+    get baseDir(): string {
+      return state.baseDir;
+    },
+    set baseDir(value) {
+      state.baseDir = value;
+    },
+    get loadedProgram(): HexProgram | undefined {
+      return state.loadedProgram;
+    },
+    set loadedProgram(value) {
+      state.loadedProgram = value;
+    },
+    get loadedEntry(): number | undefined {
+      return state.loadedEntry;
+    },
+    set loadedEntry(value) {
+      state.loadedEntry = value;
+    },
+    get restartCaptureAddress(): number | undefined {
+      return state.restartCaptureAddress;
+    },
+    set restartCaptureAddress(value) {
+      state.restartCaptureAddress = value;
+    },
+    get entryCpuState(): CpuStateSnapshot | undefined {
+      return state.entryCpuState;
+    },
+    set entryCpuState(value) {
+      state.entryCpuState = value;
+    },
+    get launchArgs(): LaunchRequestArguments | undefined {
+      return state.launchArgs;
+    },
+    set launchArgs(value) {
+      state.launchArgs = value;
+    },
+  };
+
+  state.runtimeState = {
+    get execution(): Z80Runtime | undefined {
+      return state.runtime;
+    },
+    set execution(value) {
+      state.runtime = value;
+    },
+  };
+
+  state.platform = {
+    get tec1Runtime(): Tec1Runtime | undefined {
+      return state.tec1Runtime;
+    },
+    set tec1Runtime(value) {
+      state.tec1Runtime = value;
+    },
+    get tec1gRuntime(): Tec1gRuntime | undefined {
+      return state.tec1gRuntime;
+    },
+    set tec1gRuntime(value) {
+      state.tec1gRuntime = value;
+    },
+    get platformRuntime(): ActivePlatformRuntime | undefined {
+      return state.platformRuntime;
+    },
+    set platformRuntime(value) {
+      state.platformRuntime = value;
+    },
+    get tec1gConfig(): Tec1gPlatformConfigNormalized | undefined {
+      return state.tec1gConfig;
+    },
+    set tec1gConfig(value) {
+      state.tec1gConfig = value;
+    },
+  };
+
+  state.ui = {
+    get terminalState(): TerminalState | undefined {
+      return state.terminalState;
+    },
+    set terminalState(value) {
+      state.terminalState = value;
+    },
+  };
+
+  return state;
 }
 
 /**
@@ -116,5 +302,26 @@ export function createSessionState(): SessionStateShape {
  * @param target - Session state to reset
  */
 export function resetSessionState(target: SessionStateShape): void {
-  Object.assign(target, createSessionState());
+  const next = createSessionState();
+  target.runtime = next.runtime;
+  target.listing = next.listing;
+  target.listingPath = next.listingPath;
+  target.mapping = next.mapping;
+  target.mappingIndex = next.mappingIndex;
+  target.symbolAnchors = next.symbolAnchors;
+  target.symbolList = next.symbolList;
+  target.sourceRoots = next.sourceRoots;
+  target.baseDir = next.baseDir;
+  target.terminalState = next.terminalState;
+  target.tec1Runtime = next.tec1Runtime;
+  target.tec1gRuntime = next.tec1gRuntime;
+  target.platformRuntime = next.platformRuntime;
+  target.tec1gConfig = next.tec1gConfig;
+  target.loadedProgram = next.loadedProgram;
+  target.loadedEntry = next.loadedEntry;
+  target.restartCaptureAddress = next.restartCaptureAddress;
+  target.entryCpuState = next.entryCpuState;
+  target.launchArgs = next.launchArgs;
+  target.extraListingPaths = next.extraListingPaths;
+  target.runState = next.runState;
 }

--- a/src/debug/session-state.ts
+++ b/src/debug/session-state.ts
@@ -323,5 +323,16 @@ export function resetSessionState(target: SessionStateShape): void {
   target.entryCpuState = next.entryCpuState;
   target.launchArgs = next.launchArgs;
   target.extraListingPaths = next.extraListingPaths;
-  target.runState = next.runState;
+  target.runState.stopOnEntry = next.runState.stopOnEntry;
+  target.runState.launchComplete = next.runState.launchComplete;
+  target.runState.configurationDone = next.runState.configurationDone;
+  target.runState.isRunning = next.runState.isRunning;
+  target.runState.haltNotified = next.runState.haltNotified;
+  target.runState.lastStopReason = next.runState.lastStopReason;
+  target.runState.lastBreakpointAddress = next.runState.lastBreakpointAddress;
+  target.runState.skipBreakpointOnce = next.runState.skipBreakpointOnce;
+  target.runState.callDepth = next.runState.callDepth;
+  target.runState.stepOverMaxInstructions = next.runState.stepOverMaxInstructions;
+  target.runState.stepOutMaxInstructions = next.runState.stepOutMaxInstructions;
+  target.runState.pauseRequested = next.runState.pauseRequested;
 }

--- a/tests/debug/session-state.test.ts
+++ b/tests/debug/session-state.test.ts
@@ -67,4 +67,15 @@ describe('session-state', () => {
     expect(state.restartCaptureAddress).toBeUndefined();
     expect(state.entryCpuState).toBeUndefined();
   });
+
+  it('preserves runState object identity across reset', () => {
+    const state = createSessionState();
+    const captured = state.runState;
+    state.runState.haltNotified = true;
+
+    resetSessionState(state);
+
+    expect(state.runState).toBe(captured);
+    expect(captured.haltNotified).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
Implements [#226](https://github.com/jhlagado/debug80/issues/226) by introducing domain-scoped session state views while preserving the existing flat field API for compatibility.

## Changes
- 
  - add grouped mutable views: , , , , 
  - keep existing flat  fields (no behavioral breakage)
  - make grouped views backed by the same fields via accessors
  - fix  to reset backing fields without rebinding domain views
- 
  - use grouped views in launch artifact application
- 
  - use grouped views for terminal/memory deps and launch args assignment

## Validation
- 
> debug80@0.0.1 build
> tsc && npm run build:webview


> debug80@0.0.1 build:webview
> node scripts/build-webview.js
- 
> debug80@0.0.1 pretest
> npm run build


> debug80@0.0.1 build
> tsc && npm run build:webview


> debug80@0.0.1 build:webview
> node scripts/build-webview.js


> debug80@0.0.1 test
> vitest run && npm run test:webview


 RUN  v0.33.0 /Users/johnhardy/Documents/projects/debug80

 ✓ tests/debug/config-validation.test.ts  (55 tests) 19ms
 ✓ tests/extension/project-status.test.ts  (1 test) 9ms
 ✓ tests/mapping/d8-pipeline.test.ts  (7 tests) 57ms
 ✓ tests/extension/commands.test.ts  (17 tests) 317ms
 ✓ tests/extension/workspace-selection.test.ts  (4 tests) 125ms
 ✓ tests/z80/z80.test.ts  (6 tests) 17ms
 ✓ tests/debug/source-manager.test.ts  (3 tests) 33ms
 ✓ tests/debug/stack-service.test.ts  (6 tests) 20ms
 ✓ tests/platforms/provider.test.ts  (5 tests) 1451ms
 ✓ tests/extension/platform-view-provider.test.ts  (18 tests) 108ms
 ✓ tests/z80/z80-core-helpers.test.ts  (5 tests) 27ms
 ✓ tests/debug/runtime-control.test.ts  (19 tests) 41ms
 ✓ tests/platforms/ui-panel-helpers.test.ts  (8 tests) 31ms
 ✓ tests/debug/config-utils.test.ts  (7 tests) 14ms
 ✓ tests/debug/custom-request-types.test.ts  (53 tests) 74ms
 ✓ tests/extension/extension.test.ts  (3 tests) 2600ms
 ✓ tests/z80/z80-loaders.test.ts  (5 tests) 7ms
 ✓ tests/debug/path-resolver.test.ts  (10 tests) 27ms
 ✓ tests/debug/zax-backend.test.ts  (8 tests) 38ms
 ✓ tests/debug/adapter-integration.test.ts  (6 tests) 1173ms
 ✓ tests/debug/memory-snapshot.test.ts  (1 test) 7ms
 ✓ tests/extension/project-target-selection.test.ts  (4 tests) 18ms
 ✓ tests/debug/assembler.test.ts  (9 tests) 140ms
 ✓ tests/platforms/tec1g/sd-spi.test.ts  (10 tests) 65ms
 ✓ tests/debug/mapping-service.test.ts  (9 tests) 66ms
 ✓ tests/platforms/tec1g/ui-panel-messages.test.ts  (4 tests) 13ms
 ✓ tests/debug/program-loader.test.ts  (6 tests) 20ms
 ✓ tests/extension/project-scaffolding.test.ts  (8 tests) 23ms
 ✓ tests/debug/errors.test.ts  (11 tests) 31ms
 ✓ tests/platforms/tec1g/portfd.test.ts  (2 tests) 13ms
 ✓ tests/platforms/tec1g/ui-panel-memory.test.ts  (2 tests) 8ms
 ✓ tests/debug/launch-args.test.ts  (16 tests) 24ms
 ✓ tests/mapping/d8-map.test.ts  (12 tests) 43ms
 ✓ tests/extension/debug-configuration-provider.test.ts  (5 tests) 28ms
 ✓ tests/contracts/cross-layer-contracts.test.ts  (2 tests) 23ms
 ✓ tests/platforms/tec1g/matrix-keymap.test.ts  (2 tests) 50ms
 ✓ tests/platforms/tec1g/glcd.test.ts  (10 tests) 44ms
 ✓ tests/mapping/mapping-parser.test.ts  (6 tests) 7ms
 ✓ tests/extension/project-config.test.ts  (10 tests) 46ms
 ✓ tests/extension/platform-view-serial-actions.test.ts  (6 tests) 88ms
 ✓ tests/platforms/tec1g/memory-banking.test.ts  (3 tests) 4ms
 ✓ tests/platforms/panel-messages.test.ts  (4 tests) 12ms
 ✓ tests/platforms/tec1g/sd-spi-runtime.test.ts  (2 tests) 73ms
 ✓ tests/debug/assembler-backend.test.ts  (8 tests) 35ms
 ✓ tests/debug/launch-pipeline.test.ts  (8 tests) 8ms
 ✓ tests/platforms/tec1g/matrix.test.ts  (10 tests) 73ms
 ✓ tests/debug/matrix-request.test.ts  (18 tests) 9ms
 ✓ tests/debug/tec1g-cartridge.test.ts  (2 tests) 10ms
 ✓ tests/mapping/d8-validate.test.ts  (8 tests) 12ms
 ✓ tests/mapping/mapping-layer2.test.ts  (7 tests) 10ms
 ✓ tests/platforms/tec1/ui-panel-html.test.ts  (2 tests) 12ms
 ✓ tests/debug/adapter-request-controller.test.ts  (4 tests) 20ms
 ✓ tests/platforms/tec1g/lcd.test.ts  (10 tests) 8ms
 ✓ tests/platforms/tec1/ui-panel-messages.test.ts  (4 tests) 14ms
 ✓ tests/debug/source-state-manager.test.ts  (2 tests) 7ms
 ✓ tests/debug/path-utils.test.ts  (19 tests | 3 skipped) 57ms
 ✓ tests/platforms/tec-common.test.ts  (32 tests) 12ms
 ✓ tests/debug/session-state.test.ts  (1 test) 7ms
 ✓ tests/z80/z80-runtime.test.ts  (4 tests) 12ms
 ✓ tests/z80/decode-cb.test.ts  (11 tests) 24ms
 ✓ tests/platforms/tec1g/port03.test.ts  (13 tests) 13ms
 ✓ tests/z80/decode-utils-rotate.test.ts  (8 tests) 32ms
 ✓ tests/debug/platform-requests.test.ts  (5 tests) 22ms
 ✓ tests/debug/variable-service.test.ts  (4 tests) 7ms
 ✓ tests/debug/tec1g-shadow.test.ts  (3 tests) 6ms
 ✓ tests/platforms/serialize-update-payload.test.ts  (7 tests) 15ms
 ✓ tests/mapping/d8-schema.test.ts  (6 tests) 33ms
 ✓ tests/z80/decode-utils-flags.test.ts  (6 tests) 15ms
 ✓ tests/z80/decode-utils-flow.test.ts  (7 tests) 13ms
 ✓ tests/z80/decode-utils-special.test.ts  (5 tests) 7ms
 ✓ tests/platforms/tec1g/ui-panel-html.test.ts  (2 tests) 7ms
 ✓ tests/extension/platform-view-messages.test.ts  (4 tests) 16ms
 ✓ tests/extension/debug-session-events.test.ts  (1 test) 33ms
 ✓ tests/platforms/tec1g/speaker-clock.test.ts  (1 test) 16ms
 ✓ tests/debug/debug-addressing.test.ts  (5 tests) 16ms
 ✓ tests/debug/platform-host.test.ts  (5 tests) 9ms
 ✓ tests/debug/io-requests.test.ts  (3 tests) 7ms
 ✓ tests/debug/memory-write.test.ts  (2 tests) 9ms
 ✓ tests/mapping/source-map.test.ts  (8 tests) 6ms
 ✓ tests/debug/tec1g-memory.test.ts  (4 tests) 7ms
 ✓ tests/z80/decode-utils-alu8.test.ts  (17 tests) 11ms
 ✓ tests/z80/z80-rotate.test.ts  (8 tests) 5ms
 ✓ tests/debug/breakpoint-manager.test.ts  (7 tests) 18ms
 ✓ tests/platforms/tec1g/ds1302.test.ts  (5 tests) 5ms
 ✓ tests/debug/rom-requests.test.ts  (1 test) 3ms
 ✓ tests/debug/register-request.test.ts  (5 tests) 12ms
 ✓ tests/platforms/tec1g/portfc.test.ts  (2 tests) 7ms
 ✓ tests/debug/symbol-service.test.ts  (3 tests) 7ms
 ✓ tests/z80/z80-constants.test.ts  (2 tests) 3ms
 ✓ tests/debug/adapter-ui.test.ts  (2 tests) 6ms
 ✓ tests/debug/memory-view.test.ts  (5 tests) 16ms
 ✓ tests/platforms/tec1g/serial.test.ts  (1 test) 5ms
 ✓ tests/z80/decode-utils-alu16.test.ts  (4 tests) 5ms
 ✓ tests/z80/decode-utils-stack.test.ts  (2 tests) 4ms
 ✓ tests/platforms/tec1g/sysctrl.test.ts  (7 tests) 29ms
 ✓ tests/extension/terminal-panel-html.test.ts  (2 tests) 107ms
 ✓ tests/platforms/tec1/memory-panel-html.test.ts  (4 tests) 309ms

 Test Files  97 passed (97)
      Tests  713 passed | 3 skipped (716)
   Start at  17:13:11
   Duration  12.76s (transform 2.74s, setup 25ms, collect 13.29s, tests 8.21s, environment 3.60s, prepare 20.74s)


> debug80@0.0.1 test:webview
> vitest run -c vitest.webview.config.ts


 RUN  v0.33.0 /Users/johnhardy/Documents/projects/debug80

 ✓ tests/webview/tec1-display-renderers.test.ts  (3 tests) 187ms
 ✓ tests/webview/tec1-serial-ui.test.ts  (2 tests) 173ms
 ✓ tests/webview/tec1g-visibility-controller.test.ts  (3 tests) 510ms
 ✓ tests/webview/session-status.test.ts  (6 tests) 522ms
 ✓ tests/webview/tec1g-display-renderers.test.ts  (4 tests) 388ms
 ✓ tests/webview/tec1g-matrix-ui.test.ts  (6 tests) 901ms
 ✓ tests/webview/tec1g-visibility.test.ts  (4 tests) 1401ms
 ✓ tests/webview/common/memory-panel.test.ts  (2 tests) 96ms
 ✓ tests/webview/tec1g-font-asset.test.ts  (1 test) 7ms
 ✓ tests/webview/tec1g-keypad-layout.test.ts  (3 tests) 14ms
 ✓ tests/webview/tec1g-serial-ui.test.ts  (2 tests) 218ms
 ✓ tests/webview/common/project-root-button.test.ts  (3 tests) 130ms
 ✓ tests/webview/language-contracts.test.ts  (9 tests) 120ms
 ✓ tests/webview/common/setup-card-state.test.ts  (4 tests) 5ms

 Test Files  14 passed (14)
      Tests  52 passed (52)
   Start at  17:13:25
   Duration  9.23s (transform 1.80s, setup 10ms, collect 3.27s, tests 4.67s, environment 39.86s, prepare 3.81s)

Fixes #226

Made with [Cursor](https://cursor.com)