### PR TITLE
Unify runtime/UI platform registration model (#225)

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -17,12 +17,9 @@ import { WorkspaceSelectionController } from './workspace-selection';
 import { Debug80ConfigurationProvider } from './debug-configuration-provider';
 import { OutputChannelLogger } from '../util/logger';
 import {
-  listPlatforms,
-  registerPlatform,
   type PlatformManifestEntry,
 } from '../platforms/provider';
 import {
-  registerPlatformUi,
   type PlatformUiEntry,
   type PlatformUiModules,
 } from './platform-view-manifest';
@@ -34,6 +31,11 @@ import {
   serializeTec1gClearPanelUpdateFromUiState,
   serializeTec1gUpdateFromUiState,
 } from '../platforms/tec1g/serialize-ui-update-payload';
+import {
+  listExtensionPlatforms,
+  registerExtensionPlatform,
+  registerRuntimePlatform,
+} from './platform-extension-model';
 
 export interface Debug80Api {
   registerPlatform: (entry: PlatformManifestEntry) => void;
@@ -44,8 +46,28 @@ export interface Debug80Api {
  *
  */
 function registerBuiltInPlatformUis(): void {
-  registerPlatformUi(createTec1PlatformUiEntry());
-  registerPlatformUi(createTec1gPlatformUiEntry());
+  registerExtensionPlatform({
+    runtime: {
+      id: 'tec1',
+      displayName: 'TEC-1',
+      loadProvider: async (args) => {
+        const { createTec1PlatformProvider } = await import('../platforms/tec1/provider.js');
+        return createTec1PlatformProvider(args);
+      },
+    },
+    ui: createTec1PlatformUiEntry(),
+  });
+  registerExtensionPlatform({
+    runtime: {
+      id: 'tec1g',
+      displayName: 'TEC-1G',
+      loadProvider: async (args) => {
+        const { createTec1gPlatformProvider } = await import('../platforms/tec1g/provider.js');
+        return createTec1gPlatformProvider(args);
+      },
+    },
+    ui: createTec1gPlatformUiEntry(),
+  });
 }
 
 /**
@@ -215,8 +237,8 @@ export function activate(context: vscode.ExtensionContext): Debug80Api {
   registerAutoRebuildOnSave(context, sessionState, output, rebuildDiagnostics);
 
   return {
-    registerPlatform,
-    listPlatforms,
+    registerPlatform: registerRuntimePlatform,
+    listPlatforms: () => listExtensionPlatforms().map((entry) => entry.runtime),
   };
 }
 

--- a/src/extension/platform-extension-model.ts
+++ b/src/extension/platform-extension-model.ts
@@ -1,0 +1,52 @@
+/**
+ * @file Unified extension platform registration model.
+ */
+
+import {
+  registerPlatform,
+  type PlatformManifestEntry,
+  listPlatforms,
+} from '../platforms/provider';
+import {
+  registerPlatformUi,
+  type PlatformUiEntry,
+  listPlatformUis,
+} from './platform-view-manifest';
+
+export interface ExtensionPlatformEntry {
+  runtime: PlatformManifestEntry;
+  ui?: PlatformUiEntry;
+}
+
+const extensionPlatforms = new Map<string, ExtensionPlatformEntry>();
+
+/**
+ * Registers runtime and (optionally) UI concerns for one platform in one call.
+ */
+export function registerExtensionPlatform(entry: ExtensionPlatformEntry): void {
+  registerPlatform(entry.runtime);
+  if (entry.ui !== undefined) {
+    registerPlatformUi(entry.ui);
+  }
+  extensionPlatforms.set(entry.runtime.id, entry);
+}
+
+/**
+ * Returns unified platform entries currently known to the extension.
+ */
+export function listExtensionPlatforms(): ExtensionPlatformEntry[] {
+  // Keep this aligned with runtime order to preserve existing UI expectations.
+  const runtimeById = new Map(listPlatforms().map((entry) => [entry.id, entry]));
+  const uiById = new Map(listPlatformUis().map((entry) => [entry.id, entry]));
+  return Array.from(runtimeById.values()).map((runtime) => {
+    const ui = uiById.get(runtime.id);
+    return ui !== undefined ? { runtime, ui } : { runtime };
+  });
+}
+
+/**
+ * Compatibility API: register runtime-only platform (existing public surface).
+ */
+export function registerRuntimePlatform(entry: PlatformManifestEntry): void {
+  registerExtensionPlatform({ runtime: entry });
+}

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -101,6 +101,7 @@ describe('extension activation', () => {
       };
     };
     const uiManifest = (await import('../../src/extension/platform-view-manifest')) as typeof import('../../src/extension/platform-view-manifest');
+    const unifiedManifest = (await import('../../src/extension/platform-extension-model')) as typeof import('../../src/extension/platform-extension-model');
     const context = {
       subscriptions: [] as Array<{ dispose: () => void }>,
       workspaceState: { get: vi.fn(), update: vi.fn() },
@@ -141,6 +142,21 @@ describe('extension activation', () => {
       expect.objectContaining({ id: 'tec1' }),
       expect.objectContaining({ id: 'tec1g' }),
     ]);
+    expect(unifiedManifest.listExtensionPlatforms()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          runtime: expect.objectContaining({ id: 'simple' }),
+        }),
+        expect.objectContaining({
+          runtime: expect.objectContaining({ id: 'tec1' }),
+          ui: expect.objectContaining({ id: 'tec1' }),
+        }),
+        expect.objectContaining({
+          runtime: expect.objectContaining({ id: 'tec1g' }),
+          ui: expect.objectContaining({ id: 'tec1g' }),
+        }),
+      ])
+    );
   }, 20000);
 
   it('forces asm documents to z80-asm when available', async () => {


### PR DESCRIPTION
## Summary
Completes #225 by introducing a canonical extension-side platform registration model that can register runtime and UI concerns together.

## Changes
- Added `src/extension/platform-extension-model.ts`
  - `registerExtensionPlatform({ runtime, ui? })`
  - `listExtensionPlatforms()`
  - compatibility wrapper `registerRuntimePlatform()` for runtime-only API calls
- Updated `extension.ts`
  - built-in TEC-1 and TEC-1G now register via one extension model call each
  - `Debug80Api.registerPlatform` remains available and maps to runtime-only wrapper
  - `Debug80Api.listPlatforms` remains runtime-oriented for compatibility
- Added activation test assertions for unified entries in `tests/extension/extension.test.ts`

## Why this helps
- Makes per-platform registration canonical at extension level
- Clarifies required runtime vs optional UI registration
- Reduces split orchestration points when adding/modifying a platform

## Validation
- `npm run build`
- `npm test`

Fixes #225

Made with [Cursor](https://cursor.com)