### PR TITLE
Split launch sequence source-state orchestration into focused module (#223)

### DIFF
--- a/src/debug/launch-sequence.ts
+++ b/src/debug/launch-sequence.ts
@@ -3,12 +3,9 @@
  */
 
 import * as fs from 'fs';
-import * as path from 'path';
 import type { DebugProtocol } from '@vscode/debugprotocol';
 import { resolveBundledTec1Rom } from './assembler';
 import { emitConsoleOutput } from './adapter-ui';
-import { buildSymbolIndex } from './symbol-service';
-import { SourceManager } from './source-manager';
 import type { SourceStateManager } from './source-state-manager';
 import type { PlatformRegistry } from './platform-registry';
 import { handleMatrixKeyRequest, handleMatrixModeRequest } from './matrix-request';
@@ -16,17 +13,16 @@ import {
   relativeIfPossible,
   resolveArtifacts,
   resolveAsmPath,
-  resolveDebugMapPath,
-  resolveExtraDebugMapPath,
   resolveRelative,
   type LaunchArgsHelpers,
 } from './launch-args';
-import { buildListingCacheKey, resolveBaseDir, resolveCacheDir, resolveListingSourcePath, resolveMappedPath } from './path-resolver';
+import { buildListingCacheKey, resolveBaseDir, resolveCacheDir } from './path-resolver';
 import { assembleIfRequested, normalizeStepLimit } from './launch-pipeline';
 import { loadProgramArtifacts, type PlatformKind } from './program-loader';
 import { resolveAssemblerBackend } from './assembler-backend';
 import { emitMainSource } from './adapter-ui';
 import { resolvePlatformProvider } from '../platforms/provider';
+import { buildLaunchSourceState } from './launch-source-state';
 import { createZ80Runtime } from '../z80/runtime';
 import type { MappingParseResult, SourceMapAnchor } from '../mapping/parser';
 import type { SourceMapIndex } from '../mapping/source-map';
@@ -267,66 +263,22 @@ export async function buildLaunchSession(
   });
 
   context.sessionState.listingPath = listingPath;
-  const preSourceRoots: string[] = [];
-  for (const r of merged.sourceRoots ?? []) {
-    preSourceRoots.push(resolveRelative(r, baseDir));
-  }
-  if (asmPath !== undefined && asmPath.length > 0) {
-    preSourceRoots.push(path.dirname(resolveRelative(asmPath, baseDir)));
-  }
-  context.sessionState.sourceRoots = preSourceRoots;
-  const resolvedSourceRoots =
-    preSourceRoots.length > 0 ? preSourceRoots : merged.sourceRoots ?? [];
   const extraListings = platformProvider.extraListings;
-  context.sourceState.setManager(
-    new SourceManager({
-      platform,
-      baseDir,
-      resolveRelative: (p, dir) => resolveRelative(p, dir),
-      resolveMappedPath: (file): string | undefined =>
-        resolveMappedPath(file, context.sessionState.listingPath, context.sessionState.sourceRoots),
-      relativeIfPossible: (filePath, dir) => relativeIfPossible(filePath, dir),
-      resolveExtraDebugMapPath: (p) => resolveExtraDebugMapPath(p, LAUNCH_ARGS_HELPERS),
-      resolveDebugMapPath: (args, dir, asm, listing) =>
-        resolveDebugMapPath(
-          args as LaunchRequestArguments,
-          dir,
-          asm,
-          listing,
-          LAUNCH_ARGS_HELPERS
-        ),
-      resolveListingSourcePath: (listing) => resolveListingSourcePath(listing),
-      logger: context.logger,
-    })
+  const builtSourceState = buildLaunchSourceState(
+    merged,
+    platform,
+    baseDir,
+    asmPath,
+    listingPath,
+    listingContent,
+    extraListings,
+    context.sourceState,
+    context.sessionState,
+    LAUNCH_ARGS_HELPERS,
+    context.logger
   );
 
-  const builtSourceState = context.sourceState.build({
-    listingContent,
-    listingPath,
-    ...(asmPath !== undefined && asmPath.length > 0 ? { asmPath } : {}),
-    ...(merged.sourceFile !== undefined && merged.sourceFile.length > 0
-      ? { sourceFile: merged.sourceFile }
-      : {}),
-    sourceRoots: resolvedSourceRoots,
-    extraListings,
-    mapArgs: {
-      ...(merged.artifactBase !== undefined && merged.artifactBase.length > 0
-        ? { artifactBase: merged.artifactBase }
-        : {}),
-      ...(merged.outputDir !== undefined && merged.outputDir.length > 0
-        ? { outputDir: merged.outputDir }
-        : {}),
-    },
-  });
-
   emitMainSource((event) => context.emitEvent(event as DebugProtocol.Event), context.sourceState.file);
-
-  const symbolIndex = buildSymbolIndex({
-    mapping: builtSourceState.mapping,
-    listingContent,
-    sourceFile: context.sourceState.file,
-  });
-  context.sourceState.lookupAnchors = symbolIndex.lookupAnchors;
 
   const emitPlatformEvent = (name: string) => (payload: unknown) =>
     context.emitDapEvent(name, payload);
@@ -376,8 +328,8 @@ export async function buildLaunchSession(
     mappingIndex: builtSourceState.mappingIndex,
     sourceRoots: builtSourceState.sourceRoots,
     extraListingPaths: builtSourceState.extraListingPaths,
-    symbolAnchors: symbolIndex.anchors,
-    symbolList: symbolIndex.list,
+    symbolAnchors: builtSourceState.symbolAnchors,
+    symbolList: builtSourceState.symbolList,
     loadedProgram: program,
     loadedEntry: entry,
     restartCaptureAddress,

--- a/src/debug/launch-source-state.ts
+++ b/src/debug/launch-source-state.ts
@@ -1,0 +1,116 @@
+/**
+ * @fileoverview Source-state setup for launch session assembly.
+ */
+
+import * as path from 'path';
+import { buildSymbolIndex } from './symbol-service';
+import { SourceManager } from './source-manager';
+import type { SourceStateManager } from './source-state-manager';
+import {
+  relativeIfPossible,
+  resolveDebugMapPath,
+  resolveExtraDebugMapPath,
+  resolveRelative,
+  type LaunchArgsHelpers,
+} from './launch-args';
+import {
+  resolveListingSourcePath,
+  resolveMappedPath,
+} from './path-resolver';
+import type { PlatformKind } from './program-loader';
+import type { MappingParseResult, SourceMapAnchor } from '../mapping/parser';
+import type { SourceMapIndex } from '../mapping/source-map';
+import type { Logger } from '../util/logger';
+import type { LaunchRequestArguments } from './types';
+import type { SessionStateShape } from './session-state';
+
+export interface LaunchSourceBuildResult {
+  sourceRoots: string[];
+  extraListingPaths: string[];
+  mapping: MappingParseResult;
+  mappingIndex: SourceMapIndex;
+  symbolAnchors: SourceMapAnchor[];
+  symbolList: Array<{ name: string; address: number }>;
+}
+
+export function buildLaunchSourceState(
+  args: LaunchRequestArguments,
+  platform: PlatformKind,
+  baseDir: string,
+  asmPath: string | undefined,
+  listingPath: string,
+  listingContent: string,
+  extraListings: string[],
+  sourceState: SourceStateManager,
+  sessionState: SessionStateShape,
+  launchArgsHelpers: LaunchArgsHelpers,
+  logger: Logger
+): LaunchSourceBuildResult {
+  sessionState.listingPath = listingPath;
+  const preSourceRoots: string[] = [];
+  for (const root of args.sourceRoots ?? []) {
+    preSourceRoots.push(resolveRelative(root, baseDir));
+  }
+  if (asmPath !== undefined && asmPath.length > 0) {
+    preSourceRoots.push(path.dirname(resolveRelative(asmPath, baseDir)));
+  }
+  sessionState.sourceRoots = preSourceRoots;
+  const resolvedSourceRoots = preSourceRoots.length > 0 ? preSourceRoots : args.sourceRoots ?? [];
+
+  sourceState.setManager(
+    new SourceManager({
+      platform,
+      baseDir,
+      resolveRelative: (value, dir) => resolveRelative(value, dir),
+      resolveMappedPath: (file): string | undefined =>
+        resolveMappedPath(file, sessionState.listingPath, sessionState.sourceRoots),
+      relativeIfPossible: (filePath, dir) => relativeIfPossible(filePath, dir),
+      resolveExtraDebugMapPath: (value) => resolveExtraDebugMapPath(value, launchArgsHelpers),
+      resolveDebugMapPath: (launchArgs, dir, asm, listing) =>
+        resolveDebugMapPath(
+          launchArgs as LaunchRequestArguments,
+          dir,
+          asm,
+          listing,
+          launchArgsHelpers
+        ),
+      resolveListingSourcePath: (listing) => resolveListingSourcePath(listing),
+      logger,
+    })
+  );
+
+  const builtSourceState = sourceState.build({
+    listingContent,
+    listingPath,
+    ...(asmPath !== undefined && asmPath.length > 0 ? { asmPath } : {}),
+    ...(args.sourceFile !== undefined && args.sourceFile.length > 0
+      ? { sourceFile: args.sourceFile }
+      : {}),
+    sourceRoots: resolvedSourceRoots,
+    extraListings,
+    mapArgs: {
+      ...(args.artifactBase !== undefined && args.artifactBase.length > 0
+        ? { artifactBase: args.artifactBase }
+        : {}),
+      ...(args.outputDir !== undefined && args.outputDir.length > 0
+        ? { outputDir: args.outputDir }
+        : {}),
+    },
+  });
+
+  const symbolIndex = buildSymbolIndex({
+    mapping: builtSourceState.mapping,
+    listingContent,
+    sourceFile: sourceState.file,
+  });
+  sourceState.lookupAnchors = symbolIndex.lookupAnchors;
+
+  return {
+    sourceRoots: builtSourceState.sourceRoots,
+    extraListingPaths: builtSourceState.extraListingPaths,
+    mapping: builtSourceState.mapping,
+    mappingIndex: builtSourceState.mappingIndex,
+    symbolAnchors: symbolIndex.anchors,
+    symbolList: symbolIndex.list,
+  };
+}


### PR DESCRIPTION
## Summary
- extract source-root normalization, source manager setup, and symbol-index wiring into new `src/debug/launch-source-state.ts`
- simplify `buildLaunchSession` in `src/debug/launch-sequence.ts` so it stays focused on the launch pipeline and runtime assembly flow
- preserve existing launch outputs by returning mapping/source/symbol data from the extracted builder module

## Test plan
- [x] `npm run typecheck`
- [x] `npx eslint src/debug/launch-sequence.ts src/debug/launch-source-state.ts`
- [x] `npx vitest run tests/debug/adapter-integration.test.ts tests/debug/launch-args.test.ts tests/debug/launch-pipeline.test.ts`

Made with [Cursor](https://cursor.com)