### PR TITLE
Document platform UI/runtime behavior contracts (#232)

### DIFF
--- a/docs/design-platform-ui-runtime-behaviors.md
+++ b/docs/design-platform-ui-runtime-behaviors.md
@@ -1,0 +1,87 @@
+# Platform UI/Runtime Behavior Notes
+
+This note captures cross-cutting behavior that is easy to miss when reading only one file at a time.
+It focuses on the extension-host sidebar, TEC-1G runtime display updates, and serial pacing assumptions.
+
+## Scope and intent
+
+These behaviors are intentionally preserved as implementation details that shape perceived UI correctness:
+
+- TEC-1G matrix updates favor stable full-frame commits over per-write redraws.
+- Sidebar updates use session affinity guards to avoid stale cross-session updates.
+- Webview rehydration is message-driven and expects full-state replay after HTML replacement.
+- Serial send-file pacing is deliberately slow enough for monitor firmware input loops.
+
+## TEC-1G matrix staging and idle flush
+
+Source: `src/platforms/tec1g/runtime-matrix.ts`.
+
+The TEC-1G matrix runtime does not commit brightness arrays on every port write. Instead it:
+
+1. Stages RGB row data into temporary 64-cell buffers.
+2. Tracks which row-select bits have been visited.
+3. Commits to visible brightness arrays only when all rows were visited (`0xff` mask).
+
+This avoids "partial frame" flicker during active row scanning.
+
+To avoid stalls when firmware stops mid-scan, an idle fallback commits staged data after ~40 ms with no matrix activity (`TEC1G_MATRIX_IDLE_FLUSH_MS`). That gives roughly 25 fps worst-case UI progression while preserving the full-frame-first behavior.
+
+## Sidebar session affinity rules
+
+Source: `src/extension/platform-view-provider.ts`.
+
+The provider accepts update/serial events only when `shouldAcceptSession(sessionId)` passes:
+
+- if `sessionId` is omitted, accept (legacy/unspecified events),
+- if no current session id is tracked, accept,
+- otherwise require exact id match.
+
+This is the main guard against late events from a prior debug session mutating the current in-memory UI state.
+
+The provider still keeps parallel in-memory state for TEC-1 and TEC-1G, but only posts incremental messages for the currently active platform tab.
+
+## Webview rehydration semantics
+
+Sources: `src/extension/platform-view-provider.ts`, `webview/tec1/index.ts`, `webview/tec1g/index.ts`.
+
+Rehydration is triggered whenever the webview HTML is replaced (platform switch, reveal lifecycle, initial resolve). After replacement, the host must replay state in order:
+
+1. `projectStatus`
+2. `sessionStatus`
+3. full `update` snapshot (with `uiRevision`)
+4. optional `uiVisibility` (TEC-1G)
+5. optional `serialInit`
+6. `selectTab`
+7. memory refresh restart (if memory tab is active)
+
+Important properties:
+
+- `update` messages are treated as full-state snapshots from the host cache, not deltas.
+- the webview applies a `uiRevision` monotonic guard so stale updates are ignored.
+- non-`update` messages (`projectStatus`, `serial`, etc.) are not revision-gated.
+
+## Serial send-file pacing assumptions
+
+Source: `src/extension/platform-view-serial-actions.ts`.
+
+`handlePlatformSerialSendFile()` intentionally sends one character at a time via DAP custom requests:
+
+- 2 ms delay between characters,
+- 10 ms delay between lines,
+- `\r` appended per line.
+
+The pacing mirrors historical terminal input expectations in monitor firmware (TEC-1 MON-1B and TEC-1G monitor flows), reducing dropped input and parsing errors during Intel HEX loads.
+
+Operational detail:
+
+- the handler awaits `vscode.window.withProgress(...)`, so the message-handler promise stays active until transfer completion or cancellation.
+- this is intentionally synchronous from the provider perspective and affects lifecycle ordering versus fire-and-forget dispatch.
+
+## Maintenance checklist
+
+When changing any of these areas, verify all of the following:
+
+- matrix updates still commit on full row coverage and idle timeout,
+- session-id filtering remains in front of state mutation,
+- rehydration still replays a full update snapshot before tab-specific behavior,
+- serial pacing changes are tested against monitor load reliability.

--- a/docs/manual/part5/12-the-extension-host-ui.md
+++ b/docs/manual/part5/12-the-extension-host-ui.md
@@ -6,6 +6,8 @@ The debug80 sidebar panel is a VS Code WebviewView — an iframe-based panel emb
 
 This chapter covers the provider class: what state it holds, how the webview is created and destroyed, the complete message catalogue in both directions, and how the provider wires together the debug adapter, the workspace, and the UI.
 
+For lifecycle edge-cases that are maintained as behavior contracts (session affinity filtering, rehydration replay order, TEC-1G matrix commit policy, and serial send pacing), see `docs/design-platform-ui-runtime-behaviors.md`.
+
 ---
 
 ## The provider class

--- a/docs/manual/part5/README.md
+++ b/docs/manual/part5/README.md
@@ -4,3 +4,4 @@ Part V covers the sidebar panel that the user interacts with — how it is const
 
 - [Chapter 12 — The Extension Host UI](12-the-extension-host-ui.md)
 - [Chapter 13 — The Webview Panels](13-the-webview-panels.md)
+- [Platform UI/Runtime Behavior Notes](../../design-platform-ui-runtime-behaviors.md)

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -216,6 +216,9 @@ The debugger core runs against a platform abstraction that supplies memory and
 I/O devices. Platform selection is per target in `debug80.json`. The platform
 spec and configuration layout are defined in `docs/platforms.md`.
 
+For UI/runtime lifecycle nuances that are easy to miss in isolated files, see
+`docs/design-platform-ui-runtime-behaviors.md`.
+
 ## 10. Breakpoints and stack frames
 
 ### 10.1 Breakpoint resolution


### PR DESCRIPTION
## Summary
- add `docs/design-platform-ui-runtime-behaviors.md` to document cross-cutting behavior contracts that were previously scattered across code
- cover TEC-1G matrix staging/idle flush, sidebar session-affinity filtering, webview rehydration replay order, and serial send-file pacing assumptions
- link the new note from `docs/technical.md` and Part V manual docs for easier discoverability

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run tests/extension/platform-view-provider.test.ts tests/debug/adapter-integration.test.ts`

Made with [Cursor](https://cursor.com)