### PR TITLE
Fix duplicate Create Project empty-state CTA

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "viewsWelcome": [
       {
         "view": "debug80.platformView",
-        "contents": "No Debug80 project found in this workspace.\n[Create Project](command:debug80.createProject)\nCreate a .vscode/debug80.json configuration file to get started.",
+        "contents": "No Debug80 project found in this workspace.\nOpen the Platform view above and use Create Project to add a `.vscode/debug80.json` file.",
         "when": "!debug80.hasProject"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "viewsWelcome": [
       {
         "view": "debug80.platformView",
-        "contents": "No Debug80 project found in this workspace.\nOpen the Platform view above and use Create Project to add a `.vscode/debug80.json` file.",
+        "contents": "No Debug80 project found in this workspace.\n[Create Project](command:debug80.createProject)\nCreate a .vscode/debug80.json configuration file to get started.",
         "when": "!debug80.hasProject"
       }
     ],

--- a/tests/webview/common/project-root-button.test.ts
+++ b/tests/webview/common/project-root-button.test.ts
@@ -45,7 +45,7 @@ describe('project root button controller', () => {
     expect(messages).toContainEqual({ type: 'createProject' });
   });
 
-  it('offers create-project for an empty root and keeps root selection separate', () => {
+  it('keeps create-project hidden for an empty root so setup card owns the primary action', () => {
     const messages: PostedMessage[] = [];
     const controller = createProjectRootButtonController(
       createVscodeMock(messages),
@@ -60,11 +60,9 @@ describe('project root button controller', () => {
     });
 
     expect(rootButton.textContent).toBe('debug80');
-    expect(createButton.hidden).toBe(false);
-    expect(createButton.title).toContain('debug80');
-
-    createButton.click();
-    expect(messages).toContainEqual({ type: 'createProject', rootPath: '/workspace/debug80' });
+    expect(createButton.hidden).toBe(true);
+    expect(createButton.disabled).toBe(true);
+    expect(messages).toEqual([]);
   });
 
   it('keeps the root selector behavior for configured projects', () => {

--- a/tests/webview/common/project-root-button.test.ts
+++ b/tests/webview/common/project-root-button.test.ts
@@ -17,41 +17,29 @@ function createVscodeMock(messages: PostedMessage[]) {
 
 describe('project root button controller', () => {
   let rootButton: HTMLButtonElement;
-  let createButton: HTMLButtonElement;
 
   beforeEach(() => {
     document.body.innerHTML = `
       <button id="selectProject" type="button"></button>
-      <button id="createProject" type="button"></button>
     `;
     rootButton = document.getElementById('selectProject') as HTMLButtonElement;
-    createButton = document.getElementById('createProject') as HTMLButtonElement;
   });
 
   it('offers an open-folder action when there are no workspace roots', () => {
     const messages: PostedMessage[] = [];
-    const controller = createProjectRootButtonController(
-      createVscodeMock(messages),
-      rootButton,
-      createButton
-    );
+    const controller = createProjectRootButtonController(createVscodeMock(messages), rootButton);
 
     controller.applyProjectStatus({ roots: [], targetCount: 0 });
     rootButton.click();
 
     expect(rootButton.textContent).toBe('Open Folder');
     expect(rootButton.title).toContain('Open a folder');
-    expect(createButton.hidden).toBe(true);
     expect(messages).toContainEqual({ type: 'createProject' });
   });
 
-  it('keeps create-project hidden for an empty root so setup card owns the primary action', () => {
+  it('uses select action when a root exists without a project (Create Project is on the setup card)', () => {
     const messages: PostedMessage[] = [];
-    const controller = createProjectRootButtonController(
-      createVscodeMock(messages),
-      rootButton,
-      createButton
-    );
+    const controller = createProjectRootButtonController(createVscodeMock(messages), rootButton);
 
     controller.applyProjectStatus({
       rootPath: '/workspace/debug80',
@@ -60,18 +48,13 @@ describe('project root button controller', () => {
     });
 
     expect(rootButton.textContent).toBe('debug80');
-    expect(createButton.hidden).toBe(true);
-    expect(createButton.disabled).toBe(true);
-    expect(messages).toEqual([]);
+    rootButton.click();
+    expect(messages).toContainEqual({ type: 'selectProject' });
   });
 
   it('keeps the root selector behavior for configured projects', () => {
     const messages: PostedMessage[] = [];
-    const controller = createProjectRootButtonController(
-      createVscodeMock(messages),
-      rootButton,
-      createButton
-    );
+    const controller = createProjectRootButtonController(createVscodeMock(messages), rootButton);
 
     controller.applyProjectStatus({
       rootPath: '/workspace/debug80',
@@ -81,7 +64,6 @@ describe('project root button controller', () => {
 
     rootButton.click();
 
-    expect(createButton.hidden).toBe(true);
     expect(messages).toContainEqual({ type: 'selectProject' });
   });
 });

--- a/webview/common/project-root-button.ts
+++ b/webview/common/project-root-button.ts
@@ -57,8 +57,6 @@ export function createProjectRootButtonController(
     const rootConfigured = selected?.hasProject === true;
     const hasRoots = state.roots.length > 0;
     const hasSelectedRoot = selected !== undefined;
-    const isEmptyRoot = hasSelectedRoot && !rootConfigured;
-
     if (!hasRoots) {
       rootButton.disabled = false;
       rootButton.textContent = 'Open Folder';
@@ -89,13 +87,13 @@ export function createProjectRootButtonController(
     }
 
     if (createButton) {
-      createButton.hidden = !isEmptyRoot;
-      createButton.disabled = !isEmptyRoot;
+      // The setup card already provides the primary empty-state action; keep the
+      // header focused on root selection to avoid duplicate "Create Project" CTAs.
+      createButton.hidden = true;
+      createButton.disabled = true;
       createButton.textContent = 'Create Project';
-      createButton.title = isEmptyRoot
-        ? `Create a Debug80 project in ${selected.name}.`
-        : 'Create a Debug80 project in this workspace root.';
-      createButton.dataset.rootPath = isEmptyRoot ? selected.path : '';
+      createButton.title = 'Create a Debug80 project in this workspace root.';
+      createButton.dataset.rootPath = '';
     }
   };
 

--- a/webview/common/project-root-button.ts
+++ b/webview/common/project-root-button.ts
@@ -37,10 +37,13 @@ function selectedRoot(
   return roots[0];
 }
 
+/**
+ * Controls the Project root selector only. Empty-state "Create Project" lives on the setup card
+ * (`setupPrimaryAction` + `resolveSetupCardState`) — do not add a second header button for it.
+ */
 export function createProjectRootButtonController(
   vscode: VsCodeLike,
-  rootButton: HTMLButtonElement | null,
-  createButton: HTMLButtonElement | null
+  rootButton: HTMLButtonElement | null
 ): ProjectRootButtonController {
   let state: ProjectRootButtonState = {
     roots: [],
@@ -85,16 +88,6 @@ export function createProjectRootButtonController(
       rootButton.dataset.action = 'select';
       delete rootButton.dataset.rootPath;
     }
-
-    if (createButton) {
-      // The setup card already provides the primary empty-state action; keep the
-      // header focused on root selection to avoid duplicate "Create Project" CTAs.
-      createButton.hidden = true;
-      createButton.disabled = true;
-      createButton.textContent = 'Create Project';
-      createButton.title = 'Create a Debug80 project in this workspace root.';
-      createButton.dataset.rootPath = '';
-    }
   };
 
   const handleRootClick = (): void => {
@@ -113,18 +106,7 @@ export function createProjectRootButtonController(
     vscode.postMessage({ type: 'selectProject' });
   };
 
-  const handleCreateClick = (): void => {
-    if (!createButton || createButton.hidden) {
-      return;
-    }
-    vscode.postMessage({
-      type: 'createProject',
-      ...(createButton.dataset.rootPath ? { rootPath: createButton.dataset.rootPath } : {}),
-    });
-  };
-
   rootButton?.addEventListener('click', handleRootClick);
-  createButton?.addEventListener('click', handleCreateClick);
 
   return {
     applyProjectStatus(status) {
@@ -137,7 +119,6 @@ export function createProjectRootButtonController(
     },
     dispose() {
       rootButton?.removeEventListener('click', handleRootClick);
-      createButton?.removeEventListener('click', handleCreateClick);
     },
   };
 }

--- a/webview/simple/index.html
+++ b/webview/simple/index.html
@@ -13,7 +13,6 @@
     <div class="project-control">
       <span class="project-label">Project</span>
       <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
-      <button class="project-action-button" id="createProject" type="button" hidden>Create Project</button>
     </div>
     <div class="project-control">
       <span class="project-label">Target</span>

--- a/webview/simple/index.ts
+++ b/webview/simple/index.ts
@@ -16,7 +16,6 @@ const TERMINAL_MAX = 8000;
 const vscode = acquireVscodeApi();
 
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
-const createProjectButton = document.getElementById('createProject') as HTMLButtonElement | null;
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
 const setupPrimaryAction = document.getElementById('setupPrimaryAction') as HTMLButtonElement | null;
@@ -41,7 +40,7 @@ let resizeTimer: number | null = null;
 
 const sessionStatusController = createSessionStatusController(vscode, sessionStatusButton);
 const stopOnEntryControl = wireStopOnEntryControl(vscode, stopOnEntryInput);
-const projectRootController = createProjectRootButtonController(vscode, selectProjectButton, createProjectButton);
+const projectRootController = createProjectRootButtonController(vscode, selectProjectButton);
 
 platformSelectEl?.addEventListener('change', () => {
   vscode.postMessage({ type: 'saveProjectConfig', platform: platformSelectEl.value });

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -13,7 +13,6 @@
       <div class="project-control">
         <span class="project-label">Project</span>
         <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
-        <button class="project-action-button" id="createProject" type="button" hidden>Create Project</button>
       </div>
       <div class="project-control">
         <span class="project-label">Target</span>

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -18,7 +18,6 @@ const DEFAULT_TAB: PanelTab =
     ? 'memory'
     : 'ui';
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
-const createProjectButton = document.getElementById('createProject') as HTMLButtonElement | null;
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
 const setupPrimaryAction = document.getElementById('setupPrimaryAction') as HTMLButtonElement | null;
@@ -89,11 +88,7 @@ const lcdRenderer = createLcdRenderer();
 const matrixRenderer = createMatrixRenderer();
 const sessionStatusController = createSessionStatusController(vscode, sessionStatusButton);
 const stopOnEntryControl = wireStopOnEntryControl(vscode, stopOnEntryInput);
-const projectRootController = createProjectRootButtonController(
-  vscode,
-  selectProjectButton,
-  createProjectButton
-);
+const projectRootController = createProjectRootButtonController(vscode, selectProjectButton);
 
 setupPrimaryAction?.addEventListener('click', () => {
   const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -13,7 +13,6 @@
       <div class="project-control">
         <span class="project-label">Project</span>
         <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
-        <button class="project-action-button" id="createProject" type="button" hidden>Create Project</button>
       </div>
       <div class="project-control">
         <span class="project-label">Target</span>

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -29,7 +29,6 @@ const DEFAULT_TAB: Tec1gPanelTab =
     : 'ui';
 
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
-const createProjectButton = document.getElementById('createProject') as HTMLButtonElement | null;
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
 const setupPrimaryAction = document.getElementById('setupPrimaryAction') as HTMLButtonElement | null;
@@ -83,7 +82,6 @@ const visibilityController = createVisibilityController(vscode);
 
 const projectStatusUi = createTec1gProjectStatusUi(vscode, {
   selectProjectButton,
-  createProjectButton,
   setupCard,
   setupCardText,
   setupPrimaryAction,

--- a/webview/tec1g/tec1g-project-status-ui.ts
+++ b/webview/tec1g/tec1g-project-status-ui.ts
@@ -9,7 +9,6 @@ import { resolveSetupCardState } from '../common/setup-card-state';
 
 export type Tec1gProjectStatusElements = {
   selectProjectButton: HTMLButtonElement | null;
-  createProjectButton: HTMLButtonElement | null;
   setupCard: HTMLElement | null;
   setupCardText: HTMLElement | null;
   setupPrimaryAction: HTMLButtonElement | null;
@@ -73,7 +72,6 @@ export function createTec1gProjectStatusUi(
 ): Tec1gProjectStatusUi {
   const {
     selectProjectButton,
-    createProjectButton,
     setupCard,
     setupCardText,
     setupPrimaryAction,
@@ -84,7 +82,7 @@ export function createTec1gProjectStatusUi(
   let currentRoots: Array<{ name: string; path: string; hasProject: boolean }> = [];
   let setupPrimaryActionType: 'openWorkspaceFolder' | 'createProject' = 'openWorkspaceFolder';
 
-  const projectRootController = createProjectRootButtonController(vscode, selectProjectButton, createProjectButton);
+  const projectRootController = createProjectRootButtonController(vscode, selectProjectButton);
 
   setupPrimaryAction?.addEventListener('click', () => {
     const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Two controls could show **Create Project** in the empty state:

1. **Setup card** — label from `resolveSetupCardState` (`setup-card-state.ts`), rendered on `#setupPrimaryAction`.
2. **Project header** — `#createProject` next to the root selector, wired through `project-root-button.ts`.

Hiding the header button with `hidden` was fragile; the real fix is to **not ship a second button** at all.

## Changes

- Removed `#createProject` from the simple, TEC-1, and TEC-1G platform HTML.
- Simplified `createProjectRootButtonController` to only drive the **Project** root button (`#selectProject`). Documented that empty-state Create Project belongs on the setup card only.
- Reverted the earlier `viewsWelcome` copy change in `package.json` so manifest behavior is unchanged from before that experiment.

## Testing

- `npm run build`
- `npm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7b18204-ea4b-42ff-9bfb-3b190edb8ad1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7b18204-ea4b-42ff-9bfb-3b190edb8ad1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

