### PR TITLE
Make root debug80.json canonical

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ To make a folder debuggable quickly in VS Code:
 This command scaffolds a Simple-platform config:
 - Creates `.vscode/debug80.json` with a default target (tries `src/main.asm`, or the first `.asm` it finds).
 - Creates `.vscode/launch.json` with a Debug80 launch configuration.
+- It does not generate `.vscode/settings.json`; the extension already contributes the relevant file associations.
 
 After scaffolding, adjust the `sourceFile`, `outputDir`, and `artifactBase` as needed, then press F5.
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   ],
   "activationEvents": [
     "onDebugResolve:z80",
-    "workspaceContains:**/.vscode/debug80.json",
     "workspaceContains:**/debug80.json",
+    "workspaceContains:**/.vscode/debug80.json",
     "onLanguage:asm",
     "onLanguage:asm-collection",
     "onLanguage:zax",
@@ -51,7 +51,7 @@
     "viewsWelcome": [
       {
         "view": "debug80.platformView",
-        "contents": "No Debug80 project found in this workspace.\n[Create Project](command:debug80.createProject)\nCreate a .vscode/debug80.json configuration file to get started.",
+        "contents": "No Debug80 project found in this workspace.\n[Create Project](command:debug80.createProject)\nCreate a debug80.json configuration file to get started.",
         "when": "!debug80.hasProject"
       }
     ],
@@ -240,7 +240,7 @@
             "properties": {
               "projectConfig": {
                 "type": "string",
-                "description": "Path to debug80 project config (defaults to ${workspaceFolder}/.vscode/debug80.json)"
+                "description": "Path to debug80 project config (defaults to ${workspaceFolder}/debug80.json)"
               },
               "target": {
                 "type": "string",

--- a/src/extension/project-config.ts
+++ b/src/extension/project-config.ts
@@ -67,8 +67,8 @@ export function resolveProjectPlatform(config: ProjectConfig | undefined): strin
 }
 
 export const PROJECT_CONFIG_CANDIDATES = [
-  path.join('.vscode', 'debug80.json'),
   'debug80.json',
+  path.join('.vscode', 'debug80.json'),
   '.debug80.json',
 ];
 

--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -203,36 +203,6 @@ export function createDefaultLaunchConfig(): Record<string, unknown> {
   };
 }
 
-function ensureWorkspaceSettings(vscodeDir: string): void {
-  const settingsPath = path.join(vscodeDir, 'settings.json');
-  let settings: Record<string, unknown> = {};
-  if (fs.existsSync(settingsPath)) {
-    try {
-      const raw = fs.readFileSync(settingsPath, 'utf-8');
-      const parsed = JSON.parse(raw) as unknown;
-      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        settings = parsed as Record<string, unknown>;
-      }
-    } catch {
-      // Keep defaults if settings cannot be parsed.
-    }
-  }
-
-  const associationsRaw = settings['files.associations'];
-  const associations =
-    associationsRaw !== null &&
-    associationsRaw !== undefined &&
-    typeof associationsRaw === 'object' &&
-    !Array.isArray(associationsRaw)
-      ? ({ ...associationsRaw } as Record<string, unknown>)
-      : {};
-  if (typeof associations['*.z80'] !== 'string') {
-    associations['*.z80'] = 'z80-asm';
-  }
-  settings['files.associations'] = associations;
-  fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
-}
-
 export async function scaffoldProject(
   folder: vscode.WorkspaceFolder,
   includeLaunch: boolean,
@@ -284,7 +254,6 @@ export async function scaffoldProject(
   if (includeLaunch) {
     ensureDirExists(vscodeDir);
   }
-  ensureWorkspaceSettings(vscodeDir);
 
   let created = false;
 

--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -6,7 +6,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { ensureDirExists, inferDefaultTarget } from '../debug/config-utils';
-import { DEBUG80_PROJECT_VERSION, listProjectSourceFiles } from './project-config';
+import {
+  DEBUG80_PROJECT_VERSION,
+  findProjectConfigPath,
+  listProjectSourceFiles,
+} from './project-config';
 import { TEC1_APP_START_DEFAULT } from '../platforms/tec1/constants';
 import {
   TEC1G_APP_START_DEFAULT,
@@ -203,6 +207,36 @@ export function createDefaultLaunchConfig(): Record<string, unknown> {
   };
 }
 
+function ensureWorkspaceSettings(vscodeDir: string): void {
+  const settingsPath = path.join(vscodeDir, 'settings.json');
+  let settings: Record<string, unknown> = {};
+  if (fs.existsSync(settingsPath)) {
+    try {
+      const raw = fs.readFileSync(settingsPath, 'utf-8');
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        settings = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Keep defaults if settings cannot be parsed.
+    }
+  }
+
+  const associationsRaw = settings['files.associations'];
+  const associations =
+    associationsRaw !== null &&
+    associationsRaw !== undefined &&
+    typeof associationsRaw === 'object' &&
+    !Array.isArray(associationsRaw)
+      ? ({ ...associationsRaw } as Record<string, unknown>)
+      : {};
+  if (typeof associations['*.z80'] !== 'string') {
+    associations['*.z80'] = 'z80-asm';
+  }
+  settings['files.associations'] = associations;
+  fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
+}
+
 export async function scaffoldProject(
   folder: vscode.WorkspaceFolder,
   includeLaunch: boolean,
@@ -211,9 +245,9 @@ export async function scaffoldProject(
 ): Promise<boolean> {
   const workspaceRoot = folder.uri.fsPath;
   const vscodeDir = path.join(workspaceRoot, '.vscode');
-  const configPath = path.join(vscodeDir, 'debug80.json');
+  const configPath = path.join(workspaceRoot, 'debug80.json');
   const launchPath = path.join(vscodeDir, 'launch.json');
-  const configExists = fs.existsSync(configPath);
+  const configExists = findProjectConfigPath(folder) !== undefined;
 
   const inferred = inferDefaultTarget(workspaceRoot);
   const plan = configExists ? undefined : await buildScaffoldPlan(folder, inferred, preselectedPlatform);
@@ -254,6 +288,7 @@ export async function scaffoldProject(
   if (includeLaunch) {
     ensureDirExists(vscodeDir);
   }
+  ensureWorkspaceSettings(vscodeDir);
 
   let created = false;
 
@@ -274,17 +309,17 @@ export async function scaffoldProject(
       }
       fs.writeFileSync(configPath, `${JSON.stringify(defaultConfig, null, 2)}\n`);
       void vscode.window.showInformationMessage(
-        `Debug80: Created ${platformDisplayName(scaffoldPlan.platform)} project in .vscode/debug80.json targeting ${scaffoldPlan.sourceFile}.`
+        `Debug80: Created ${platformDisplayName(scaffoldPlan.platform)} project in debug80.json targeting ${scaffoldPlan.sourceFile}.`
       );
       created = true;
     } catch (err) {
       void vscode.window.showErrorMessage(
-        `Debug80: Failed to write .vscode/debug80.json: ${String(err)}`
+        `Debug80: Failed to write debug80.json: ${String(err)}`
       );
       return false;
     }
   } else if (!includeLaunch) {
-    void vscode.window.showInformationMessage('.vscode/debug80.json already exists.');
+    void vscode.window.showInformationMessage('Debug80 project config already exists.');
   }
 
   if (includeLaunch) {

--- a/src/extension/workspace-selection.ts
+++ b/src/extension/workspace-selection.ts
@@ -2,13 +2,14 @@
  * @file Workspace selection and project-detection state for Debug80.
  */
 
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { PlatformViewProvider } from './platform-view-provider';
 import { findProjectConfigPath } from './project-config';
 import { resolvePreferredTargetName } from './project-target-selection';
 
 const WORKSPACE_KEY = 'debug80.selectedWorkspace';
-const PROJECT_CONFIG_WATCH_GLOBS = ['**/.vscode/debug80.json', '**/debug80.json', '**/.debug80.json'];
+const PROJECT_CONFIG_WATCH_GLOBS = ['**/debug80.json', '**/.vscode/debug80.json', '**/.debug80.json'];
 
 export type ResolveWorkspaceFolderOptions = {
   prompt?: boolean;
@@ -114,7 +115,7 @@ export class WorkspaceSelectionController {
           description: folder.uri.fsPath,
           detail:
             projectConfig !== undefined
-              ? `Configured Debug80 root (${projectConfig.split('/').slice(-2).join('/')})`
+              ? `Configured Debug80 root (${path.relative(folder.uri.fsPath, projectConfig).split(path.sep).join('/')})`
               : 'No Debug80 project config in this root',
           folder,
         };

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const projectConfigPath = path.normalize('/workspace/tec1g-mon3/.vscode/debug80.json');
+const projectConfigPath = path.normalize('/workspace/tec1g-mon3/debug80.json');
 
 const registeredCommands = new Map<string, (...args: unknown[]) => unknown>();
 const registerCommand = vi.fn((name: string, callback: (...args: unknown[]) => unknown) => {
@@ -345,8 +345,8 @@ describe('registerExtensionCommands', () => {
 
     const oldRoot = '/workspace/tec1g-mon3';
     const newRoot = '/workspace/tec1-mon1';
-    const oldConfigPath = path.normalize(`${oldRoot}/.vscode/debug80.json`);
-    const newConfigPath = path.normalize(`${newRoot}/.vscode/debug80.json`);
+    const oldConfigPath = path.normalize(`${oldRoot}/debug80.json`);
+    const newConfigPath = path.normalize(`${newRoot}/debug80.json`);
     workspaceFolders = [
       { name: 'tec1g-mon3', uri: { fsPath: oldRoot }, index: 0 },
       { name: 'tec1-mon1', uri: { fsPath: newRoot }, index: 1 },
@@ -419,8 +419,8 @@ describe('registerExtensionCommands', () => {
 
     const rootA = '/workspace/tec1-mon1';
     const rootB = '/workspace/tec1-mon2';
-    const configAPath = path.normalize(`${rootA}/.vscode/debug80.json`);
-    const configBPath = path.normalize(`${rootB}/.vscode/debug80.json`);
+    const configAPath = path.normalize(`${rootA}/debug80.json`);
+    const configBPath = path.normalize(`${rootB}/debug80.json`);
     workspaceFolders = [
       { name: 'tec1-mon1', uri: { fsPath: rootA }, index: 0 },
       { name: 'tec1-mon2', uri: { fsPath: rootB }, index: 1 },

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -223,7 +223,7 @@ describe('registerExtensionCommands', () => {
     expect(result).toBe(true);
     expect(rememberWorkspace).toHaveBeenCalledWith(folder);
     expect(refreshIdleView).toHaveBeenCalled();
-    expect(scaffoldProject).toHaveBeenCalledWith(folder, false, undefined);
+    expect(scaffoldProject).toHaveBeenCalledWith(folder, false, undefined, undefined);
   });
 
   it('forces a prompt when selecting the active target', async () => {

--- a/tests/extension/debug-configuration-provider.test.ts
+++ b/tests/extension/debug-configuration-provider.test.ts
@@ -1,8 +1,8 @@
 import path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const cavernsProjectConfigPath = path.normalize('/workspace/caverns80/.vscode/debug80.json');
-const debug80ProjectConfigPath = path.normalize('/workspace/debug80/.vscode/debug80.json');
+const cavernsProjectConfigPath = path.normalize('/workspace/caverns80/debug80.json');
+const debug80ProjectConfigPath = path.normalize('/workspace/debug80/debug80.json');
 
 const executeCommand = vi.fn();
 const showInformationMessage = vi.fn();

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -20,7 +20,7 @@ const {
       entrySource: 'src/main.asm',
     })),
     findProjectConfigPath: vi.fn(
-      (folder: { uri: { fsPath: string } }) => `${folder.uri.fsPath}/.vscode/debug80.json`
+      (folder: { uri: { fsPath: string } }) => `${folder.uri.fsPath}/debug80.json`
     ),
     listProjectTargetChoices: vi.fn(() => [
       { name: 'app', description: 'src/main.asm', detail: 'src/main.asm' },

--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -282,5 +282,10 @@ describe('project-scaffolding helpers', () => {
     expect(showInformationMessage).toHaveBeenCalledWith(
       'Debug80: Created TEC-1G project in .vscode/debug80.json targeting src/main.asm.'
     );
+
+    const settingsWrite = writeFileSync.mock.calls.find(([filePath]) =>
+      String(filePath).replace(/\\/g, '/').endsWith('/.vscode/settings.json')
+    );
+    expect(settingsWrite).toBeUndefined();
   });
 });

--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -32,7 +32,11 @@ vi.mock('fs', async () => {
     ...actual,
     existsSync: vi.fn((candidate: string) => {
       const normalized = candidate.replace(/\\/g, '/');
-      return !normalized.endsWith('/.vscode/debug80.json');
+      return (
+        !normalized.endsWith('/debug80.json') &&
+        !normalized.endsWith('/.vscode/debug80.json') &&
+        !normalized.endsWith('/.debug80.json')
+      );
     }),
     writeFileSync: vi.fn(),
   };
@@ -260,7 +264,7 @@ describe('project-scaffolding helpers', () => {
     expect(writeFileSync).toHaveBeenCalled();
 
     const configWrite = writeFileSync.mock.calls.find(([filePath]) =>
-      String(filePath).replace(/\\/g, '/').endsWith('/.vscode/debug80.json')
+      String(filePath).replace(/\\/g, '/').endsWith('/debug80.json')
     );
     expect(configWrite).toBeDefined();
 
@@ -280,12 +284,7 @@ describe('project-scaffolding helpers', () => {
     );
 
     expect(showInformationMessage).toHaveBeenCalledWith(
-      'Debug80: Created TEC-1G project in .vscode/debug80.json targeting src/main.asm.'
+      'Debug80: Created TEC-1G project in debug80.json targeting src/main.asm.'
     );
-
-    const settingsWrite = writeFileSync.mock.calls.find(([filePath]) =>
-      String(filePath).replace(/\\/g, '/').endsWith('/.vscode/settings.json')
-    );
-    expect(settingsWrite).toBeUndefined();
   });
 });

--- a/tests/extension/project-status.test.ts
+++ b/tests/extension/project-status.test.ts
@@ -9,9 +9,8 @@ vi.mock('vscode', () => ({}));
 describe('project-status', () => {
   it('resolves the selected project target and program file', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-project-status-'));
-    fs.mkdirSync(path.join(root, '.vscode'), { recursive: true });
     fs.writeFileSync(
-      path.join(root, '.vscode', 'debug80.json'),
+      path.join(root, 'debug80.json'),
       JSON.stringify({
         defaultTarget: 'app',
         targets: {
@@ -24,7 +23,7 @@ describe('project-status', () => {
     const summary = resolveProjectStatusSummary(
       {
         get: vi.fn((key: string) =>
-          key === `debug80.selectedTarget:${path.join(root, '.vscode', 'debug80.json')}`
+          key === `debug80.selectedTarget:${path.join(root, 'debug80.json')}`
             ? 'serial'
             : undefined
         ),

--- a/tests/extension/workspace-selection.test.ts
+++ b/tests/extension/workspace-selection.test.ts
@@ -87,7 +87,7 @@ describe('WorkspaceSelectionController', () => {
     ];
     existsSync.mockImplementation(
       (candidate: string) =>
-        path.normalize(candidate) === path.normalize('/workspace/caverns80/.vscode/debug80.json')
+        path.normalize(candidate) === path.normalize('/workspace/caverns80/debug80.json')
     );
 
     const { WorkspaceSelectionController } = await import(
@@ -120,8 +120,8 @@ describe('WorkspaceSelectionController', () => {
     ];
     existsSync.mockImplementation(
       (candidate: string) =>
-        path.normalize(candidate) === path.normalize('/workspace/debug80/.vscode/debug80.json') ||
-        path.normalize(candidate) === path.normalize('/workspace/caverns80/.vscode/debug80.json')
+        path.normalize(candidate) === path.normalize('/workspace/debug80/debug80.json') ||
+        path.normalize(candidate) === path.normalize('/workspace/caverns80/debug80.json')
     );
     showQuickPick.mockResolvedValueOnce({
       label: 'caverns80',
@@ -167,7 +167,7 @@ describe('WorkspaceSelectionController', () => {
     storedPath = '/workspace/caverns80';
     existsSync.mockImplementation(
       (candidate: string) =>
-        path.normalize(candidate) === path.normalize('/workspace/caverns80/.vscode/debug80.json')
+        path.normalize(candidate) === path.normalize('/workspace/caverns80/debug80.json')
     );
     resolvePreferredTargetName.mockReturnValue('app');
 
@@ -195,7 +195,7 @@ describe('WorkspaceSelectionController', () => {
         type: 'z80',
         request: 'launch',
         name: 'Debug80: Current Project',
-        projectConfig: path.normalize('/workspace/caverns80/.vscode/debug80.json'),
+        projectConfig: path.normalize('/workspace/caverns80/debug80.json'),
       })
     );
   });


### PR DESCRIPTION
Implements issue #277: prefer root-level debug80.json for new projects, config resolution, and workspace/project detection while retaining legacy .vscode/debug80.json support.