### PR TITLE
Define next-gen debug80 manifest contract

### DIFF
--- a/src/debug/launch-args.ts
+++ b/src/debug/launch-args.ts
@@ -27,6 +27,82 @@ function mergeNestedPlatformBlock<T extends object>(
   return Object.keys(out).length > 0 ? (out as T) : undefined;
 }
 
+type LaunchConfigManifest = Partial<LaunchRequestArguments> & {
+  projectPlatform?: string;
+  defaultProfile?: string;
+  source?: string;
+  profiles?: Record<string, { platform?: string } | undefined>;
+  targets?: Record<
+    string,
+    Partial<LaunchRequestArguments> & { sourceFile?: string; source?: string; profile?: string }
+  >;
+  defaultTarget?: string;
+  target?: string;
+};
+
+type LaunchTargetConfig = Partial<LaunchRequestArguments> & {
+  sourceFile?: string;
+  source?: string;
+  profile?: string;
+};
+
+function normalizeNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed.toLowerCase() : undefined;
+}
+
+function resolveProfilePlatform(
+  profileName: string | undefined,
+  cfg: LaunchConfigManifest
+): string | undefined {
+  const normalizedName = normalizeNonEmptyString(profileName);
+  if (normalizedName === undefined) {
+    return undefined;
+  }
+  const profile = cfg.profiles?.[normalizedName];
+  return normalizeNonEmptyString(profile?.platform);
+}
+
+function resolveLaunchPlatform(
+  args: LaunchRequestArguments,
+  cfg: LaunchConfigManifest,
+  targetCfg: LaunchTargetConfig | undefined
+): string | undefined {
+  const explicit =
+    normalizeNonEmptyString(args.platform) ??
+    normalizeNonEmptyString(targetCfg?.platform) ??
+    normalizeNonEmptyString(cfg.platform) ??
+    normalizeNonEmptyString(cfg.projectPlatform);
+  if (explicit !== undefined) {
+    return explicit;
+  }
+
+  const targetProfile = resolveProfilePlatform(targetCfg?.profile, cfg);
+  if (targetProfile !== undefined) {
+    return targetProfile;
+  }
+
+  const defaultProfile = resolveProfilePlatform(cfg.defaultProfile, cfg);
+  if (defaultProfile !== undefined) {
+    return defaultProfile;
+  }
+
+  const profiles = Object.values(
+    cfg.profiles ?? {}
+  ) as Array<{ platform?: string } | undefined>;
+  for (const profile of profiles) {
+    const platform = normalizeNonEmptyString(profile?.platform);
+    if (platform !== undefined) {
+      return platform;
+    }
+  }
+
+  return undefined;
+}
+
 /**
  * When `romHex` lives only under another target's `tec1g` block (common for MON-3),
  * the active target's partial `tec1g` would otherwise drop it after merge.
@@ -140,13 +216,7 @@ export function populateFromConfig(
   }
 
   try {
-    let cfg: {
-      defaultTarget?: string;
-      targets?: Record<
-        string,
-        Partial<LaunchRequestArguments> & { sourceFile?: string; source?: string }
-      >;
-    } & (Partial<LaunchRequestArguments> & { sourceFile?: string; source?: string });
+    let cfg: LaunchConfigManifest;
 
     if (configPath.endsWith('package.json')) {
       const pkgRaw = fs.readFileSync(configPath, 'utf-8');
@@ -163,7 +233,7 @@ export function populateFromConfig(
 
     const targets = cfg.targets ?? {};
     const targetName = args.target ?? cfg.target ?? cfg.defaultTarget ?? Object.keys(targets)[0];
-    const targetCfg = (targetName !== undefined ? targets[targetName] : undefined) ?? undefined;
+      const targetCfg = (targetName !== undefined ? targets[targetName] : undefined) ?? undefined;
 
     const merged: LaunchRequestArguments = {
       ...cfg,
@@ -251,7 +321,10 @@ export function populateFromConfig(
     }
 
     const platformResolved = args.platform ?? targetCfg?.platform ?? cfg.platform;
-    if (platformResolved !== undefined) {
+    const launchPlatformResolved = resolveLaunchPlatform(args, cfg, targetCfg);
+    if (launchPlatformResolved !== undefined) {
+      merged.platform = launchPlatformResolved;
+    } else if (platformResolved !== undefined) {
       merged.platform = platformResolved;
     }
 

--- a/src/debug/types.ts
+++ b/src/debug/types.ts
@@ -34,7 +34,7 @@ export interface ProjectProfileConfig {
   /** Optional display note for the profile */
   description?: string;
   /** Baseline platform id for this profile */
-  platform?: Debug80PlatformId | string;
+  platform?: string;
   /** Bundled assets attached to this profile */
   bundledAssets?: Record<string, BundledAssetReference>;
 }

--- a/src/debug/types.ts
+++ b/src/debug/types.ts
@@ -11,6 +11,35 @@ import type {
 import type { TerminalConfig } from './terminal-types';
 
 /**
+ * Debug80 platform ids supported by the project manifest.
+ */
+export type Debug80PlatformId = 'simple' | 'tec1' | 'tec1g';
+
+/**
+ * Reference to a bundled asset shipped with the extension.
+ */
+export interface BundledAssetReference {
+  /** Stable bundle id, for example `tec1g/mon3/v1` */
+  bundleId: string;
+  /** Path inside the bundle directory */
+  path: string;
+  /** Optional workspace-relative destination for materialization */
+  destination?: string;
+}
+
+/**
+ * Named project profile in the next-generation manifest.
+ */
+export interface ProjectProfileConfig {
+  /** Optional display note for the profile */
+  description?: string;
+  /** Baseline platform id for this profile */
+  platform?: Debug80PlatformId | string;
+  /** Bundled assets attached to this profile */
+  bundledAssets?: Record<string, BundledAssetReference>;
+}
+
+/**
  * Launch request arguments for the Z80 debug adapter.
  * Extends the standard DAP launch request with Z80-specific options.
  */
@@ -64,15 +93,24 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
  */
 export interface ProjectConfig {
   /** Schema version for the Debug80 project manifest/config model */
-  projectVersion?: 1;
+  projectVersion?: 1 | 2;
   /** Project-level platform identity chosen at project creation time */
   projectPlatform?: string;
+  /** Named reusable profiles for the next-generation manifest */
+  profiles?: Record<string, ProjectProfileConfig>;
+  /** Shared bundled asset references, keyed by logical name */
+  bundledAssets?: Record<string, BundledAssetReference>;
+  /** Default profile name when the manifest uses profiles */
+  defaultProfile?: string;
   /** Default target to use when none specified */
   defaultTarget?: string;
   /** Alternative name for defaultTarget */
   target?: string;
   /** Named target configurations */
-  targets?: Record<string, Partial<LaunchRequestArguments> & { source?: string }>;
+  targets?: Record<
+    string,
+    Partial<LaunchRequestArguments> & { source?: string; profile?: string }
+  >;
   /** Fields that can be specified at the root level */
   asm?: string;
   assembler?: string;

--- a/src/extension/project-config.ts
+++ b/src/extension/project-config.ts
@@ -7,7 +7,59 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import type { ProjectConfig } from '../debug/types';
 
-export const DEBUG80_PROJECT_VERSION = 1 as const;
+export const DEBUG80_PROJECT_VERSION = 2 as const;
+
+const LEGACY_DEBUG80_PROJECT_VERSION = 1 as const;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+function isBundledAssetReference(value: unknown): boolean {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const o = value as Record<string, unknown>;
+  return isNonEmptyString(o.bundleId) && isNonEmptyString(o.path) && (
+    o.destination === undefined || isNonEmptyString(o.destination)
+  );
+}
+
+function isProjectProfileConfig(value: unknown): boolean {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const o = value as Record<string, unknown>;
+  if (o.platform !== undefined && !isNonEmptyString(o.platform)) {
+    return false;
+  }
+  if (o.description !== undefined && !isNonEmptyString(o.description)) {
+    return false;
+  }
+  const bundledAssets = o.bundledAssets;
+  if (bundledAssets === undefined) {
+    return true;
+  }
+  if (bundledAssets === null || typeof bundledAssets !== 'object' || Array.isArray(bundledAssets)) {
+    return false;
+  }
+  return Object.values(bundledAssets).every((entry) => isBundledAssetReference(entry));
+}
+
+function normalizeProjectVersion(config: ProjectConfig): ProjectConfig {
+  const hasProfiles = Object.keys(config.profiles ?? {}).length > 0;
+  const hasBundledAssets = Object.keys(config.bundledAssets ?? {}).length > 0;
+  if (
+    config.projectVersion === DEBUG80_PROJECT_VERSION ||
+    (!hasProfiles && !hasBundledAssets && config.defaultProfile === undefined)
+  ) {
+    return config;
+  }
+  return {
+    ...config,
+    projectVersion: DEBUG80_PROJECT_VERSION,
+  };
+}
 
 export function isDebug80ProjectConfig(config: ProjectConfig | undefined): config is ProjectConfig {
   if (config === undefined) {
@@ -19,8 +71,50 @@ export function isDebug80ProjectConfig(config: ProjectConfig | undefined): confi
     return false;
   }
 
-  if (config.projectVersion !== undefined && config.projectVersion !== DEBUG80_PROJECT_VERSION) {
+  if (
+    config.projectVersion !== undefined &&
+    config.projectVersion !== LEGACY_DEBUG80_PROJECT_VERSION &&
+    config.projectVersion !== DEBUG80_PROJECT_VERSION
+  ) {
     return false;
+  }
+
+  const profiles = config.profiles;
+  if (profiles !== undefined) {
+    if (profiles === null || typeof profiles !== 'object' || Array.isArray(profiles)) {
+      return false;
+    }
+    if (!Object.values(profiles).every((profile) => isProjectProfileConfig(profile))) {
+      return false;
+    }
+    if (config.defaultProfile !== undefined && profiles[config.defaultProfile] === undefined) {
+      return false;
+    }
+  }
+
+  const bundledAssets = config.bundledAssets;
+  if (bundledAssets !== undefined) {
+    if (bundledAssets === null || typeof bundledAssets !== 'object' || Array.isArray(bundledAssets)) {
+      return false;
+    }
+    if (!Object.values(bundledAssets).every((asset) => isBundledAssetReference(asset))) {
+      return false;
+    }
+  }
+
+  for (const target of Object.values(targets)) {
+    if (target === undefined || typeof target !== 'object') {
+      continue;
+    }
+    const profileName = (target as { profile?: unknown }).profile;
+    if (profileName !== undefined) {
+      if (!isNonEmptyString(profileName)) {
+        return false;
+      }
+      if (profiles !== undefined && profiles[profileName] === undefined) {
+        return false;
+      }
+    }
   }
 
   return true;
@@ -56,8 +150,29 @@ export function resolveProjectPlatform(config: ProjectConfig | undefined): strin
     return config.platform.trim().toLowerCase();
   }
 
+  const defaultProfile = config.defaultProfile;
+  if (isNonEmptyString(defaultProfile)) {
+    const profile = config.profiles?.[defaultProfile];
+    if (profile !== undefined && isNonEmptyString(profile.platform)) {
+      return profile.platform.trim().toLowerCase();
+    }
+  }
+
+  for (const profile of Object.values(config.profiles ?? {})) {
+    if (profile !== undefined && isNonEmptyString(profile.platform)) {
+      return profile.platform.trim().toLowerCase();
+    }
+  }
+
   const targets = Object.values(config.targets ?? {});
   for (const target of targets) {
+    if (target !== undefined && isNonEmptyString((target as { profile?: unknown }).profile)) {
+      const profileName = (target as { profile?: string }).profile;
+      const profile = profileName !== undefined ? config.profiles?.[profileName] : undefined;
+      if (profile !== undefined && isNonEmptyString(profile.platform)) {
+        return profile.platform.trim().toLowerCase();
+      }
+    }
     if (typeof target?.platform === 'string' && target.platform.trim() !== '') {
       return target.platform.trim().toLowerCase();
     }
@@ -87,11 +202,11 @@ export function readProjectConfig(projectConfigPath: string): ProjectConfig | un
     if (projectConfigPath.endsWith('package.json')) {
       const pkgRaw = fs.readFileSync(projectConfigPath, 'utf-8');
       const pkg = JSON.parse(pkgRaw) as { debug80?: ProjectConfig };
-      return pkg.debug80;
+      return pkg.debug80 !== undefined ? normalizeProjectVersion(pkg.debug80) : undefined;
     }
 
     const raw = fs.readFileSync(projectConfigPath, 'utf-8');
-    return JSON.parse(raw) as ProjectConfig;
+    return normalizeProjectVersion(JSON.parse(raw) as ProjectConfig);
   } catch {
     return undefined;
   }
@@ -102,12 +217,12 @@ export function writeProjectConfig(projectConfigPath: string, config: ProjectCon
     if (projectConfigPath.endsWith('package.json')) {
       const pkgRaw = fs.readFileSync(projectConfigPath, 'utf-8');
       const pkg = JSON.parse(pkgRaw) as { debug80?: ProjectConfig } & Record<string, unknown>;
-      pkg.debug80 = config;
+      pkg.debug80 = normalizeProjectVersion(config);
       fs.writeFileSync(projectConfigPath, `${JSON.stringify(pkg, null, 2)}\n`);
       return true;
     }
 
-    fs.writeFileSync(projectConfigPath, `${JSON.stringify(config, null, 2)}\n`);
+    fs.writeFileSync(projectConfigPath, `${JSON.stringify(normalizeProjectVersion(config), null, 2)}\n`);
     return true;
   } catch {
     return false;

--- a/tests/debug/launch-args.test.ts
+++ b/tests/debug/launch-args.test.ts
@@ -109,6 +109,64 @@ describe('launch-args', () => {
     expect(merged.outputDir).toBe('build');
   });
 
+  it('resolves platform from target profile metadata when explicit platform is absent', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-profile-target-'));
+    const configPath = path.join(dir, 'debug80.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        defaultTarget: 'app',
+        profiles: {
+          mon3: {
+            platform: 'tec1g',
+          },
+        },
+        targets: {
+          app: {
+            asm: 'src/main.asm',
+            profile: 'mon3',
+          },
+        },
+      })
+    );
+
+    const merged = populateFromConfig(
+      { projectConfig: configPath } as LaunchRequestArguments,
+      { resolveBaseDir: () => dir }
+    );
+
+    expect(merged.platform).toBe('tec1g');
+  });
+
+  it('resolves platform from defaultProfile when target profile is absent', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-profile-default-'));
+    const configPath = path.join(dir, 'debug80.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        defaultTarget: 'app',
+        defaultProfile: 'mon3',
+        profiles: {
+          mon3: {
+            platform: 'tec1g',
+          },
+        },
+        targets: {
+          app: {
+            asm: 'src/main.asm',
+          },
+        },
+      })
+    );
+
+    const merged = populateFromConfig(
+      { projectConfig: configPath } as LaunchRequestArguments,
+      { resolveBaseDir: () => dir }
+    );
+
+    expect(merged.platform).toBe('tec1g');
+  });
+
   it('deep-merges tec1g so target overrides do not drop root romHex', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-tec1g-merge-'));
     const configPath = path.join(dir, 'debug80.json');

--- a/tests/extension/project-config.test.ts
+++ b/tests/extension/project-config.test.ts
@@ -68,6 +68,28 @@ describe('project-config helpers', () => {
     ).toBe('tec1g');
   });
 
+  it('resolves project platform from the default profile when projectPlatform is absent', () => {
+    expect(
+      resolveProjectPlatform({
+        defaultProfile: 'mon3',
+        profiles: {
+          mon3: {
+            platform: 'tec1g',
+            bundledAssets: {
+              romHex: {
+                bundleId: 'tec1g/mon3/v1',
+                path: 'mon3.bin',
+              },
+            },
+          },
+        },
+        targets: {
+          app: { sourceFile: 'src/main.asm', profile: 'mon3' },
+        },
+      })
+    ).toBe('tec1g');
+  });
+
   it('falls back to target platform when project platform is absent', () => {
     expect(
       resolveProjectPlatform({
@@ -143,6 +165,61 @@ describe('project-config helpers', () => {
         },
       })
     ).toBe(false);
+  });
+
+  it('rejects configs with invalid profile or bundle references', () => {
+    expect(
+      isDebug80ProjectConfig({
+        projectVersion: DEBUG80_PROJECT_VERSION,
+        projectPlatform: 'simple',
+        profiles: {
+          app: {
+            platform: 'simple',
+            bundledAssets: {
+              romHex: {
+                bundleId: '',
+                path: 'rom.bin',
+              },
+            },
+          },
+        },
+        targets: {
+          app: { sourceFile: 'src/main.asm', profile: 'app' },
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('upgrades manifests that use profile metadata to version 2 on read', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-project-manifest-v2-'));
+    const configPath = path.join(root, 'debug80.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        defaultProfile: 'mon3',
+        profiles: {
+          mon3: {
+            platform: 'tec1g',
+            bundledAssets: {
+              romHex: {
+                bundleId: 'tec1g/mon3/v1',
+                path: 'mon3.bin',
+                destination: 'roms/tec1g/mon3/mon3.bin',
+              },
+            },
+          },
+        },
+        targets: {
+          app: { sourceFile: 'src/main.asm', profile: 'mon3' },
+        },
+      })
+    );
+
+    const config = readProjectConfig(configPath);
+
+    expect(config?.projectVersion).toBe(DEBUG80_PROJECT_VERSION);
+    expect(config?.defaultProfile).toBe('mon3');
+    expect(config?.profiles?.mon3?.bundledAssets?.romHex?.bundleId).toBe('tec1g/mon3/v1');
   });
 
   it('updates the selected target source in package.json debug80 config', () => {


### PR DESCRIPTION
Adds version-2 manifest support for profile metadata and bundled asset references, with compatibility normalization for legacy configs and tests covering the new shape.