### PR TITLE
Add profile kits for project scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ To make a folder debuggable quickly in VS Code:
 1) Press `Cmd-Shift-P` (macOS) or `Ctrl-Shift-P` (Windows/Linux) to open the Command Palette.
 2) Type “Debug80: Create Project (config + launch)” and press Enter.
 
-This command scaffolds a Simple-platform config:
+This command scaffolds a built-in profile kit:
 - Creates `.vscode/debug80.json` with a default target (tries `src/main.asm`, or the first `.asm` it finds).
 - Creates `.vscode/launch.json` with a Debug80 launch configuration.
+- Built-in kits cover Simple/default, TEC-1/MON-1B, TEC-1/Classic 2K, and TEC-1G/MON-3.
 - It does not generate `.vscode/settings.json`; the extension already contributes the relevant file associations.
 
 After scaffolding, adjust the `sourceFile`, `outputDir`, and `artifactBase` as needed, then press F5.
@@ -155,7 +156,7 @@ To target a different platform (e.g., `tec1`):
 
 ## Z80 workflow
 
-1) Run “Debug80: Create Project (config + launch)” to scaffold `.vscode/debug80.json` (defaults to `targets.app` with `src/main.asm`) and `.vscode/launch.json`.
+1) Run “Debug80: Create Project (config + launch)” to scaffold `.vscode/debug80.json` (defaults to `targets.app` with `src/main.asm`) and `.vscode/launch.json`. The profile picker lets you choose the built-in kit before scaffolding.
 2) Start debugging with the generated debug80 launch; the adapter reads `.vscode/debug80.json`, runs `asm80` automatically using the target’s `sourceFile`/`asm`, and writes HEX/LST into `outputDir` (install `asm80` locally first). Set `assemble: false` to use pre-built artifacts instead.
 3) Set breakpoints in `.asm` files (preferred). Listing breakpoints in `.lst` still work as a fallback.
 4) Start debugging (F5). `stopOnEntry` halts on entry; Step/Continue as usual. Registers show in the Variables view.
@@ -170,7 +171,7 @@ Notes:
 For external repos:
 1) Open the external project as your workspace (e.g., `caverns80`).
 2) Run “Debug80: Create Project (config + launch)” to scaffold `.vscode`.
-3) Update `platform` and `sourceFile` to match the project and platform (Simple/TEC-1).
+3) Update the selected profile kit and `sourceFile` to match the project and platform (Simple/TEC-1).
 4) Press F5.
 
 This keeps example configs inside Debug80 while letting external projects own their debug setup.

--- a/resources/project-kits/simple/default/starter.asm
+++ b/resources/project-kits/simple/default/starter.asm
@@ -1,0 +1,6 @@
+; Debug80 starter (Simple / Default)
+        ORG 0x0900
+
+start:  NOP
+        JR  start
+

--- a/resources/project-kits/simple/default/starter.zax
+++ b/resources/project-kits/simple/default/starter.zax
@@ -1,0 +1,6 @@
+; Debug80 starter (Simple / Default)
+        ORG 0x0900
+
+start:  NOP
+        JR  start
+

--- a/resources/project-kits/tec1/classic-2k/starter.asm
+++ b/resources/project-kits/tec1/classic-2k/starter.asm
@@ -1,0 +1,6 @@
+; Debug80 starter (TEC-1 / Classic 2K)
+        ORG 0x0900
+
+start:  NOP
+        JR  start
+

--- a/resources/project-kits/tec1/classic-2k/starter.zax
+++ b/resources/project-kits/tec1/classic-2k/starter.zax
@@ -1,0 +1,6 @@
+; Debug80 starter (TEC-1 / Classic 2K)
+        ORG 0x0900
+
+start:  NOP
+        JR  start
+

--- a/resources/project-kits/tec1/mon1b/starter.asm
+++ b/resources/project-kits/tec1/mon1b/starter.asm
@@ -1,0 +1,6 @@
+; Debug80 starter (TEC-1 / MON-1B)
+        ORG 0x0800
+
+start:  NOP
+        JR  start
+

--- a/resources/project-kits/tec1/mon1b/starter.zax
+++ b/resources/project-kits/tec1/mon1b/starter.zax
@@ -1,0 +1,6 @@
+; Debug80 starter (TEC-1 / MON-1B)
+        ORG 0x0800
+
+start:  NOP
+        JR  start
+

--- a/resources/project-kits/tec1g/mon3/starter.asm
+++ b/resources/project-kits/tec1g/mon3/starter.asm
@@ -1,0 +1,6 @@
+; Debug80 starter (TEC-1G / MON-3)
+        ORG 0x4000
+
+start:  NOP
+        JR  start
+

--- a/resources/project-kits/tec1g/mon3/starter.zax
+++ b/resources/project-kits/tec1g/mon3/starter.zax
@@ -1,0 +1,6 @@
+; Debug80 starter (TEC-1G / MON-3)
+        ORG 0x4000
+
+start:  NOP
+        JR  start
+

--- a/src/extension/project-kits.ts
+++ b/src/extension/project-kits.ts
@@ -1,0 +1,146 @@
+/**
+ * @file Built-in project kit metadata and starter templates.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { BUNDLED_MON1B_V1_REL, BUNDLED_MON3_V1_REL } from './bundle-materialize';
+
+export type ScaffoldPlatform = 'simple' | 'tec1' | 'tec1g';
+export type StarterLanguage = 'asm' | 'zax';
+export type ProjectKitId = 'simple/default' | 'tec1/mon1b' | 'tec1/classic-2k' | 'tec1g/mon3';
+
+export type ProjectKit = {
+  id: ProjectKitId;
+  platform: ScaffoldPlatform;
+  profileName: string;
+  label: string;
+  description: string;
+  appStart: number;
+  entry: number;
+  starterTemplates: Record<StarterLanguage, string>;
+  bundledProfile?: {
+    bundleRel: string;
+    bundleId: string;
+    romPath: string;
+    listingPath?: string;
+    sourceRoots: string[];
+  };
+};
+
+const PROJECT_KITS: Record<ProjectKitId, ProjectKit> = {
+  'simple/default': {
+    id: 'simple/default',
+    platform: 'simple',
+    profileName: 'default',
+    label: 'Simple / Default',
+    description: 'Generic Debug80 RAM program kit at 0x0900.',
+    appStart: 0x0900,
+    entry: 0,
+    starterTemplates: {
+      asm: 'simple/default/starter.asm',
+      zax: 'simple/default/starter.zax',
+    },
+  },
+  'tec1/mon1b': {
+    id: 'tec1/mon1b',
+    platform: 'tec1',
+    profileName: 'mon1b',
+    label: 'TEC-1 / MON-1B',
+    description: 'TEC-1 monitor-first profile with user code at 0x0800.',
+    appStart: 0x0800,
+    entry: 0,
+    starterTemplates: {
+      asm: 'tec1/mon1b/starter.asm',
+      zax: 'tec1/mon1b/starter.zax',
+    },
+    bundledProfile: {
+      bundleRel: BUNDLED_MON1B_V1_REL,
+      bundleId: BUNDLED_MON1B_V1_REL,
+      romPath: 'roms/tec1/mon1b/mon-1b.bin',
+      listingPath: 'roms/tec1/mon1b/mon-1b.lst',
+      sourceRoots: ['src', 'roms/tec1/mon1b'],
+    },
+  },
+  'tec1/classic-2k': {
+    id: 'tec1/classic-2k',
+    platform: 'tec1',
+    profileName: 'classic-2k',
+    label: 'TEC-1 / Classic 2K',
+    description: 'Classic TEC-1 RAM-program profile at 0x0900.',
+    appStart: 0x0900,
+    entry: 0,
+    starterTemplates: {
+      asm: 'tec1/classic-2k/starter.asm',
+      zax: 'tec1/classic-2k/starter.zax',
+    },
+  },
+  'tec1g/mon3': {
+    id: 'tec1g/mon3',
+    platform: 'tec1g',
+    profileName: 'mon3',
+    label: 'TEC-1G / MON-3',
+    description: 'TEC-1G monitor-first profile with user code at 0x4000.',
+    appStart: 0x4000,
+    entry: 0,
+    starterTemplates: {
+      asm: 'tec1g/mon3/starter.asm',
+      zax: 'tec1g/mon3/starter.zax',
+    },
+    bundledProfile: {
+      bundleRel: BUNDLED_MON3_V1_REL,
+      bundleId: BUNDLED_MON3_V1_REL,
+      romPath: 'roms/tec1g/mon3/mon3.bin',
+      listingPath: 'roms/tec1g/mon3/mon3.lst',
+      sourceRoots: ['src', 'roms/tec1g/mon3'],
+    },
+  },
+};
+
+export type ProjectKitChoice = vscode.QuickPickItem & {
+  kit: ProjectKit;
+};
+
+export function listProjectKits(preselectedPlatform?: string): ProjectKit[] {
+  const normalized = preselectedPlatform?.trim().toLowerCase();
+  const kits = Object.values(PROJECT_KITS);
+  if (normalized === 'simple' || normalized === 'tec1' || normalized === 'tec1g') {
+    const filtered = kits.filter((kit) => kit.platform === normalized);
+    if (filtered.length > 0) {
+      return filtered;
+    }
+  }
+  return kits;
+}
+
+export function getProjectKitById(id: string | undefined): ProjectKit | undefined {
+  if (id === undefined) {
+    return undefined;
+  }
+  return PROJECT_KITS[id as ProjectKitId];
+}
+
+export function getProjectKitChoices(preselectedPlatform?: string): ProjectKitChoice[] {
+  return listProjectKits(preselectedPlatform).map((kit) => ({
+    label: kit.label,
+    description: kit.description,
+    kit,
+  }));
+}
+
+export function resolveProjectKitTemplatePath(
+  kit: ProjectKit,
+  language: StarterLanguage
+): string {
+  return path.join('resources', 'project-kits', kit.starterTemplates[language]);
+}
+
+export function readProjectKitStarterTemplate(
+  extensionUri: vscode.Uri,
+  kit: ProjectKit,
+  language: StarterLanguage
+): string {
+  const templatePath = path.join(extensionUri.fsPath, resolveProjectKitTemplatePath(kit, language));
+  return fs.readFileSync(templatePath, 'utf-8');
+}

--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -251,8 +251,8 @@ export async function scaffoldProject(
 
   let scaffoldPlan = plan;
 
-  if (scaffoldPlan !== undefined && extensionUri !== undefined) {
-    if (scaffoldPlan.kit.platform === 'tec1g') {
+  if (scaffoldPlan !== undefined && extensionUri !== undefined && scaffoldPlan.kit.bundledProfile !== undefined) {
+    if (scaffoldPlan.kit.bundledProfile.bundleRel === BUNDLED_MON3_V1_REL) {
       const mat = materializeBundledRom(extensionUri, workspaceRoot, BUNDLED_MON3_V1_REL);
       if (mat.ok) {
         scaffoldPlan = { ...scaffoldPlan, bundledMon3: mat };
@@ -261,7 +261,7 @@ export async function scaffoldProject(
           `Debug80: Could not copy bundled MON3 ROM (${mat.reason}). You can add romHex manually in debug80.json.`
         );
       }
-    } else if (scaffoldPlan.kit.platform === 'tec1') {
+    } else if (scaffoldPlan.kit.bundledProfile.bundleRel === BUNDLED_MON1B_V1_REL) {
       const mat = materializeBundledRom(extensionUri, workspaceRoot, BUNDLED_MON1B_V1_REL);
       if (mat.ok) {
         scaffoldPlan = { ...scaffoldPlan, bundledMon1b: mat };

--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -11,9 +11,7 @@ import {
   findProjectConfigPath,
   listProjectSourceFiles,
 } from './project-config';
-import { TEC1_APP_START_DEFAULT } from '../platforms/tec1/constants';
 import {
-  TEC1G_APP_START_DEFAULT,
   TEC1G_RAM_END,
   TEC1G_RAM_START,
   TEC1G_ROM0_END,
@@ -27,20 +25,23 @@ import {
   materializeBundledRom,
   type MaterializeBundledRomResult,
 } from './bundle-materialize';
-
-type ScaffoldPlatform = 'simple' | 'tec1' | 'tec1g';
-
-type StarterLanguage = 'asm' | 'zax';
+import {
+  getProjectKitChoices,
+  readProjectKitStarterTemplate,
+  type ProjectKit,
+  type ScaffoldPlatform,
+  type StarterLanguage,
+} from './project-kits';
 
 type ScaffoldPlan = {
+  kit: ProjectKit;
   targetName: string;
-  platform: ScaffoldPlatform;
   sourceFile: string;
   outputDir: string;
   artifactBase: string;
+  starterLanguage?: StarterLanguage;
   starterFile?: {
     path: string;
-    content: string;
   };
   /** Present when bundled MON3 was copied into the workspace during scaffold */
   bundledMon3?: Extract<MaterializeBundledRomResult, { ok: true }>;
@@ -63,25 +64,25 @@ function createSimpleDefaults(): Record<string, unknown> {
   };
 }
 
-function createTec1Defaults(): Record<string, unknown> {
+function createTec1Defaults(appStart: number): Record<string, unknown> {
   return {
     regions: [
       { start: 0, end: 2047, kind: 'rom' },
       { start: 2048, end: 4095, kind: 'ram' },
     ],
-    appStart: TEC1_APP_START_DEFAULT,
+    appStart,
     entry: 0,
   };
 }
 
-function createTec1gDefaults(): Record<string, unknown> {
+function createTec1gDefaults(appStart: number): Record<string, unknown> {
   return {
     regions: [
       { start: TEC1G_ROM0_START, end: TEC1G_ROM0_END, kind: 'rom' },
       { start: TEC1G_RAM_START, end: TEC1G_RAM_END, kind: 'ram' },
       { start: TEC1G_ROM1_START, end: TEC1G_ROM1_END, kind: 'rom' },
     ],
-    appStart: TEC1G_APP_START_DEFAULT,
+    appStart,
     entry: 0,
   };
 }
@@ -96,29 +97,55 @@ function platformDisplayName(platform: ScaffoldPlatform): string {
   return 'Simple';
 }
 
-export function createStarterSourceContent(language: StarterLanguage): string {
-  if (language === 'zax') {
-    return ['; Debug80 starter (ZAX)', '', 'start:', '    nop', '    jr start', ''].join('\n');
-  }
-
-  return ['; Debug80 starter (ASM)', '', 'start:', '    nop', '    jr start', ''].join('\n');
+export function createStarterSourceContent(
+  extensionUri: vscode.Uri,
+  kit: ProjectKit,
+  language: StarterLanguage
+): string {
+  return readProjectKitStarterTemplate(extensionUri, kit, language);
 }
 
 export function createDefaultProjectConfig(plan: ScaffoldPlan): {
   projectVersion: typeof DEBUG80_PROJECT_VERSION;
   projectPlatform: ScaffoldPlatform;
   defaultTarget: string;
+  defaultProfile: string;
+  profiles: Record<string, Record<string, unknown>>;
   targets: Record<string, Record<string, unknown>>;
 } {
+  const profileConfig: Record<string, unknown> = {
+    platform: plan.kit.platform,
+  };
+  if (plan.kit.description.length > 0) {
+    profileConfig.description = plan.kit.description;
+  }
+  if (plan.kit.bundledProfile !== undefined) {
+    profileConfig.bundledAssets = {
+      romHex: {
+        bundleId: plan.kit.bundledProfile.bundleId,
+        path: path.basename(plan.kit.bundledProfile.romPath),
+      },
+      ...(plan.kit.bundledProfile.listingPath !== undefined
+        ? {
+            listing: {
+              bundleId: plan.kit.bundledProfile.bundleId,
+              path: path.basename(plan.kit.bundledProfile.listingPath),
+            },
+          }
+        : {}),
+    };
+  }
+
   const targetConfig: Record<string, unknown> = {
     sourceFile: plan.sourceFile,
     outputDir: plan.outputDir,
     artifactBase: plan.artifactBase,
-    platform: plan.platform,
+    platform: plan.kit.platform,
+    profile: plan.kit.profileName,
   };
 
-  if (plan.platform === 'tec1') {
-    const base = createTec1Defaults();
+  if (plan.kit.platform === 'tec1') {
+    const base = createTec1Defaults(plan.kit.appStart);
     if (plan.bundledMon1b !== undefined) {
       const sourceRoots = [
         'src',
@@ -135,8 +162,8 @@ export function createDefaultProjectConfig(plan: ScaffoldPlan): {
     } else {
       targetConfig.tec1 = base;
     }
-  } else if (plan.platform === 'tec1g') {
-    const base = createTec1gDefaults();
+  } else if (plan.kit.platform === 'tec1g') {
+    const base = createTec1gDefaults(plan.kit.appStart);
     if (plan.bundledMon3 !== undefined) {
       const sourceRoots = [
         'src',
@@ -159,39 +186,33 @@ export function createDefaultProjectConfig(plan: ScaffoldPlan): {
 
   return {
     projectVersion: DEBUG80_PROJECT_VERSION,
-    projectPlatform: plan.platform,
+    projectPlatform: plan.kit.platform,
+    defaultProfile: plan.kit.profileName,
     defaultTarget: plan.targetName,
+    profiles: {
+      [plan.kit.profileName]: profileConfig,
+    },
     targets: {
       [plan.targetName]: targetConfig,
     },
   };
 }
 
-async function choosePlatform(): Promise<ScaffoldPlatform | undefined> {
-  const items: Array<vscode.QuickPickItem & { platform: ScaffoldPlatform }> = [
-    {
-      label: 'Simple',
-      description: 'Generic Debug80 memory-map platform',
-      platform: 'simple',
-    },
-    {
-      label: 'TEC-1',
-      description: 'Classic TEC-1 keypad/LCD platform',
-      platform: 'tec1',
-    },
-    {
-      label: 'TEC-1G',
-      description: 'TEC-1G LCD/GLCD/matrix platform',
-      platform: 'tec1g',
-    },
-  ];
+async function chooseProjectKit(preselectedPlatform?: string): Promise<ProjectKit | undefined> {
+  const items = getProjectKitChoices(preselectedPlatform);
+  if (items.length === 1) {
+    return items[0]?.kit;
+  }
 
   const picked = await vscode.window.showQuickPick(items, {
-    placeHolder: 'Choose the platform for this Debug80 project',
+    placeHolder:
+      preselectedPlatform !== undefined && preselectedPlatform.trim().length > 0
+        ? `Choose a profile kit for ${platformDisplayName(preselectedPlatform.trim().toLowerCase() as ScaffoldPlatform)}`
+        : 'Choose the profile kit for this Debug80 project',
     matchOnDescription: true,
   });
 
-  return picked?.platform;
+  return picked?.kit;
 }
 
 export function createDefaultLaunchConfig(): Record<string, unknown> {
@@ -220,7 +241,9 @@ export async function scaffoldProject(
   const configExists = findProjectConfigPath(folder) !== undefined;
 
   const inferred = inferDefaultTarget(workspaceRoot);
-  const plan = configExists ? undefined : await buildScaffoldPlan(folder, inferred, preselectedPlatform);
+  const plan = configExists
+    ? undefined
+    : await buildScaffoldPlan(folder, inferred, preselectedPlatform);
 
   if (!configExists && plan === undefined) {
     return false;
@@ -229,7 +252,7 @@ export async function scaffoldProject(
   let scaffoldPlan = plan;
 
   if (scaffoldPlan !== undefined && extensionUri !== undefined) {
-    if (scaffoldPlan.platform === 'tec1g') {
+    if (scaffoldPlan.kit.platform === 'tec1g') {
       const mat = materializeBundledRom(extensionUri, workspaceRoot, BUNDLED_MON3_V1_REL);
       if (mat.ok) {
         scaffoldPlan = { ...scaffoldPlan, bundledMon3: mat };
@@ -238,7 +261,7 @@ export async function scaffoldProject(
           `Debug80: Could not copy bundled MON3 ROM (${mat.reason}). You can add romHex manually in debug80.json.`
         );
       }
-    } else if (scaffoldPlan.platform === 'tec1') {
+    } else if (scaffoldPlan.kit.platform === 'tec1') {
       const mat = materializeBundledRom(extensionUri, workspaceRoot, BUNDLED_MON1B_V1_REL);
       if (mat.ok) {
         scaffoldPlan = { ...scaffoldPlan, bundledMon1b: mat };
@@ -273,12 +296,19 @@ export async function scaffoldProject(
         const starterPath = path.join(workspaceRoot, scaffoldPlan.starterFile.path);
         ensureDirExists(path.dirname(starterPath));
         if (!fs.existsSync(starterPath)) {
-          fs.writeFileSync(starterPath, scaffoldPlan.starterFile.content);
+          fs.writeFileSync(
+            starterPath,
+            createStarterSourceContent(
+              extensionUri ?? vscode.Uri.file(process.cwd()),
+              scaffoldPlan.kit,
+              scaffoldPlan.starterLanguage ?? 'asm'
+            )
+          );
         }
       }
       fs.writeFileSync(configPath, `${JSON.stringify(defaultConfig, null, 2)}\n`);
       void vscode.window.showInformationMessage(
-        `Debug80: Created ${platformDisplayName(scaffoldPlan.platform)} project in debug80.json targeting ${scaffoldPlan.sourceFile}.`
+        `Debug80: Created ${scaffoldPlan.kit.label} project in debug80.json targeting ${scaffoldPlan.sourceFile}.`
       );
       created = true;
     } catch (err) {
@@ -321,19 +351,8 @@ async function buildScaffoldPlan(
   inferred: { sourceFile: string; outputDir: string; artifactBase: string },
   preselectedPlatform?: string
 ): Promise<ScaffoldPlan | undefined> {
-  const resolvedPlatform: ScaffoldPlatform | undefined =
-    preselectedPlatform === 'tec1' || preselectedPlatform === 'tec1g' || preselectedPlatform === 'simple'
-      ? preselectedPlatform
-      : undefined;
-
-  // When the platform comes from the webview UI, skip all interactive pickers
-  // and build a plan from defaults immediately.
-  if (resolvedPlatform !== undefined) {
-    return buildDefaultScaffoldPlan(folder, inferred, resolvedPlatform);
-  }
-
-  const platform = await choosePlatform();
-  if (platform === undefined) {
+  const kit = await chooseProjectKit(preselectedPlatform);
+  if (kit === undefined) {
     return undefined;
   }
 
@@ -359,8 +378,8 @@ async function buildScaffoldPlan(
   if (choice.kind === 'existing') {
     const sourceFile = choice.sourceFile;
     return {
+      kit,
       targetName,
-      platform,
       sourceFile,
       outputDir: inferred.outputDir,
       artifactBase: path.basename(sourceFile, path.extname(sourceFile)) || inferred.artifactBase,
@@ -369,46 +388,15 @@ async function buildScaffoldPlan(
 
   const sourceFile = choice.language === 'zax' ? 'src/main.zax' : 'src/main.asm';
   return {
+    kit,
     targetName,
-    platform,
     sourceFile,
     outputDir: inferred.outputDir,
     artifactBase: path.basename(sourceFile, path.extname(sourceFile)) || inferred.artifactBase,
+    starterLanguage: choice.language,
     starterFile: {
       path: sourceFile,
-      content: createStarterSourceContent(choice.language),
     },
-  };
-}
-
-function buildDefaultScaffoldPlan(
-  folder: vscode.WorkspaceFolder,
-  inferred: { sourceFile: string; outputDir: string; artifactBase: string },
-  platform: ScaffoldPlatform
-): ScaffoldPlan {
-  const sourceFiles = listProjectSourceFiles(folder.uri.fsPath);
-  const inferredExists = sourceFiles.includes(inferred.sourceFile);
-  const sourceFile =
-    sourceFiles.length === 1
-      ? (sourceFiles[0] ?? inferred.sourceFile)
-      : inferredExists
-        ? inferred.sourceFile
-        : sourceFiles[0] ?? inferred.sourceFile;
-
-  const needsStarter = sourceFiles.length === 0;
-  const starterFile = needsStarter
-    ? { path: 'src/main.asm', content: createStarterSourceContent('asm') }
-    : undefined;
-  const resolvedSource = needsStarter ? 'src/main.asm' : sourceFile;
-
-  const baseName = path.basename(resolvedSource, path.extname(resolvedSource)) || inferred.artifactBase;
-  return {
-    targetName: baseName,
-    platform,
-    sourceFile: resolvedSource,
-    outputDir: inferred.outputDir,
-    artifactBase: baseName,
-    ...(starterFile !== undefined ? { starterFile } : {}),
   };
 }
 

--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -16,6 +16,7 @@ import {
   scaffoldProject,
 } from '../../src/extension/project-scaffolding';
 import { DEBUG80_PROJECT_VERSION } from '../../src/extension/project-config';
+import { getProjectKitById } from '../../src/extension/project-kits';
 
 vi.mock('vscode', () => ({
   window: {
@@ -66,10 +67,16 @@ describe('project-scaffolding helpers', () => {
     vi.clearAllMocks();
   });
 
-  it('builds a simple target config for asm sources', () => {
+  function kit(id: Parameters<typeof getProjectKitById>[0]) {
+    const resolved = getProjectKitById(id);
+    expect(resolved).toBeDefined();
+    return resolved as NonNullable<typeof resolved>;
+  }
+
+  it('builds a simple/default profile kit config for asm sources', () => {
     const config = createDefaultProjectConfig({
+      kit: kit('simple/default'),
       targetName: 'app',
-      platform: 'simple',
       sourceFile: 'src/main.asm',
       outputDir: 'build',
       artifactBase: 'main',
@@ -78,13 +85,21 @@ describe('project-scaffolding helpers', () => {
     expect(config).toEqual({
       projectVersion: DEBUG80_PROJECT_VERSION,
       projectPlatform: 'simple',
+      defaultProfile: 'default',
       defaultTarget: 'app',
+      profiles: {
+        default: {
+          platform: 'simple',
+          description: 'Generic Debug80 RAM program kit at 0x0900.',
+        },
+      },
       targets: {
         app: {
           sourceFile: 'src/main.asm',
           outputDir: 'build',
           artifactBase: 'main',
           platform: 'simple',
+          profile: 'default',
           simple: {
             regions: [
               { start: 0, end: 2047, kind: 'rom' },
@@ -98,10 +113,10 @@ describe('project-scaffolding helpers', () => {
     });
   });
 
-  it('does not include assembler field when scaffolding a zax target (auto-inferred from extension)', () => {
+  it('builds a simple/default profile kit config for zax sources', () => {
     const config = createDefaultProjectConfig({
+      kit: kit('simple/default'),
       targetName: 'app',
-      platform: 'simple',
       sourceFile: 'src/main.zax',
       outputDir: 'build',
       artifactBase: 'main',
@@ -109,22 +124,34 @@ describe('project-scaffolding helpers', () => {
 
     expect(config).toEqual(
       expect.objectContaining({
+        defaultProfile: 'default',
         targets: {
           app: expect.objectContaining({
             sourceFile: 'src/main.zax',
+            profile: 'default',
           }),
         },
       })
     );
-    // assembler is no longer written to new project configs (auto-inferred from file extension)
-    expect(config.targets.app).not.toHaveProperty('assembler');
   });
 
-  it('creates starter source text for asm and zax', () => {
-    expect(createStarterSourceContent('asm')).toContain('; Debug80 starter (ASM)');
-    expect(createStarterSourceContent('asm')).toContain('jr start');
-    expect(createStarterSourceContent('zax')).toContain('; Debug80 starter (ZAX)');
-    expect(createStarterSourceContent('zax')).toContain('jr start');
+  it('creates starter source text for all built-in kits', () => {
+    const extensionUri = { fsPath: process.cwd() } as never;
+    expect(createStarterSourceContent(extensionUri, kit('simple/default'), 'asm')).toContain(
+      'ORG 0x0900'
+    );
+    expect(createStarterSourceContent(extensionUri, kit('simple/default'), 'zax')).toContain(
+      'ORG 0x0900'
+    );
+    expect(createStarterSourceContent(extensionUri, kit('tec1/mon1b'), 'asm')).toContain(
+      'ORG 0x0800'
+    );
+    expect(createStarterSourceContent(extensionUri, kit('tec1/classic-2k'), 'asm')).toContain(
+      'ORG 0x0900'
+    );
+    expect(createStarterSourceContent(extensionUri, kit('tec1g/mon3'), 'asm')).toContain(
+      'ORG 0x4000'
+    );
   });
 
   it('creates a generic current-project launch config', () => {
@@ -140,10 +167,62 @@ describe('project-scaffolding helpers', () => {
     });
   });
 
-  it('builds a tec1 target config when scaffolding for TEC-1', () => {
+  it('builds a tec1 mon1b profile kit config when scaffolding for TEC-1', () => {
     const config = createDefaultProjectConfig({
+      kit: kit('tec1/mon1b'),
       targetName: 'app',
-      platform: 'tec1',
+      sourceFile: 'src/main.asm',
+      outputDir: 'build',
+      artifactBase: 'main',
+      bundledMon1b: {
+        ok: true,
+        destinationRelative: 'roms/tec1/mon1b',
+        romRelativePath: 'roms/tec1/mon1b/mon-1b.bin',
+        listingRelativePath: 'roms/tec1/mon1b/mon-1b.lst',
+      },
+    });
+
+    expect(config).toEqual({
+      projectVersion: DEBUG80_PROJECT_VERSION,
+      projectPlatform: 'tec1',
+      defaultProfile: 'mon1b',
+      defaultTarget: 'app',
+      profiles: {
+        mon1b: expect.objectContaining({
+          platform: 'tec1',
+          bundledAssets: expect.objectContaining({
+            romHex: expect.objectContaining({ bundleId: 'tec1/mon1b/v1', path: 'mon-1b.bin' }),
+            listing: expect.objectContaining({ bundleId: 'tec1/mon1b/v1', path: 'mon-1b.lst' }),
+          }),
+        }),
+      },
+      targets: {
+        app: {
+          sourceFile: 'src/main.asm',
+          outputDir: 'build',
+          artifactBase: 'main',
+          platform: 'tec1',
+          profile: 'mon1b',
+          tec1: {
+            regions: [
+              { start: 0, end: 2047, kind: 'rom' },
+              { start: 2048, end: 4095, kind: 'ram' },
+            ],
+            appStart: 0x0800,
+            entry: 0,
+            romHex: 'roms/tec1/mon1b/mon-1b.bin',
+            extraListings: ['roms/tec1/mon1b/mon-1b.lst'],
+            sourceRoots: ['src', 'roms/tec1/mon1b'],
+          },
+        },
+      },
+    });
+  });
+
+  it('builds a tec1 classic-2k profile kit config when scaffolding for TEC-1', () => {
+    const config = createDefaultProjectConfig({
+      kit: kit('tec1/classic-2k'),
+      targetName: 'app',
       sourceFile: 'src/main.asm',
       outputDir: 'build',
       artifactBase: 'main',
@@ -152,19 +231,27 @@ describe('project-scaffolding helpers', () => {
     expect(config).toEqual({
       projectVersion: DEBUG80_PROJECT_VERSION,
       projectPlatform: 'tec1',
+      defaultProfile: 'classic-2k',
       defaultTarget: 'app',
+      profiles: {
+        'classic-2k': {
+          platform: 'tec1',
+          description: 'Classic TEC-1 RAM-program profile at 0x0900.',
+        },
+      },
       targets: {
         app: {
           sourceFile: 'src/main.asm',
           outputDir: 'build',
           artifactBase: 'main',
           platform: 'tec1',
+          profile: 'classic-2k',
           tec1: {
             regions: [
               { start: 0, end: 2047, kind: 'rom' },
               { start: 2048, end: 4095, kind: 'ram' },
             ],
-            appStart: 0x0800,
+            appStart: 0x0900,
             entry: 0,
           },
         },
@@ -172,10 +259,10 @@ describe('project-scaffolding helpers', () => {
     });
   });
 
-  it('merges bundled MON3 paths into tec1g when materialization succeeded', () => {
+  it('builds a tec1g mon3 profile kit config when scaffolding for TEC-1G', () => {
     const config = createDefaultProjectConfig({
+      kit: kit('tec1g/mon3'),
       targetName: 'app',
-      platform: 'tec1g',
       sourceFile: 'src/main.asm',
       outputDir: 'build',
       artifactBase: 'main',
@@ -187,37 +274,27 @@ describe('project-scaffolding helpers', () => {
       },
     });
 
-    expect(config.targets.app).toEqual(
-      expect.objectContaining({
-        platform: 'tec1g',
-        tec1g: expect.objectContaining({
-          romHex: 'roms/tec1g/mon3/mon3.bin',
-          extraListings: ['roms/tec1g/mon3/mon3.lst'],
-          sourceRoots: ['src', 'roms/tec1g/mon3'],
-        }),
-      })
-    );
-  });
-
-  it('builds a tec1g target config when scaffolding for TEC-1G', () => {
-    const config = createDefaultProjectConfig({
-      targetName: 'app',
-      platform: 'tec1g',
-      sourceFile: 'src/main.asm',
-      outputDir: 'build',
-      artifactBase: 'main',
-    });
-
     expect(config).toEqual({
       projectVersion: DEBUG80_PROJECT_VERSION,
       projectPlatform: 'tec1g',
+      defaultProfile: 'mon3',
       defaultTarget: 'app',
+      profiles: {
+        mon3: expect.objectContaining({
+          platform: 'tec1g',
+          bundledAssets: expect.objectContaining({
+            romHex: expect.objectContaining({ bundleId: 'tec1g/mon3/v1', path: 'mon3.bin' }),
+            listing: expect.objectContaining({ bundleId: 'tec1g/mon3/v1', path: 'mon3.lst' }),
+          }),
+        }),
+      },
       targets: {
         app: {
           sourceFile: 'src/main.asm',
           outputDir: 'build',
           artifactBase: 'main',
           platform: 'tec1g',
+          profile: 'mon3',
           tec1g: {
             regions: [
               { start: 0, end: 2047, kind: 'rom' },
@@ -226,13 +303,16 @@ describe('project-scaffolding helpers', () => {
             ],
             appStart: 0x4000,
             entry: 0,
+            romHex: 'roms/tec1g/mon3/mon3.bin',
+            extraListings: ['roms/tec1g/mon3/mon3.lst'],
+            sourceRoots: ['src', 'roms/tec1g/mon3'],
           },
         },
       },
     });
   });
 
-  it('cancels scaffolding when platform selection is dismissed', async () => {
+  it('cancels scaffolding when profile kit selection is dismissed', async () => {
     showQuickPick.mockResolvedValueOnce(undefined);
 
     const created = await scaffoldProject(
@@ -244,11 +324,11 @@ describe('project-scaffolding helpers', () => {
     expect(showInputBox).not.toHaveBeenCalled();
   });
 
-  it('writes a tec1g config after choosing platform, target name, and starter source', async () => {
+  it('writes a tec1g config after choosing a profile kit, target name, and starter source', async () => {
     const fs = await import('fs');
     const writeFileSync = vi.mocked(fs.writeFileSync);
 
-    showQuickPick.mockResolvedValueOnce({ platform: 'tec1g' }).mockResolvedValueOnce({
+    showQuickPick.mockResolvedValueOnce({ kit: kit('tec1g/mon3') }).mockResolvedValueOnce({
       choice: { kind: 'starter', language: 'asm' },
     });
     showInputBox.mockResolvedValueOnce('app');
@@ -276,11 +356,14 @@ describe('project-scaffolding helpers', () => {
     const writtenConfig = JSON.parse(String(configWrite?.[1] ?? '{}')) as {
       projectVersion?: number;
       projectPlatform?: string;
-      targets?: Record<string, { platform?: string; tec1g?: Record<string, unknown> }>;
+      defaultProfile?: string;
+      targets?: Record<string, { platform?: string; profile?: string; tec1g?: Record<string, unknown> }>;
     };
     expect(writtenConfig.projectVersion).toBe(DEBUG80_PROJECT_VERSION);
     expect(writtenConfig.projectPlatform).toBe('tec1g');
+    expect(writtenConfig.defaultProfile).toBe('mon3');
     expect(writtenConfig.targets?.app?.platform).toBe('tec1g');
+    expect(writtenConfig.targets?.app?.profile).toBe('mon3');
     expect(writtenConfig.targets?.app?.tec1g).toEqual(
       expect.objectContaining({
         appStart: 0x4000,
@@ -289,7 +372,7 @@ describe('project-scaffolding helpers', () => {
     );
 
     expect(showInformationMessage).toHaveBeenCalledWith(
-      'Debug80: Created TEC-1G project in debug80.json targeting src/main.asm.'
+      'Debug80: Created TEC-1G / MON-3 project in debug80.json targeting src/main.asm.'
     );
   });
 });

--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -259,6 +259,36 @@ describe('project-scaffolding helpers', () => {
     });
   });
 
+  it('does not pull MON-1B bundle fields into classic-2k scaffolding', async () => {
+    const fs = await import('fs');
+    const writeFileSync = vi.mocked(fs.writeFileSync);
+
+    showQuickPick.mockResolvedValueOnce({ kit: kit('tec1/classic-2k') }).mockResolvedValueOnce({
+      choice: { kind: 'starter', language: 'asm' },
+    });
+    showInputBox.mockResolvedValueOnce('app');
+
+    const created = await scaffoldProject(
+      { name: 'demo', uri: { fsPath: '/workspace/demo' }, index: 0 } as never,
+      false
+    );
+
+    expect(created).toBe(true);
+
+    const configWrite = writeFileSync.mock.calls.find(([filePath]) =>
+      String(filePath).replace(/\\/g, '/').endsWith('/debug80.json')
+    );
+    expect(configWrite).toBeDefined();
+
+    const writtenConfig = JSON.parse(String(configWrite?.[1] ?? '{}')) as {
+      targets?: Record<string, { tec1?: Record<string, unknown> }>;
+    };
+    expect(writtenConfig.targets?.app?.tec1).toBeDefined();
+    expect(writtenConfig.targets?.app?.tec1).not.toHaveProperty('romHex');
+    expect(writtenConfig.targets?.app?.tec1).not.toHaveProperty('extraListings');
+    expect(writtenConfig.targets?.app?.tec1).not.toHaveProperty('sourceRoots');
+  });
+
   it('builds a tec1g mon3 profile kit config when scaffolding for TEC-1G', () => {
     const config = createDefaultProjectConfig({
       kit: kit('tec1g/mon3'),


### PR DESCRIPTION
Implements issue #279 by replacing generic new-project scaffolding with built-in profile kits for simple/default, tec1/mon1b, tec1/classic-2k, and tec1g/mon3. The scaffold flow now selects a profile kit first, then generates profile-correct starter source/config pairs. Bundled asset resolution is intentionally left to #280.