### PR TITLE
Generalize bundled asset materialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
       },
       {
         "command": "debug80.materializeBundledRom",
-        "title": "Debug80: Copy Bundled MON3 ROM and Listing into Workspace"
+        "title": "Debug80: Copy Bundled Assets into Workspace"
       }
     ],
     "menus": {

--- a/src/extension/bundle-materialize.ts
+++ b/src/extension/bundle-materialize.ts
@@ -115,6 +115,35 @@ function resolveAssetDestination(
   );
 }
 
+function resolveWorkspaceDestination(
+  workspaceRoot: string,
+  destinationRelative: string
+): { ok: true; absolutePath: string; relativePath: string } | { ok: false; reason: string } {
+  const trimmed = destinationRelative.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, reason: 'Bundled asset destination is empty' };
+  }
+
+  if (path.isAbsolute(trimmed)) {
+    return { ok: false, reason: `Bundled asset destination must be workspace-relative: ${trimmed}` };
+  }
+
+  const normalizedRelative = normalizeRelativePath(path.normalize(trimmed));
+  const absolutePath = path.resolve(workspaceRoot, normalizedRelative);
+  const relativeToWorkspace = path.relative(workspaceRoot, absolutePath);
+  if (
+    relativeToWorkspace === '' ||
+    (!relativeToWorkspace.startsWith('..') && !path.isAbsolute(relativeToWorkspace))
+  ) {
+    return { ok: true, absolutePath, relativePath: normalizedRelative };
+  }
+
+  return {
+    ok: false,
+    reason: `Bundled asset destination escapes the workspace root: ${trimmed}`,
+  };
+}
+
 /**
  * Copies a single bundled asset reference into the workspace.
  * This is the generic path used by manifest-backed bundled asset refs.
@@ -141,7 +170,10 @@ export function materializeBundledAsset(
   const bundleDiskRoot = bundleRootUri(extensionUri, reference.bundleId).fsPath;
   const from = path.join(bundleDiskRoot, entry.path);
   const destinationRelative = resolveAssetDestination(manifest, reference);
-  const to = path.join(workspaceRoot, destinationRelative);
+  const destination = resolveWorkspaceDestination(workspaceRoot, destinationRelative);
+  if (!destination.ok) {
+    return destination;
+  }
   const overwrite = options?.overwrite === true;
 
   if (!fs.existsSync(from)) {
@@ -157,23 +189,26 @@ export function materializeBundledAsset(
   }
 
   try {
-    fs.mkdirSync(path.dirname(to), { recursive: true });
+    fs.mkdirSync(path.dirname(destination.absolutePath), { recursive: true });
   } catch (e) {
-    return { ok: false, reason: `Could not create ${path.dirname(to)}: ${String(e)}` };
+    return {
+      ok: false,
+      reason: `Could not create ${path.dirname(destination.absolutePath)}: ${String(e)}`,
+    };
   }
 
-  if (!(fs.existsSync(to) && !overwrite)) {
+  if (!(fs.existsSync(destination.absolutePath) && !overwrite)) {
     try {
-      fs.copyFileSync(from, to);
+      fs.copyFileSync(from, destination.absolutePath);
     } catch (e) {
-      return { ok: false, reason: `Copy failed ${from} -> ${to}: ${String(e)}` };
+      return { ok: false, reason: `Copy failed ${from} -> ${destination.absolutePath}: ${String(e)}` };
     }
   }
 
   return {
     ok: true,
-    destinationRelative,
-    materializedRelativePath: destinationRelative,
+    destinationRelative: destination.relativePath,
+    materializedRelativePath: destination.relativePath,
   };
 }
 

--- a/src/extension/bundle-materialize.ts
+++ b/src/extension/bundle-materialize.ts
@@ -6,6 +6,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import type { BundledAssetReference } from '../debug/types';
 import type { BundleManifestV1 } from './bundle-manifest';
 import { isBundleManifestV1 } from './bundle-manifest';
 
@@ -26,11 +27,23 @@ export type MaterializeBundledRomResult = {
   reason: string;
 };
 
+export type MaterializeBundledAssetResult = {
+  ok: true;
+  destinationRelative: string;
+  materializedRelativePath: string;
+} | {
+  ok: false;
+  reason: string;
+};
+
 function bundleRootUri(extensionUri: vscode.Uri, bundleRelPath: string): vscode.Uri {
   return vscode.Uri.joinPath(extensionUri, 'resources', 'bundles', ...bundleRelPath.split('/'));
 }
 
-function readManifest(extensionUri: vscode.Uri, bundleRelPath: string): BundleManifestV1 | undefined {
+function readManifest(
+  extensionUri: vscode.Uri,
+  bundleRelPath: string
+): BundleManifestV1 | undefined {
   const manifestUri = vscode.Uri.joinPath(bundleRootUri(extensionUri, bundleRelPath), 'bundle.json');
   try {
     const raw = fs.readFileSync(manifestUri.fsPath, 'utf-8');
@@ -83,6 +96,85 @@ function checksumMismatchReason(
 ): string {
   const expected = entry.sha256 ?? '';
   return `Checksum mismatch for ${entry.path} (expected ${expected}, got ${actualHash})`;
+}
+
+function normalizeRelativePath(relPath: string): string {
+  return relPath.split(path.sep).join('/');
+}
+
+function resolveAssetDestination(
+  manifest: BundleManifestV1,
+  reference: BundledAssetReference
+): string {
+  const destination = reference.destination;
+  if (destination !== undefined && destination.trim().length > 0) {
+    return normalizeRelativePath(path.normalize(destination.trim()));
+  }
+  return normalizeRelativePath(
+    path.join(manifest.workspaceLayout.destination, path.basename(reference.path))
+  );
+}
+
+/**
+ * Copies a single bundled asset reference into the workspace.
+ * This is the generic path used by manifest-backed bundled asset refs.
+ */
+export function materializeBundledAsset(
+  extensionUri: vscode.Uri,
+  workspaceRoot: string,
+  reference: BundledAssetReference,
+  options?: { overwrite?: boolean }
+): MaterializeBundledAssetResult {
+  const manifest = readManifest(extensionUri, reference.bundleId);
+  if (manifest === undefined) {
+    return { ok: false, reason: `Missing or invalid bundle manifest at ${reference.bundleId}` };
+  }
+
+  const entry = manifest.files.find((file) => file.path === reference.path);
+  if (entry === undefined) {
+    return {
+      ok: false,
+      reason: `Bundle ${reference.bundleId} does not contain ${reference.path}`,
+    };
+  }
+
+  const bundleDiskRoot = bundleRootUri(extensionUri, reference.bundleId).fsPath;
+  const from = path.join(bundleDiskRoot, entry.path);
+  const destinationRelative = resolveAssetDestination(manifest, reference);
+  const to = path.join(workspaceRoot, destinationRelative);
+  const overwrite = options?.overwrite === true;
+
+  if (!fs.existsSync(from)) {
+    return { ok: false, reason: `Bundled file missing in extension: ${reference.path}` };
+  }
+
+  const checksumMismatch = verifyEntryChecksum(from, entry);
+  if (checksumMismatch !== undefined) {
+    return {
+      ok: false,
+      reason: checksumMismatchReason(entry, checksumMismatch),
+    };
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(to), { recursive: true });
+  } catch (e) {
+    return { ok: false, reason: `Could not create ${path.dirname(to)}: ${String(e)}` };
+  }
+
+  if (!(fs.existsSync(to) && !overwrite)) {
+    try {
+      fs.copyFileSync(from, to);
+    } catch (e) {
+      return { ok: false, reason: `Copy failed ${from} -> ${to}: ${String(e)}` };
+    }
+  }
+
+  return {
+    ok: true,
+    destinationRelative,
+    materializedRelativePath: destinationRelative,
+  };
 }
 
 /**

--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -20,13 +20,17 @@ import {
   listProjectTargetChoices,
   resolvePreferredTargetName,
 } from './project-target-selection';
-import { BUNDLED_MON3_V1_REL, materializeBundledRom } from './bundle-materialize';
+import {
+  BUNDLED_MON1B_V1_REL,
+  BUNDLED_MON3_V1_REL,
+  materializeBundledAsset,
+} from './bundle-materialize';
 import { scaffoldProject } from './project-scaffolding';
 import { fetchRomSources } from './rom-sources';
 import { SourceColumnController } from './source-columns';
 import { TerminalPanelController } from './terminal-panel';
 import { WorkspaceSelectionController } from './workspace-selection';
-import type { ProjectConfig } from '../debug/types';
+import type { BundledAssetReference, ProjectConfig } from '../debug/types';
 import { TEC1_APP_START_DEFAULT } from '../platforms/tec1/constants';
 import {
   TEC1G_APP_START_DEFAULT,
@@ -67,6 +71,11 @@ type ConfigureFieldId =
   | 'targetName'
   | 'outputDir'
   | 'artifactBase';
+
+type BundledAssetInstallPlan = {
+  label: string;
+  references: BundledAssetReference[];
+};
 
 function createSimplePlatformDefaults(): Record<string, unknown> {
   return {
@@ -378,6 +387,86 @@ function resolveSessionProjectConfigPath(session: vscode.DebugSession): string |
   return path.normalize(projectConfigRaw);
 }
 
+function normalizeBundledAssetInstallPlan(
+  label: string,
+  references: BundledAssetReference[]
+): BundledAssetInstallPlan | undefined {
+  const filtered = references.filter(
+    (reference) =>
+      typeof reference.bundleId === 'string' &&
+      reference.bundleId.trim().length > 0 &&
+      typeof reference.path === 'string' &&
+      reference.path.trim().length > 0
+  );
+  if (filtered.length === 0) {
+    return undefined;
+  }
+  return { label, references: filtered };
+}
+
+function resolveProjectBundledAssetInstallPlan(
+  config: ProjectConfig
+): BundledAssetInstallPlan | undefined {
+  const defaultProfileName =
+    typeof config.defaultProfile === 'string' && config.defaultProfile.trim().length > 0
+      ? config.defaultProfile.trim()
+      : undefined;
+  if (defaultProfileName !== undefined) {
+    const defaultProfile = config.profiles?.[defaultProfileName];
+    const profilePlan = normalizeBundledAssetInstallPlan(
+      `profile:${defaultProfileName}`,
+      Object.values(defaultProfile?.bundledAssets ?? {})
+    );
+    if (profilePlan !== undefined) {
+      return profilePlan;
+    }
+  }
+
+  const rootPlan = normalizeBundledAssetInstallPlan(
+    'bundledAssets',
+    Object.values(config.bundledAssets ?? {})
+  );
+  if (rootPlan !== undefined) {
+    return rootPlan;
+  }
+
+  const profileEntries = Object.entries(config.profiles ?? {}).filter(([, profile]) =>
+    Object.keys(profile?.bundledAssets ?? {}).length > 0
+  );
+  if (profileEntries.length === 1) {
+    const firstProfileEntry = profileEntries[0];
+    if (firstProfileEntry === undefined) {
+      return undefined;
+    }
+    const [profileName, profile] = firstProfileEntry;
+    return normalizeBundledAssetInstallPlan(
+      `profile:${profileName}`,
+      Object.values(profile?.bundledAssets ?? {})
+    );
+  }
+
+  return undefined;
+}
+
+function buildBundledAssetFallbackPlans(): BundledAssetInstallPlan[] {
+  return [
+    {
+      label: 'MON3 (TEC-1G)',
+      references: [
+        { bundleId: BUNDLED_MON3_V1_REL, path: 'mon3.bin' },
+        { bundleId: BUNDLED_MON3_V1_REL, path: 'mon3.lst' },
+      ],
+    },
+    {
+      label: 'MON-1B (TEC-1)',
+      references: [
+        { bundleId: BUNDLED_MON1B_V1_REL, path: 'mon-1b.bin' },
+        { bundleId: BUNDLED_MON1B_V1_REL, path: 'mon-1b.lst' },
+      ],
+    },
+  ];
+}
+
 export function registerExtensionCommands({
   context,
   platformViewProvider,
@@ -422,9 +511,33 @@ export function registerExtensionCommands({
       const folder = await workspaceSelection.resolveWorkspaceFolder({
         prompt: true,
         requireProject: false,
-        placeHolder: 'Select the workspace folder to install bundled MON3 ROM and listing',
+        placeHolder: 'Select the workspace folder to install bundled assets',
       });
       if (folder === undefined) {
+        return false;
+      }
+      const projectConfigPath = findProjectConfigPath(folder);
+      const projectConfig =
+        projectConfigPath !== undefined ? readProjectConfig(projectConfigPath) : undefined;
+      const projectPlan =
+        projectConfig !== undefined ? resolveProjectBundledAssetInstallPlan(projectConfig) : undefined;
+      let installPlan = projectPlan;
+      if (installPlan === undefined) {
+        const pick = await vscode.window.showQuickPick(
+          buildBundledAssetFallbackPlans().map((plan) => ({
+            label: plan.label,
+            plan,
+          })),
+          {
+            placeHolder: 'Select the bundled asset set to install',
+          }
+        );
+        installPlan = pick?.plan;
+      }
+      if (installPlan === undefined) {
+        void vscode.window.showErrorMessage(
+          'Debug80: No bundled asset references were available to install.'
+        );
         return false;
       }
       const pick = await vscode.window.showQuickPick(
@@ -437,24 +550,24 @@ export function registerExtensionCommands({
       if (pick === undefined) {
         return undefined;
       }
-      const result = materializeBundledRom(
-        context.extensionUri,
-        folder.uri.fsPath,
-        BUNDLED_MON3_V1_REL,
-        { overwrite: pick.value }
-      );
-      if (result.ok) {
-        const listingNote =
-          result.listingRelativePath !== undefined
-            ? ` Listing: ${result.listingRelativePath}.`
-            : '';
-        void vscode.window.showInformationMessage(
-          `Debug80: Installed bundled MON3 ROM at ${result.romRelativePath}.${listingNote}`
+      const installed: string[] = [];
+      for (const reference of installPlan.references) {
+        const result = materializeBundledAsset(
+          context.extensionUri,
+          folder.uri.fsPath,
+          reference,
+          { overwrite: pick.value }
         );
-        return true;
+        if (!result.ok) {
+          void vscode.window.showErrorMessage(`Debug80: ${result.reason}`);
+          return false;
+        }
+        installed.push(result.materializedRelativePath);
       }
-      void vscode.window.showErrorMessage(`Debug80: ${result.reason}`);
-      return false;
+      void vscode.window.showInformationMessage(
+        `Debug80: Installed bundled assets for ${installPlan.label}: ${installed.join(', ')}`
+      );
+      return true;
     })
   );
 

--- a/tests/extension/bundle-materialize.test.ts
+++ b/tests/extension/bundle-materialize.test.ts
@@ -19,6 +19,7 @@ vi.mock('vscode', () => ({
 import * as vscode from 'vscode';
 import {
   BUNDLED_MON3_V1_REL,
+  materializeBundledAsset,
   materializeBundledRom,
 } from '../../src/extension/bundle-materialize';
 import * as crypto from 'crypto';
@@ -102,6 +103,43 @@ describe('bundle-materialize', () => {
     }
     expect(result.romRelativePath).toBe('roms/out/rom.bin');
     expect(result.listingRelativePath).toBe('roms/out/rom.lst');
+  });
+
+  it('materializes a single bundled asset reference to an explicit destination', () => {
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-asset-'));
+    tmpDirs.push(workspaceRoot);
+
+    const bundleRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-asset-ext-'));
+    tmpDirs.push(bundleRoot);
+    const rel = 'demo/asset/v1';
+    const bundleDir = path.join(bundleRoot, 'resources', 'bundles', ...rel.split('/'));
+    fs.mkdirSync(bundleDir, { recursive: true });
+    fs.writeFileSync(path.join(bundleDir, 'payload.bin'), Buffer.from([0xde, 0xad, 0xbe, 0xef]));
+
+    const manifest = {
+      schemaVersion: 1,
+      id: 'demo-asset',
+      version: '1',
+      platform: 'tec1g',
+      label: 'Demo Asset',
+      files: [{ role: 'rom' as const, path: 'payload.bin' }],
+      workspaceLayout: { destination: 'roms/demo-default' },
+    };
+    fs.writeFileSync(path.join(bundleDir, 'bundle.json'), JSON.stringify(manifest));
+
+    const result = materializeBundledAsset(vscode.Uri.file(bundleRoot), workspaceRoot, {
+      bundleId: rel,
+      path: 'payload.bin',
+      destination: 'assets/custom/payload.bin',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.destinationRelative).toBe('assets/custom/payload.bin');
+    expect(result.materializedRelativePath).toBe('assets/custom/payload.bin');
+    expect(fs.existsSync(path.join(workspaceRoot, 'assets', 'custom', 'payload.bin'))).toBe(true);
   });
 
   it('exposes bundled MON3 path constant for scaffold', () => {

--- a/tests/extension/bundle-materialize.test.ts
+++ b/tests/extension/bundle-materialize.test.ts
@@ -142,6 +142,88 @@ describe('bundle-materialize', () => {
     expect(fs.existsSync(path.join(workspaceRoot, 'assets', 'custom', 'payload.bin'))).toBe(true);
   });
 
+  it('rejects a bundled asset destination that escapes the workspace root', () => {
+    const workspaceBase = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-asset-root-'));
+    tmpDirs.push(workspaceBase);
+    const workspaceRoot = path.join(workspaceBase, 'project');
+    fs.mkdirSync(workspaceRoot, { recursive: true });
+
+    const bundleRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-asset-ext-escape-'));
+    tmpDirs.push(bundleRoot);
+    const rel = 'demo/escape/v1';
+    const bundleDir = path.join(bundleRoot, 'resources', 'bundles', ...rel.split('/'));
+    fs.mkdirSync(bundleDir, { recursive: true });
+    fs.writeFileSync(path.join(bundleDir, 'payload.bin'), Buffer.from([0x01]));
+    fs.writeFileSync(
+      path.join(bundleDir, 'bundle.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        id: 'demo-escape',
+        version: '1',
+        platform: 'tec1g',
+        label: 'Escape',
+        files: [{ role: 'rom' as const, path: 'payload.bin' }],
+        workspaceLayout: { destination: 'roms/escape' },
+      })
+    );
+
+    const escapeTarget = path.resolve(workspaceRoot, '../../escape.bin');
+    fs.rmSync(escapeTarget, { force: true });
+
+    const result = materializeBundledAsset(vscode.Uri.file(bundleRoot), workspaceRoot, {
+      bundleId: rel,
+      path: 'payload.bin',
+      destination: '../../escape.bin',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.reason).toContain('escapes the workspace root');
+    expect(fs.existsSync(escapeTarget)).toBe(false);
+  });
+
+  it('rejects an absolute bundled asset destination path', () => {
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-asset-abs-'));
+    tmpDirs.push(workspaceRoot);
+
+    const bundleRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-asset-ext-abs-'));
+    tmpDirs.push(bundleRoot);
+    const rel = 'demo/abs/v1';
+    const bundleDir = path.join(bundleRoot, 'resources', 'bundles', ...rel.split('/'));
+    fs.mkdirSync(bundleDir, { recursive: true });
+    fs.writeFileSync(path.join(bundleDir, 'payload.bin'), Buffer.from([0x02]));
+    fs.writeFileSync(
+      path.join(bundleDir, 'bundle.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        id: 'demo-abs',
+        version: '1',
+        platform: 'tec1g',
+        label: 'Absolute',
+        files: [{ role: 'rom' as const, path: 'payload.bin' }],
+        workspaceLayout: { destination: 'roms/abs' },
+      })
+    );
+
+    const absoluteTarget = path.resolve(os.tmpdir(), 'debug80-absolute.bin');
+    fs.rmSync(absoluteTarget, { force: true });
+
+    const result = materializeBundledAsset(vscode.Uri.file(bundleRoot), workspaceRoot, {
+      bundleId: rel,
+      path: 'payload.bin',
+      destination: absoluteTarget,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.reason).toContain('must be workspace-relative');
+    expect(fs.existsSync(absoluteTarget)).toBe(false);
+  });
+
   it('exposes bundled MON3 path constant for scaffold', () => {
     expect(BUNDLED_MON3_V1_REL).toBe('tec1g/mon3/v1');
   });

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -18,6 +18,8 @@ const startDebugging = vi.fn();
 const stopDebugging = vi.fn();
 const executeCommand = vi.fn();
 const scaffoldProject = vi.fn();
+const materializeBundledAsset = vi.fn();
+const materializeBundledRom = vi.fn();
 let workspaceFolders: Array<{ name: string; uri: { fsPath: string } }> | undefined;
 let panelMessageHandler: ((msg: unknown) => void) | undefined;
 let panelHtml = '';
@@ -60,6 +62,13 @@ vi.mock('vscode', () => ({
 
 vi.mock('../../src/extension/project-scaffolding', () => ({
   scaffoldProject,
+}));
+
+vi.mock('../../src/extension/bundle-materialize', () => ({
+  BUNDLED_MON1B_V1_REL: 'tec1/mon1b/v1',
+  BUNDLED_MON3_V1_REL: 'tec1g/mon3/v1',
+  materializeBundledAsset,
+  materializeBundledRom,
 }));
 
 describe('registerExtensionCommands', () => {
@@ -224,6 +233,101 @@ describe('registerExtensionCommands', () => {
     expect(rememberWorkspace).toHaveBeenCalledWith(folder);
     expect(refreshIdleView).toHaveBeenCalled();
     expect(scaffoldProject).toHaveBeenCalledWith(folder, false, undefined, undefined);
+  });
+
+  it('materializes manifest-backed bundled asset references from the project config', async () => {
+    const vscode = await import('vscode');
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    const folder = {
+      name: 'tec1g-mon3',
+      uri: { fsPath: '/workspace/tec1g-mon3' },
+      index: 0,
+    };
+    const resolveWorkspaceFolder = vi.fn().mockResolvedValue(folder);
+    const showQuickPickMock = vscode.window.showQuickPick as ReturnType<typeof vi.fn>;
+    showQuickPickMock.mockResolvedValueOnce({
+      label: 'Skip existing files',
+      value: false,
+    });
+
+    readFileSync.mockImplementationOnce(() =>
+      JSON.stringify({
+        defaultProfile: 'mon3',
+        profiles: {
+          mon3: {
+            bundledAssets: {
+              romHex: {
+                bundleId: 'tec1g/mon3/v1',
+                path: 'mon3.bin',
+                destination: 'roms/tec1g/mon3/mon3.bin',
+              },
+              listing: {
+                bundleId: 'tec1g/mon3/v1',
+                path: 'mon3.lst',
+                destination: 'roms/tec1g/mon3/mon3.lst',
+              },
+            },
+          },
+        },
+        targets: {
+          app: { sourceFile: 'src/main.asm', profile: 'mon3' },
+        },
+      })
+    );
+    materializeBundledAsset.mockImplementation(
+      (_extensionUri: unknown, _workspaceRoot: string, reference: { destination?: string }) => ({
+        ok: true,
+        destinationRelative: reference.destination ?? 'roms/tec1g/mon3',
+        materializedRelativePath: reference.destination ?? 'roms/tec1g/mon3',
+      })
+    );
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder,
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {} as never,
+    });
+
+    const materializeBundledRomCommand = registeredCommands.get('debug80.materializeBundledRom');
+    expect(materializeBundledRomCommand).toBeTypeOf('function');
+
+    const result = await materializeBundledRomCommand?.();
+
+    expect(result).toBe(true);
+    expect(materializeBundledAsset).toHaveBeenCalledTimes(2);
+    expect(materializeBundledAsset).toHaveBeenNthCalledWith(
+      1,
+      undefined,
+      '/workspace/tec1g-mon3',
+      expect.objectContaining({
+        bundleId: 'tec1g/mon3/v1',
+        path: 'mon3.bin',
+        destination: 'roms/tec1g/mon3/mon3.bin',
+      }),
+      { overwrite: false }
+    );
+    expect(materializeBundledAsset).toHaveBeenNthCalledWith(
+      2,
+      undefined,
+      '/workspace/tec1g-mon3',
+      expect.objectContaining({
+        bundleId: 'tec1g/mon3/v1',
+        path: 'mon3.lst',
+        destination: 'roms/tec1g/mon3/mon3.lst',
+      }),
+      { overwrite: false }
+    );
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Installed bundled assets for profile:mon3')
+    );
   });
 
   it('forces a prompt when selecting the active target', async () => {


### PR DESCRIPTION
Slice 1 for #280: add a generic manifest-backed bundled asset materialization helper and wire the explicit workspace command to use project-config refs or bundled asset presets. Includes focused tests for both the helper and command flow.