### PR TITLE
Emit bundled profile scaffold defaults

### DIFF
--- a/src/extension/project-kits.ts
+++ b/src/extension/project-kits.ts
@@ -1,0 +1,61 @@
+/**
+ * @file Built-in project kit definitions used by scaffolding.
+ */
+
+import type { BundledAssetReference } from '../debug/types';
+
+export type ScaffoldPlatform = 'simple' | 'tec1' | 'tec1g';
+
+export type BuiltInProjectKit = {
+  profileName: string;
+  platform: Exclude<ScaffoldPlatform, 'simple'>;
+  bundledAssets: Record<string, BundledAssetReference>;
+  romHexDestination: string;
+  listingDestination?: string;
+  sourceRoots: string[];
+};
+
+const BUILT_IN_PROJECT_KITS: Record<Exclude<ScaffoldPlatform, 'simple'>, BuiltInProjectKit> = {
+  tec1: {
+    profileName: 'mon1b',
+    platform: 'tec1',
+    bundledAssets: {
+      romHex: {
+        bundleId: 'tec1/mon1b/v1',
+        path: 'mon-1b.bin',
+        destination: 'roms/tec1/mon1b/mon-1b.bin',
+      },
+      listing: {
+        bundleId: 'tec1/mon1b/v1',
+        path: 'mon-1b.lst',
+        destination: 'roms/tec1/mon1b/mon-1b.lst',
+      },
+    },
+    romHexDestination: 'roms/tec1/mon1b/mon-1b.bin',
+    listingDestination: 'roms/tec1/mon1b/mon-1b.lst',
+    sourceRoots: ['src', 'roms/tec1/mon1b'],
+  },
+  tec1g: {
+    profileName: 'mon3',
+    platform: 'tec1g',
+    bundledAssets: {
+      romHex: {
+        bundleId: 'tec1g/mon3/v1',
+        path: 'mon3.bin',
+        destination: 'roms/tec1g/mon3/mon3.bin',
+      },
+      listing: {
+        bundleId: 'tec1g/mon3/v1',
+        path: 'mon3.lst',
+        destination: 'roms/tec1g/mon3/mon3.lst',
+      },
+    },
+    romHexDestination: 'roms/tec1g/mon3/mon3.bin',
+    listingDestination: 'roms/tec1g/mon3/mon3.lst',
+    sourceRoots: ['src', 'roms/tec1g/mon3'],
+  },
+};
+
+export function resolveBuiltInProjectKit(platform: Exclude<ScaffoldPlatform, 'simple'>): BuiltInProjectKit {
+  return BUILT_IN_PROJECT_KITS[platform];
+}

--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -11,6 +11,7 @@ import {
   findProjectConfigPath,
   listProjectSourceFiles,
 } from './project-config';
+import { materializeBundledRom } from './bundle-materialize';
 import {
   TEC1G_RAM_END,
   TEC1G_RAM_START,
@@ -227,6 +228,19 @@ export async function scaffoldProject(
 
   if (!configExists && plan === undefined) {
     return false;
+  }
+
+  if (plan !== undefined && plan.kit.bundledProfile !== undefined) {
+    const materializeResult = materializeBundledRom(
+      extensionUri ?? vscode.Uri.file(process.cwd()),
+      workspaceRoot,
+      plan.kit.bundledProfile.bundleRel
+    );
+    if (!materializeResult.ok) {
+      void vscode.window.showWarningMessage(
+        `Debug80: Could not copy bundled ${plan.kit.label} ROM (${materializeResult.reason}). You can add romHex manually in debug80.json.`
+      );
+    }
   }
 
   ensureDirExists(

--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -11,6 +11,7 @@ import {
   findProjectConfigPath,
   listProjectSourceFiles,
 } from './project-config';
+import { resolveBuiltInProjectKit, type BuiltInProjectKit, type ScaffoldPlatform } from './project-kits';
 import { TEC1_APP_START_DEFAULT } from '../platforms/tec1/constants';
 import {
   TEC1G_APP_START_DEFAULT,
@@ -21,20 +22,13 @@ import {
   TEC1G_ROM1_END,
   TEC1G_ROM1_START,
 } from '../platforms/tec1g/constants';
-import {
-  BUNDLED_MON1B_V1_REL,
-  BUNDLED_MON3_V1_REL,
-  materializeBundledRom,
-  type MaterializeBundledRomResult,
-} from './bundle-materialize';
-
-type ScaffoldPlatform = 'simple' | 'tec1' | 'tec1g';
 
 type StarterLanguage = 'asm' | 'zax';
 
 type ScaffoldPlan = {
   targetName: string;
   platform: ScaffoldPlatform;
+  kit?: BuiltInProjectKit;
   sourceFile: string;
   outputDir: string;
   artifactBase: string;
@@ -42,10 +36,6 @@ type ScaffoldPlan = {
     path: string;
     content: string;
   };
-  /** Present when bundled MON3 was copied into the workspace during scaffold */
-  bundledMon3?: Extract<MaterializeBundledRomResult, { ok: true }>;
-  /** Present when bundled MON-1B was copied into the workspace during scaffold */
-  bundledMon1b?: Extract<MaterializeBundledRomResult, { ok: true }>;
 };
 
 type SourceChoice =
@@ -110,6 +100,10 @@ export function createDefaultProjectConfig(plan: ScaffoldPlan): {
   defaultTarget: string;
   targets: Record<string, Record<string, unknown>>;
 } {
+  const kit =
+    plan.kit ?? (plan.platform === 'tec1' || plan.platform === 'tec1g'
+      ? resolveBuiltInProjectKit(plan.platform)
+      : undefined);
   const targetConfig: Record<string, unknown> = {
     sourceFile: plan.sourceFile,
     outputDir: plan.outputDir,
@@ -117,53 +111,55 @@ export function createDefaultProjectConfig(plan: ScaffoldPlan): {
     platform: plan.platform,
   };
 
-  if (plan.platform === 'tec1') {
+  if (kit !== undefined) {
+    targetConfig.profile = kit.profileName;
+    const base = plan.platform === 'tec1' ? createTec1Defaults() : createTec1gDefaults();
+    targetConfig[plan.platform] = {
+      ...base,
+      romHex: kit.romHexDestination,
+      ...(kit.listingDestination !== undefined
+        ? { extraListings: [kit.listingDestination] }
+        : {}),
+      sourceRoots: kit.sourceRoots,
+    };
+  } else if (plan.platform === 'tec1') {
     const base = createTec1Defaults();
-    if (plan.bundledMon1b !== undefined) {
-      const sourceRoots = [
-        'src',
-        ...(plan.bundledMon1b.listingRelativePath !== undefined ? ['roms/tec1/mon1b'] : []),
-      ];
-      targetConfig.tec1 = {
-        ...base,
-        romHex: plan.bundledMon1b.romRelativePath,
-        ...(plan.bundledMon1b.listingRelativePath !== undefined
-          ? { extraListings: [plan.bundledMon1b.listingRelativePath] }
-          : {}),
-        sourceRoots,
-      };
-    } else {
-      targetConfig.tec1 = base;
-    }
+    targetConfig.tec1 = base;
   } else if (plan.platform === 'tec1g') {
     const base = createTec1gDefaults();
-    if (plan.bundledMon3 !== undefined) {
-      const sourceRoots = [
-        'src',
-        ...(plan.bundledMon3.listingRelativePath !== undefined ? ['roms/tec1g/mon3'] : []),
-      ];
-      targetConfig.tec1g = {
-        ...base,
-        romHex: plan.bundledMon3.romRelativePath,
-        ...(plan.bundledMon3.listingRelativePath !== undefined
-          ? { extraListings: [plan.bundledMon3.listingRelativePath] }
-          : {}),
-        sourceRoots,
-      };
-    } else {
-      targetConfig.tec1g = base;
-    }
+    targetConfig.tec1g = base;
   } else {
     targetConfig.simple = createSimpleDefaults();
   }
 
-  return {
+  const config: {
+    projectVersion: typeof DEBUG80_PROJECT_VERSION;
+    projectPlatform: ScaffoldPlatform;
+    defaultTarget: string;
+    targets: Record<string, Record<string, unknown>>;
+    defaultProfile?: string;
+    profiles?: Record<string, { platform: ScaffoldPlatform; bundledAssets: BuiltInProjectKit['bundledAssets'] }>;
+  } = {
     projectVersion: DEBUG80_PROJECT_VERSION,
     projectPlatform: plan.platform,
     defaultTarget: plan.targetName,
     targets: {
       [plan.targetName]: targetConfig,
     },
+  };
+
+  if (kit !== undefined) {
+    config.defaultProfile = kit.profileName;
+    config.profiles = {
+      [kit.profileName]: {
+        platform: plan.platform,
+        bundledAssets: kit.bundledAssets,
+      },
+    };
+  }
+
+  return {
+    ...config,
   };
 }
 
@@ -213,6 +209,7 @@ export async function scaffoldProject(
   extensionUri?: vscode.Uri,
   preselectedPlatform?: string
 ): Promise<boolean> {
+  void extensionUri;
   const workspaceRoot = folder.uri.fsPath;
   const vscodeDir = path.join(workspaceRoot, '.vscode');
   const configPath = path.join(workspaceRoot, 'debug80.json');
@@ -226,29 +223,7 @@ export async function scaffoldProject(
     return false;
   }
 
-  let scaffoldPlan = plan;
-
-  if (scaffoldPlan !== undefined && extensionUri !== undefined) {
-    if (scaffoldPlan.platform === 'tec1g') {
-      const mat = materializeBundledRom(extensionUri, workspaceRoot, BUNDLED_MON3_V1_REL);
-      if (mat.ok) {
-        scaffoldPlan = { ...scaffoldPlan, bundledMon3: mat };
-      } else {
-        void vscode.window.showWarningMessage(
-          `Debug80: Could not copy bundled MON3 ROM (${mat.reason}). You can add romHex manually in debug80.json.`
-        );
-      }
-    } else if (scaffoldPlan.platform === 'tec1') {
-      const mat = materializeBundledRom(extensionUri, workspaceRoot, BUNDLED_MON1B_V1_REL);
-      if (mat.ok) {
-        scaffoldPlan = { ...scaffoldPlan, bundledMon1b: mat };
-      } else {
-        void vscode.window.showWarningMessage(
-          `Debug80: Could not copy bundled MON-1B ROM (${mat.reason}). You can add romHex manually in debug80.json.`
-        );
-      }
-    }
-  }
+  const scaffoldPlan = plan;
 
   ensureDirExists(
     path.join(workspaceRoot, path.dirname(scaffoldPlan?.sourceFile ?? inferred.sourceFile))
@@ -356,11 +331,15 @@ async function buildScaffoldPlan(
     return undefined;
   }
 
+  const kit =
+    platform === 'tec1' || platform === 'tec1g' ? resolveBuiltInProjectKit(platform) : undefined;
+
   if (choice.kind === 'existing') {
     const sourceFile = choice.sourceFile;
     return {
       targetName,
       platform,
+      ...(kit !== undefined ? { kit } : {}),
       sourceFile,
       outputDir: inferred.outputDir,
       artifactBase: path.basename(sourceFile, path.extname(sourceFile)) || inferred.artifactBase,
@@ -371,6 +350,7 @@ async function buildScaffoldPlan(
   return {
     targetName,
     platform,
+    ...(kit !== undefined ? { kit } : {}),
     sourceFile,
     outputDir: inferred.outputDir,
     artifactBase: path.basename(sourceFile, path.extname(sourceFile)) || inferred.artifactBase,
@@ -400,11 +380,13 @@ function buildDefaultScaffoldPlan(
     ? { path: 'src/main.asm', content: createStarterSourceContent('asm') }
     : undefined;
   const resolvedSource = needsStarter ? 'src/main.asm' : sourceFile;
+  const kit = platform === 'tec1' || platform === 'tec1g' ? resolveBuiltInProjectKit(platform) : undefined;
 
   const baseName = path.basename(resolvedSource, path.extname(resolvedSource)) || inferred.artifactBase;
   return {
     targetName: baseName,
     platform,
+    ...(kit !== undefined ? { kit } : {}),
     sourceFile: resolvedSource,
     outputDir: inferred.outputDir,
     artifactBase: baseName,

--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -152,13 +152,32 @@ describe('project-scaffolding helpers', () => {
     expect(config).toEqual({
       projectVersion: DEBUG80_PROJECT_VERSION,
       projectPlatform: 'tec1',
+      defaultProfile: 'mon1b',
       defaultTarget: 'app',
+      profiles: {
+        mon1b: {
+          platform: 'tec1',
+          bundledAssets: {
+            romHex: {
+              bundleId: 'tec1/mon1b/v1',
+              path: 'mon-1b.bin',
+              destination: 'roms/tec1/mon1b/mon-1b.bin',
+            },
+            listing: {
+              bundleId: 'tec1/mon1b/v1',
+              path: 'mon-1b.lst',
+              destination: 'roms/tec1/mon1b/mon-1b.lst',
+            },
+          },
+        },
+      },
       targets: {
         app: {
           sourceFile: 'src/main.asm',
           outputDir: 'build',
           artifactBase: 'main',
           platform: 'tec1',
+          profile: 'mon1b',
           tec1: {
             regions: [
               { start: 0, end: 2047, kind: 'rom' },
@@ -166,37 +185,122 @@ describe('project-scaffolding helpers', () => {
             ],
             appStart: 0x0800,
             entry: 0,
+            romHex: 'roms/tec1/mon1b/mon-1b.bin',
+            extraListings: ['roms/tec1/mon1b/mon-1b.lst'],
+            sourceRoots: ['src', 'roms/tec1/mon1b'],
           },
         },
       },
     });
   });
 
-  it('merges bundled MON3 paths into tec1g when materialization succeeded', () => {
+  it('builds a tec1g bundled profile config for MON3', () => {
     const config = createDefaultProjectConfig({
       targetName: 'app',
       platform: 'tec1g',
       sourceFile: 'src/main.asm',
       outputDir: 'build',
       artifactBase: 'main',
-      bundledMon3: {
-        ok: true,
-        destinationRelative: 'roms/tec1g/mon3',
-        romRelativePath: 'roms/tec1g/mon3/mon3.bin',
-        listingRelativePath: 'roms/tec1g/mon3/mon3.lst',
-      },
     });
 
-    expect(config.targets.app).toEqual(
-      expect.objectContaining({
-        platform: 'tec1g',
-        tec1g: expect.objectContaining({
-          romHex: 'roms/tec1g/mon3/mon3.bin',
-          extraListings: ['roms/tec1g/mon3/mon3.lst'],
-          sourceRoots: ['src', 'roms/tec1g/mon3'],
-        }),
-      })
-    );
+    expect(config).toEqual({
+      projectVersion: DEBUG80_PROJECT_VERSION,
+      projectPlatform: 'tec1g',
+      defaultProfile: 'mon3',
+      defaultTarget: 'app',
+      profiles: {
+        mon3: {
+          platform: 'tec1g',
+          bundledAssets: {
+            romHex: {
+              bundleId: 'tec1g/mon3/v1',
+              path: 'mon3.bin',
+              destination: 'roms/tec1g/mon3/mon3.bin',
+            },
+            listing: {
+              bundleId: 'tec1g/mon3/v1',
+              path: 'mon3.lst',
+              destination: 'roms/tec1g/mon3/mon3.lst',
+            },
+          },
+        },
+      },
+      targets: {
+        app: {
+          sourceFile: 'src/main.asm',
+          outputDir: 'build',
+          artifactBase: 'main',
+          platform: 'tec1g',
+          profile: 'mon3',
+          tec1g: {
+            regions: [
+              { start: 0, end: 2047, kind: 'rom' },
+              { start: 2048, end: 32767, kind: 'ram' },
+              { start: 49152, end: 65535, kind: 'rom' },
+            ],
+            appStart: 0x4000,
+            entry: 0,
+            romHex: 'roms/tec1g/mon3/mon3.bin',
+            extraListings: ['roms/tec1g/mon3/mon3.lst'],
+            sourceRoots: ['src', 'roms/tec1g/mon3'],
+          },
+        },
+      },
+    });
+  });
+
+  it('builds a tec1 bundled profile config for MON-1B', () => {
+    const config = createDefaultProjectConfig({
+      targetName: 'app',
+      platform: 'tec1',
+      sourceFile: 'src/main.asm',
+      outputDir: 'build',
+      artifactBase: 'main',
+    });
+
+    expect(config).toEqual({
+      projectVersion: DEBUG80_PROJECT_VERSION,
+      projectPlatform: 'tec1',
+      defaultProfile: 'mon1b',
+      defaultTarget: 'app',
+      profiles: {
+        mon1b: {
+          platform: 'tec1',
+          bundledAssets: {
+            romHex: {
+              bundleId: 'tec1/mon1b/v1',
+              path: 'mon-1b.bin',
+              destination: 'roms/tec1/mon1b/mon-1b.bin',
+            },
+            listing: {
+              bundleId: 'tec1/mon1b/v1',
+              path: 'mon-1b.lst',
+              destination: 'roms/tec1/mon1b/mon-1b.lst',
+            },
+          },
+        },
+      },
+      targets: {
+        app: {
+          sourceFile: 'src/main.asm',
+          outputDir: 'build',
+          artifactBase: 'main',
+          platform: 'tec1',
+          profile: 'mon1b',
+          tec1: {
+            regions: [
+              { start: 0, end: 2047, kind: 'rom' },
+              { start: 2048, end: 4095, kind: 'ram' },
+            ],
+            appStart: 0x0800,
+            entry: 0,
+            romHex: 'roms/tec1/mon1b/mon-1b.bin',
+            extraListings: ['roms/tec1/mon1b/mon-1b.lst'],
+            sourceRoots: ['src', 'roms/tec1/mon1b'],
+          },
+        },
+      },
+    });
   });
 
   it('builds a tec1g target config when scaffolding for TEC-1G', () => {
@@ -211,13 +315,32 @@ describe('project-scaffolding helpers', () => {
     expect(config).toEqual({
       projectVersion: DEBUG80_PROJECT_VERSION,
       projectPlatform: 'tec1g',
+      defaultProfile: 'mon3',
       defaultTarget: 'app',
+      profiles: {
+        mon3: {
+          platform: 'tec1g',
+          bundledAssets: {
+            romHex: {
+              bundleId: 'tec1g/mon3/v1',
+              path: 'mon3.bin',
+              destination: 'roms/tec1g/mon3/mon3.bin',
+            },
+            listing: {
+              bundleId: 'tec1g/mon3/v1',
+              path: 'mon3.lst',
+              destination: 'roms/tec1g/mon3/mon3.lst',
+            },
+          },
+        },
+      },
       targets: {
         app: {
           sourceFile: 'src/main.asm',
           outputDir: 'build',
           artifactBase: 'main',
           platform: 'tec1g',
+          profile: 'mon3',
           tec1g: {
             regions: [
               { start: 0, end: 2047, kind: 'rom' },
@@ -226,6 +349,9 @@ describe('project-scaffolding helpers', () => {
             ],
             appStart: 0x4000,
             entry: 0,
+            romHex: 'roms/tec1g/mon3/mon3.bin',
+            extraListings: ['roms/tec1g/mon3/mon3.lst'],
+            sourceRoots: ['src', 'roms/tec1g/mon3'],
           },
         },
       },
@@ -276,15 +402,23 @@ describe('project-scaffolding helpers', () => {
     const writtenConfig = JSON.parse(String(configWrite?.[1] ?? '{}')) as {
       projectVersion?: number;
       projectPlatform?: string;
-      targets?: Record<string, { platform?: string; tec1g?: Record<string, unknown> }>;
+      defaultProfile?: string;
+      profiles?: Record<string, { platform?: string; bundledAssets?: Record<string, { bundleId?: string }> }>;
+      targets?: Record<string, { platform?: string; profile?: string; tec1g?: Record<string, unknown> }>;
     };
     expect(writtenConfig.projectVersion).toBe(DEBUG80_PROJECT_VERSION);
     expect(writtenConfig.projectPlatform).toBe('tec1g');
+    expect(writtenConfig.defaultProfile).toBe('mon3');
+    expect(writtenConfig.profiles?.mon3?.platform).toBe('tec1g');
+    expect(writtenConfig.profiles?.mon3?.bundledAssets?.romHex?.bundleId).toBe('tec1g/mon3/v1');
     expect(writtenConfig.targets?.app?.platform).toBe('tec1g');
+    expect(writtenConfig.targets?.app?.profile).toBe('mon3');
     expect(writtenConfig.targets?.app?.tec1g).toEqual(
       expect.objectContaining({
         appStart: 0x4000,
         entry: 0,
+        romHex: 'roms/tec1g/mon3/mon3.bin',
+        extraListings: ['roms/tec1g/mon3/mon3.lst'],
       })
     );
 

--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
 
 const { showQuickPick, showInputBox, showInformationMessage, showErrorMessage } = vi.hoisted(
   () => ({
@@ -8,6 +11,15 @@ const { showQuickPick, showInputBox, showInformationMessage, showErrorMessage } 
     showErrorMessage: vi.fn(),
   })
 );
+
+function defaultExistsSync(candidate: string): boolean {
+  const normalized = candidate.replace(/\\/g, '/');
+  return (
+    !normalized.endsWith('/debug80.json') &&
+    !normalized.endsWith('/.vscode/debug80.json') &&
+    !normalized.endsWith('/.debug80.json')
+  );
+}
 
 import {
   createDefaultProjectConfig,
@@ -19,6 +31,15 @@ import { DEBUG80_PROJECT_VERSION } from '../../src/extension/project-config';
 import { getProjectKitById } from '../../src/extension/project-kits';
 
 vi.mock('vscode', () => ({
+  Uri: {
+    file: (fsPath: string) => ({ fsPath }),
+    joinPath: (...segments: Array<{ fsPath?: string } | string>) => {
+      const parts = segments.map((segment) =>
+        typeof segment === 'string' ? segment : segment.fsPath ?? ''
+      );
+      return { fsPath: path.join(...parts) };
+    },
+  },
   window: {
     showQuickPick,
     showInputBox,
@@ -31,14 +52,7 @@ vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
   return {
     ...actual,
-    existsSync: vi.fn((candidate: string) => {
-      const normalized = candidate.replace(/\\/g, '/');
-      return (
-        !normalized.endsWith('/debug80.json') &&
-        !normalized.endsWith('/.vscode/debug80.json') &&
-        !normalized.endsWith('/.debug80.json')
-      );
-    }),
+    existsSync: vi.fn(defaultExistsSync),
     writeFileSync: vi.fn(),
   };
 });
@@ -65,6 +79,7 @@ vi.mock('../../src/extension/project-config', async () => {
 describe('project-scaffolding helpers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockImplementation(defaultExistsSync);
   });
 
   function kit(id: Parameters<typeof getProjectKitById>[0]) {
@@ -330,63 +345,151 @@ describe('project-scaffolding helpers', () => {
     expect(showInputBox).not.toHaveBeenCalled();
   });
 
-  it('writes a tec1g config without materializing bundle files during scaffold', async () => {
+  it('writes a tec1g config and materializes MON-3 bundle files during scaffold', async () => {
     const fs = await import('fs');
+    const actualFs = await vi.importActual<typeof import('fs')>('fs');
     const writeFileSync = vi.mocked(fs.writeFileSync);
+    const existsSync = vi.mocked(fs.existsSync);
 
-    showQuickPick.mockResolvedValueOnce({ kit: kit('tec1g/mon3') }).mockResolvedValueOnce({
-      choice: { kind: 'starter', language: 'asm' },
+    existsSync.mockImplementation((candidate: string) => {
+      const normalized = candidate.replace(/\\/g, '/');
+      if (
+        normalized.endsWith('/debug80.json') ||
+        normalized.endsWith('/.vscode/debug80.json') ||
+        normalized.endsWith('/.debug80.json')
+      ) {
+        return false;
+      }
+      if (normalized.includes('/resources/bundles/')) {
+        return true;
+      }
+      return false;
     });
-    showInputBox.mockResolvedValueOnce('app');
 
-    const created = await scaffoldProject(
-      { name: 'demo', uri: { fsPath: '/workspace/demo' }, index: 0 } as never,
-      false
-    );
+    const workspaceRoot = actualFs.mkdtempSync(path.join(os.tmpdir(), 'debug80-scaffold-'));
+    try {
+      showQuickPick.mockResolvedValueOnce({ kit: kit('tec1g/mon3') }).mockResolvedValueOnce({
+        choice: { kind: 'starter', language: 'asm' },
+      });
+      showInputBox.mockResolvedValueOnce('app');
 
-    expect(created).toBe(true);
-    expect(showQuickPick).toHaveBeenCalledTimes(2);
-    expect(showInputBox).toHaveBeenCalledOnce();
-    expect(writeFileSync).toHaveBeenCalled();
-    expect(
-      writeFileSync.mock.calls.some(([filePath]) =>
-        String(filePath).replace(/\\/g, '/').includes('/roms/')
-      )
-    ).toBe(false);
+      const created = await scaffoldProject(
+        { name: 'demo', uri: { fsPath: workspaceRoot }, index: 0 } as never,
+        false
+      );
 
-    const configWrite = writeFileSync.mock.calls.find(([filePath]) =>
-      String(filePath).replace(/\\/g, '/').endsWith('/debug80.json')
-    );
-    expect(configWrite).toBeDefined();
+      expect(created).toBe(true);
+      expect(showQuickPick).toHaveBeenCalledTimes(2);
+      expect(showInputBox).toHaveBeenCalledOnce();
+      expect(writeFileSync).toHaveBeenCalled();
 
-    const writtenConfig = JSON.parse(String(configWrite?.[1] ?? '{}')) as {
-      projectVersion?: number;
-      projectPlatform?: string;
-      defaultProfile?: string;
-      profiles?: Record<string, { platform?: string; bundledAssets?: Record<string, { bundleId?: string; destination?: string }> }>;
-      targets?: Record<string, { platform?: string; profile?: string; tec1g?: Record<string, unknown> }>;
-    };
-    expect(writtenConfig.projectVersion).toBe(DEBUG80_PROJECT_VERSION);
-    expect(writtenConfig.projectPlatform).toBe('tec1g');
-    expect(writtenConfig.defaultProfile).toBe('mon3');
-    expect(writtenConfig.profiles?.mon3?.platform).toBe('tec1g');
-    expect(writtenConfig.profiles?.mon3?.bundledAssets?.romHex?.bundleId).toBe('tec1g/mon3/v1');
-    expect(writtenConfig.profiles?.mon3?.bundledAssets?.romHex?.destination).toBe(
-      'roms/tec1g/mon3/mon3.bin'
-    );
-    expect(writtenConfig.targets?.app?.platform).toBe('tec1g');
-    expect(writtenConfig.targets?.app?.profile).toBe('mon3');
-    expect(writtenConfig.targets?.app?.tec1g).toEqual(
-      expect.objectContaining({
-        appStart: 0x4000,
-        entry: 0,
-        romHex: 'roms/tec1g/mon3/mon3.bin',
-        extraListings: ['roms/tec1g/mon3/mon3.lst'],
-      })
-    );
+      const configWrite = writeFileSync.mock.calls.find(([filePath]) =>
+        String(filePath).replace(/\\/g, '/').endsWith('/debug80.json')
+      );
+      expect(configWrite).toBeDefined();
 
-    expect(showInformationMessage).toHaveBeenCalledWith(
-      'Debug80: Created TEC-1G / MON-3 project in debug80.json targeting src/main.asm.'
-    );
+      const writtenConfig = JSON.parse(String(configWrite?.[1] ?? '{}')) as {
+        projectVersion?: number;
+        projectPlatform?: string;
+        defaultProfile?: string;
+        profiles?: Record<string, { platform?: string; bundledAssets?: Record<string, { bundleId?: string; destination?: string }> }>;
+        targets?: Record<string, { platform?: string; profile?: string; tec1g?: Record<string, unknown> }>;
+      };
+      expect(writtenConfig.projectVersion).toBe(DEBUG80_PROJECT_VERSION);
+      expect(writtenConfig.projectPlatform).toBe('tec1g');
+      expect(writtenConfig.defaultProfile).toBe('mon3');
+      expect(writtenConfig.profiles?.mon3?.platform).toBe('tec1g');
+      expect(writtenConfig.profiles?.mon3?.bundledAssets?.romHex?.bundleId).toBe('tec1g/mon3/v1');
+      expect(writtenConfig.profiles?.mon3?.bundledAssets?.romHex?.destination).toBe(
+        'roms/tec1g/mon3/mon3.bin'
+      );
+      expect(writtenConfig.targets?.app?.platform).toBe('tec1g');
+      expect(writtenConfig.targets?.app?.profile).toBe('mon3');
+      expect(writtenConfig.targets?.app?.tec1g).toEqual(
+        expect.objectContaining({
+          appStart: 0x4000,
+          entry: 0,
+          romHex: 'roms/tec1g/mon3/mon3.bin',
+          extraListings: ['roms/tec1g/mon3/mon3.lst'],
+        })
+      );
+
+      expect(actualFs.existsSync(path.join(workspaceRoot, 'roms/tec1g/mon3/mon3.bin'))).toBe(true);
+      expect(actualFs.existsSync(path.join(workspaceRoot, 'roms/tec1g/mon3/mon3.lst'))).toBe(true);
+      expect(showInformationMessage).toHaveBeenCalledWith(
+        'Debug80: Created TEC-1G / MON-3 project in debug80.json targeting src/main.asm.'
+      );
+    } finally {
+      vi.mocked(fs.existsSync).mockImplementation(defaultExistsSync);
+      actualFs.rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('writes a tec1 config and materializes MON-1B bundle files during scaffold', async () => {
+    const fs = await import('fs');
+    const actualFs = await vi.importActual<typeof import('fs')>('fs');
+    const writeFileSync = vi.mocked(fs.writeFileSync);
+    const existsSync = vi.mocked(fs.existsSync);
+
+    existsSync.mockImplementation((candidate: string) => {
+      const normalized = candidate.replace(/\\/g, '/');
+      if (
+        normalized.endsWith('/debug80.json') ||
+        normalized.endsWith('/.vscode/debug80.json') ||
+        normalized.endsWith('/.debug80.json')
+      ) {
+        return false;
+      }
+      if (normalized.includes('/resources/bundles/')) {
+        return true;
+      }
+      return false;
+    });
+
+    const workspaceRoot = actualFs.mkdtempSync(path.join(os.tmpdir(), 'debug80-scaffold-'));
+    try {
+      showQuickPick.mockResolvedValueOnce({ kit: kit('tec1/mon1b') }).mockResolvedValueOnce({
+        choice: { kind: 'starter', language: 'asm' },
+      });
+      showInputBox.mockResolvedValueOnce('app');
+
+      const created = await scaffoldProject(
+        { name: 'demo', uri: { fsPath: workspaceRoot }, index: 0 } as never,
+        false
+      );
+
+      expect(created).toBe(true);
+      expect(showQuickPick).toHaveBeenCalledTimes(2);
+      expect(showInputBox).toHaveBeenCalledOnce();
+      expect(writeFileSync).toHaveBeenCalled();
+
+      const configWrite = writeFileSync.mock.calls.find(([filePath]) =>
+        String(filePath).replace(/\\/g, '/').endsWith('/debug80.json')
+      );
+      expect(configWrite).toBeDefined();
+
+      const writtenConfig = JSON.parse(String(configWrite?.[1] ?? '{}')) as {
+        projectPlatform?: string;
+        defaultProfile?: string;
+        targets?: Record<string, { tec1?: Record<string, unknown> }>;
+      };
+      expect(writtenConfig.projectPlatform).toBe('tec1');
+      expect(writtenConfig.defaultProfile).toBe('mon1b');
+      expect(writtenConfig.targets?.app?.tec1).toEqual(
+        expect.objectContaining({
+          romHex: 'roms/tec1/mon1b/mon-1b.bin',
+          extraListings: ['roms/tec1/mon1b/mon-1b.lst'],
+        })
+      );
+
+      expect(actualFs.existsSync(path.join(workspaceRoot, 'roms/tec1/mon1b/mon-1b.bin'))).toBe(true);
+      expect(actualFs.existsSync(path.join(workspaceRoot, 'roms/tec1/mon1b/mon-1b.lst'))).toBe(true);
+      expect(showInformationMessage).toHaveBeenCalledWith(
+        'Debug80: Created TEC-1 / MON-1B project in debug80.json targeting src/main.asm.'
+      );
+    } finally {
+      vi.mocked(fs.existsSync).mockImplementation(defaultExistsSync);
+      actualFs.rmSync(workspaceRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Slice 2 for #280: scaffold built-in TEC-1 and TEC-1G kits using manifest/profile bundled asset refs instead of copying ROM assets during project creation. Adds kit definitions and updates scaffold tests for the new default config shape.