### PR TITLE
Resolve bundled profile assets during launch

### DIFF
--- a/src/debug/launch-args.ts
+++ b/src/debug/launch-args.ts
@@ -31,7 +31,11 @@ type LaunchConfigManifest = Partial<LaunchRequestArguments> & {
   projectPlatform?: string;
   defaultProfile?: string;
   source?: string;
-  profiles?: Record<string, { platform?: string } | undefined>;
+  bundledAssets?: Record<string, { destination?: string } | undefined>;
+  profiles?: Record<
+    string,
+    { platform?: string; bundledAssets?: Record<string, { destination?: string } | undefined> } | undefined
+  >;
   targets?: Record<
     string,
     Partial<LaunchRequestArguments> & { sourceFile?: string; source?: string; profile?: string }
@@ -64,6 +68,25 @@ function resolveProfilePlatform(
   }
   const profile = cfg.profiles?.[normalizedName];
   return normalizeNonEmptyString(profile?.platform);
+}
+
+function resolveBundledAssetDestination(
+  cfg: LaunchConfigManifest,
+  targetCfg: LaunchTargetConfig | undefined,
+  assetName: string
+): string | undefined {
+  const profileName =
+    normalizeNonEmptyString(targetCfg?.profile) ?? normalizeNonEmptyString(cfg.defaultProfile);
+  if (profileName !== undefined) {
+    const profileAsset = cfg.profiles?.[profileName]?.bundledAssets?.[assetName]?.destination;
+    const profileDestination = normalizeNonEmptyString(profileAsset);
+    if (profileDestination !== undefined) {
+      return profileDestination;
+    }
+  }
+
+  const rootAsset = cfg.bundledAssets?.[assetName]?.destination;
+  return normalizeNonEmptyString(rootAsset);
 }
 
 function resolveLaunchPlatform(
@@ -322,11 +345,6 @@ export function populateFromConfig(
 
     const platformResolved = args.platform ?? targetCfg?.platform ?? cfg.platform;
     const launchPlatformResolved = resolveLaunchPlatform(args, cfg, targetCfg);
-    if (launchPlatformResolved !== undefined) {
-      merged.platform = launchPlatformResolved;
-    } else if (platformResolved !== undefined) {
-      merged.platform = platformResolved;
-    }
 
     const simpleResolved = args.simple ?? targetCfg?.simple ?? cfg.simple;
     if (simpleResolved !== undefined) {
@@ -352,6 +370,43 @@ export function populateFromConfig(
     const sourceRootsResolved = args.sourceRoots ?? targetCfg?.sourceRoots ?? cfg.sourceRoots;
     if (sourceRootsResolved !== undefined) {
       merged.sourceRoots = sourceRootsResolved;
+    }
+
+    const resolvedRomHex =
+      merged.tec1?.romHex ??
+      merged.tec1g?.romHex ??
+      resolveBundledAssetDestination(cfg, targetCfg, 'romHex');
+    const resolvedExtraListing =
+      merged.tec1?.extraListings?.[0] ??
+      merged.tec1g?.extraListings?.[0] ??
+      resolveBundledAssetDestination(cfg, targetCfg, 'listing');
+
+    if (resolvedRomHex !== undefined) {
+      if (launchPlatformResolved === 'tec1' || platformResolved === 'tec1') {
+        merged.tec1 = { ...(merged.tec1 ?? {}), romHex: resolvedRomHex };
+      } else if (launchPlatformResolved === 'tec1g' || platformResolved === 'tec1g') {
+        merged.tec1g = { ...(merged.tec1g ?? {}), romHex: resolvedRomHex };
+      }
+    }
+
+    if (resolvedExtraListing !== undefined) {
+      if (launchPlatformResolved === 'tec1' || platformResolved === 'tec1') {
+        const extraListings = merged.tec1?.extraListings ?? [];
+        if (extraListings.length === 0) {
+          merged.tec1 = { ...(merged.tec1 ?? {}), extraListings: [resolvedExtraListing] };
+        }
+      } else if (launchPlatformResolved === 'tec1g' || platformResolved === 'tec1g') {
+        const extraListings = merged.tec1g?.extraListings ?? [];
+        if (extraListings.length === 0) {
+          merged.tec1g = { ...(merged.tec1g ?? {}), extraListings: [resolvedExtraListing] };
+        }
+      }
+    }
+
+    if (launchPlatformResolved !== undefined) {
+      merged.platform = launchPlatformResolved;
+    } else if (platformResolved !== undefined) {
+      merged.platform = platformResolved;
     }
 
     const stepOverResolved =

--- a/tests/debug/launch-args.test.ts
+++ b/tests/debug/launch-args.test.ts
@@ -167,6 +167,94 @@ describe('launch-args', () => {
     expect(merged.platform).toBe('tec1g');
   });
 
+  it('hydrates tec1g launch paths from bundled profile assets', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-profile-bundle-tec1g-'));
+    const configPath = path.join(dir, 'debug80.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        defaultTarget: 'app',
+        defaultProfile: 'mon3',
+        profiles: {
+          mon3: {
+            platform: 'tec1g',
+            bundledAssets: {
+              romHex: {
+                bundleId: 'tec1g/mon3/v1',
+                path: 'mon3.bin',
+                destination: 'roms/tec1g/mon3/mon3.bin',
+              },
+              listing: {
+                bundleId: 'tec1g/mon3/v1',
+                path: 'mon3.lst',
+                destination: 'roms/tec1g/mon3/mon3.lst',
+              },
+            },
+          },
+        },
+        targets: {
+          app: {
+            asm: 'src/main.asm',
+            profile: 'mon3',
+          },
+        },
+      })
+    );
+
+    const merged = populateFromConfig(
+      { projectConfig: configPath } as LaunchRequestArguments,
+      { resolveBaseDir: () => dir }
+    );
+
+    expect(merged.platform).toBe('tec1g');
+    expect(merged.tec1g?.romHex).toBe('roms/tec1g/mon3/mon3.bin');
+    expect(merged.tec1g?.extraListings).toEqual(['roms/tec1g/mon3/mon3.lst']);
+  });
+
+  it('hydrates tec1 launch paths from bundled profile assets', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-profile-bundle-tec1-'));
+    const configPath = path.join(dir, 'debug80.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        defaultTarget: 'app',
+        defaultProfile: 'mon1b',
+        profiles: {
+          mon1b: {
+            platform: 'tec1',
+            bundledAssets: {
+              romHex: {
+                bundleId: 'tec1/mon1b/v1',
+                path: 'mon-1b.bin',
+                destination: 'roms/tec1/mon1b/mon-1b.bin',
+              },
+              listing: {
+                bundleId: 'tec1/mon1b/v1',
+                path: 'mon-1b.lst',
+                destination: 'roms/tec1/mon1b/mon-1b.lst',
+              },
+            },
+          },
+        },
+        targets: {
+          app: {
+            asm: 'src/main.asm',
+            profile: 'mon1b',
+          },
+        },
+      })
+    );
+
+    const merged = populateFromConfig(
+      { projectConfig: configPath } as LaunchRequestArguments,
+      { resolveBaseDir: () => dir }
+    );
+
+    expect(merged.platform).toBe('tec1');
+    expect(merged.tec1?.romHex).toBe('roms/tec1/mon1b/mon-1b.bin');
+    expect(merged.tec1?.extraListings).toEqual(['roms/tec1/mon1b/mon-1b.lst']);
+  });
+
   it('deep-merges tec1g so target overrides do not drop root romHex', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-tec1g-merge-'));
     const configPath = path.join(dir, 'debug80.json');


### PR DESCRIPTION
Issue #280 slice 3: add runtime/source/listing browse integration so bundled asset refs can populate launch args through the extension seam while keeping scaffold-time materialization intact.