### PR TITLE
Remove scaffold-time bundle copying

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -344,16 +344,25 @@ Mon-2 example (RAM reserved 0x0800–0x08ff, user programs at 0x0900):
 
 ### TEC-1G: bundled MON3 (wizard and manual projects)
 
-For **TEC-1G**, Debug80 can ship a **MON3** ROM snapshot inside the VSIX and copy it into
-your workspace under stable paths (see `docs/plans/platform-rom-bundles.md`).
+For **TEC-1G**, Debug80 can ship a **MON3** ROM snapshot inside the VSIX and
+resolve it directly at launch, with an explicit command available if you want
+to copy it into your workspace under stable paths (see
+`docs/plans/platform-rom-bundles.md`).
 
-**After “Create Project” (TEC-1G)** the extension copies, when possible:
+**After “Create Project” (TEC-1G)** the extension records the MON-3 bundle
+reference in `debug80.json` and resolves the shipped bundle on launch when no
+workspace copy is present:
 
 - `roms/tec1g/mon3/mon3.bin` — monitor ROM image (`tec1g.romHex`; `.bin` or `.hex` per program loader rules).
 - `roms/tec1g/mon3/mon3.lst` — ASM80 listing for ROM source mapping (`tec1g.extraListings`).
 - `tec1g.sourceRoots` includes `src` and `roms/tec1g/mon3` so monitor sources resolve cleanly when a listing is present.
 
-**Command:** **Debug80: Copy Bundled MON3 ROM into Workspace** (`debug80.materializeBundledRom`) — pick a folder and optional overwrite; copies the same files as the wizard.
+**Command:** **Debug80: Copy Bundled MON3 ROM into Workspace** (`debug80.materializeBundledRom`) — pick a folder and optional overwrite; copies the same files on demand.
+
+New TEC-1G projects keep the MON-3 bundle reference in `debug80.json` by
+default. At launch, Debug80 resolves the shipped bundle directly when the
+workspace copy is absent, and the explicit materialize command remains
+available if you want local ROM/listing files.
 
 **Manual project (no wizard):** point `tec1g.romHex` and `tec1g.extraListings` at workspace-relative paths (or absolute paths). Example:
 

--- a/src/debug/launch-args.ts
+++ b/src/debug/launch-args.ts
@@ -4,6 +4,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { LaunchRequestArguments } from './types';
 import type { PlatformKind } from './program-loader';
 import type { Tec1gPlatformConfig } from '../platforms/types';
@@ -31,10 +32,19 @@ type LaunchConfigManifest = Partial<LaunchRequestArguments> & {
   projectPlatform?: string;
   defaultProfile?: string;
   source?: string;
-  bundledAssets?: Record<string, { destination?: string } | undefined>;
+  bundledAssets?: Record<
+    string,
+    { bundleId?: string; path?: string; destination?: string } | undefined
+  >;
   profiles?: Record<
     string,
-    { platform?: string; bundledAssets?: Record<string, { destination?: string } | undefined> } | undefined
+    {
+      platform?: string;
+      bundledAssets?: Record<
+        string,
+        { bundleId?: string; path?: string; destination?: string } | undefined
+      >;
+    } | undefined
   >;
   targets?: Record<
     string,
@@ -50,12 +60,26 @@ type LaunchTargetConfig = Partial<LaunchRequestArguments> & {
   profile?: string;
 };
 
+type BundledAssetReferenceLike = {
+  bundleId?: string;
+  path?: string;
+  destination?: string;
+};
+
 function normalizeNonEmptyString(value: unknown): string | undefined {
   if (typeof value !== 'string') {
     return undefined;
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed.toLowerCase() : undefined;
+}
+
+function normalizePathString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function resolveProfilePlatform(
@@ -70,23 +94,83 @@ function resolveProfilePlatform(
   return normalizeNonEmptyString(profile?.platform);
 }
 
-function resolveBundledAssetDestination(
+function resolveBundledAssetReference(
   cfg: LaunchConfigManifest,
   targetCfg: LaunchTargetConfig | undefined,
   assetName: string
-): string | undefined {
+): BundledAssetReferenceLike | undefined {
   const profileName =
     normalizeNonEmptyString(targetCfg?.profile) ?? normalizeNonEmptyString(cfg.defaultProfile);
   if (profileName !== undefined) {
-    const profileAsset = cfg.profiles?.[profileName]?.bundledAssets?.[assetName]?.destination;
-    const profileDestination = normalizeNonEmptyString(profileAsset);
-    if (profileDestination !== undefined) {
-      return profileDestination;
+    const profileAsset = cfg.profiles?.[profileName]?.bundledAssets?.[assetName];
+    if (profileAsset !== undefined) {
+      return profileAsset;
     }
   }
 
-  const rootAsset = cfg.bundledAssets?.[assetName]?.destination;
-  return normalizeNonEmptyString(rootAsset);
+  return cfg.bundledAssets?.[assetName];
+}
+
+function resolveExtensionBundledAssetPath(
+  reference: BundledAssetReferenceLike
+): string | undefined {
+  const extension = vscode.extensions.getExtension('jhlagado.debug80');
+  if (extension === undefined) {
+    return undefined;
+  }
+
+  const bundleId = normalizePathString(reference.bundleId);
+  const assetPath = normalizePathString(reference.path);
+  if (bundleId === undefined || assetPath === undefined) {
+    return undefined;
+  }
+
+  const candidate = path.join(
+    extension.extensionPath,
+    'resources',
+    'bundles',
+    ...bundleId.split('/'),
+    assetPath
+  );
+  return fs.existsSync(candidate) ? candidate : undefined;
+}
+
+function resolveBundledAssetRuntimePath(
+  candidatePath: string | undefined,
+  reference: BundledAssetReferenceLike | undefined,
+  baseDir: string
+): string | undefined {
+  const resolvedCandidate =
+    candidatePath !== undefined && candidatePath !== ''
+      ? path.isAbsolute(candidatePath)
+        ? path.normalize(candidatePath)
+        : path.resolve(baseDir, candidatePath)
+      : undefined;
+  if (resolvedCandidate !== undefined && fs.existsSync(resolvedCandidate)) {
+    return resolvedCandidate;
+  }
+
+  if (reference === undefined) {
+    return resolvedCandidate;
+  }
+
+  const destination = normalizePathString(reference.destination);
+  const resolvedDestination =
+    destination !== undefined
+      ? path.isAbsolute(destination)
+        ? path.normalize(destination)
+        : path.resolve(baseDir, destination)
+      : undefined;
+
+  const shouldUseBundle =
+    resolvedCandidate === undefined ||
+    resolvedDestination === undefined ||
+    path.normalize(resolvedCandidate) === path.normalize(resolvedDestination);
+  if (!shouldUseBundle) {
+    return resolvedCandidate;
+  }
+
+  return resolveExtensionBundledAssetPath(reference) ?? resolvedCandidate;
 }
 
 function resolveLaunchPlatform(
@@ -256,7 +340,7 @@ export function populateFromConfig(
 
     const targets = cfg.targets ?? {};
     const targetName = args.target ?? cfg.target ?? cfg.defaultTarget ?? Object.keys(targets)[0];
-      const targetCfg = (targetName !== undefined ? targets[targetName] : undefined) ?? undefined;
+    const targetCfg = (targetName !== undefined ? targets[targetName] : undefined) ?? undefined;
 
     const merged: LaunchRequestArguments = {
       ...cfg,
@@ -372,14 +456,18 @@ export function populateFromConfig(
       merged.sourceRoots = sourceRootsResolved;
     }
 
-    const resolvedRomHex =
-      merged.tec1?.romHex ??
-      merged.tec1g?.romHex ??
-      resolveBundledAssetDestination(cfg, targetCfg, 'romHex');
-    const resolvedExtraListing =
-      merged.tec1?.extraListings?.[0] ??
-      merged.tec1g?.extraListings?.[0] ??
-      resolveBundledAssetDestination(cfg, targetCfg, 'listing');
+    const bundledRomReference = resolveBundledAssetReference(cfg, targetCfg, 'romHex');
+    const bundledListingReference = resolveBundledAssetReference(cfg, targetCfg, 'listing');
+    const resolvedRomHex = resolveBundledAssetRuntimePath(
+      merged.tec1?.romHex ?? merged.tec1g?.romHex,
+      bundledRomReference,
+      workspaceRoot
+    );
+    const resolvedExtraListing = resolveBundledAssetRuntimePath(
+      merged.tec1?.extraListings?.[0] ?? merged.tec1g?.extraListings?.[0],
+      bundledListingReference,
+      workspaceRoot
+    );
 
     if (resolvedRomHex !== undefined) {
       if (launchPlatformResolved === 'tec1' || platformResolved === 'tec1') {
@@ -391,15 +479,35 @@ export function populateFromConfig(
 
     if (resolvedExtraListing !== undefined) {
       if (launchPlatformResolved === 'tec1' || platformResolved === 'tec1') {
-        const extraListings = merged.tec1?.extraListings ?? [];
-        if (extraListings.length === 0) {
-          merged.tec1 = { ...(merged.tec1 ?? {}), extraListings: [resolvedExtraListing] };
-        }
+        const extraListings = (merged.tec1?.extraListings ?? [])
+          .map((entry) =>
+            resolveBundledAssetRuntimePath(entry, bundledListingReference, workspaceRoot)
+          )
+          .filter((entry): entry is string => entry !== undefined);
+        merged.tec1 = {
+          ...(merged.tec1 ?? {}),
+          extraListings:
+            extraListings.length > 0
+              ? extraListings
+              : resolvedExtraListing !== undefined
+                ? [resolvedExtraListing]
+                : [],
+        };
       } else if (launchPlatformResolved === 'tec1g' || platformResolved === 'tec1g') {
-        const extraListings = merged.tec1g?.extraListings ?? [];
-        if (extraListings.length === 0) {
-          merged.tec1g = { ...(merged.tec1g ?? {}), extraListings: [resolvedExtraListing] };
-        }
+        const extraListings = (merged.tec1g?.extraListings ?? [])
+          .map((entry) =>
+            resolveBundledAssetRuntimePath(entry, bundledListingReference, workspaceRoot)
+          )
+          .filter((entry): entry is string => entry !== undefined);
+        merged.tec1g = {
+          ...(merged.tec1g ?? {}),
+          extraListings:
+            extraListings.length > 0
+              ? extraListings
+              : resolvedExtraListing !== undefined
+                ? [resolvedExtraListing]
+                : [],
+        };
       }
     }
 

--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -11,7 +11,6 @@ import {
   findProjectConfigPath,
   listProjectSourceFiles,
 } from './project-config';
-import { materializeBundledRom } from './bundle-materialize';
 import {
   TEC1G_RAM_END,
   TEC1G_RAM_START,
@@ -228,19 +227,6 @@ export async function scaffoldProject(
 
   if (!configExists && plan === undefined) {
     return false;
-  }
-
-  if (plan !== undefined && plan.kit.bundledProfile !== undefined) {
-    const materializeResult = materializeBundledRom(
-      extensionUri ?? vscode.Uri.file(process.cwd()),
-      workspaceRoot,
-      plan.kit.bundledProfile.bundleRel
-    );
-    if (!materializeResult.ok) {
-      void vscode.window.showWarningMessage(
-        `Debug80: Could not copy bundled ${plan.kit.label} ROM (${materializeResult.reason}). You can add romHex manually in debug80.json.`
-      );
-    }
   }
 
   ensureDirExists(

--- a/tests/debug/launch-args.test.ts
+++ b/tests/debug/launch-args.test.ts
@@ -2,10 +2,19 @@
  * @file Launch args helpers tests.
  */
 
-import { describe, it, expect } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+const { getExtension } = vi.hoisted(() => ({
+  getExtension: vi.fn(),
+}));
+vi.mock('vscode', () => ({
+  extensions: {
+    getExtension,
+  },
+}));
+
 import {
   normalizePlatformName,
   populateFromConfig,
@@ -21,6 +30,11 @@ import {
 import type { LaunchRequestArguments } from '../../src/debug/types';
 
 describe('launch-args', () => {
+  beforeEach(() => {
+    getExtension.mockReset();
+    getExtension.mockReturnValue(undefined);
+  });
+
   it('normalizes platform names', () => {
     expect(normalizePlatformName({ platform: 'TEC1' } as LaunchRequestArguments)).toBe('tec1');
     expect(normalizePlatformName({ platform: 'simple' } as LaunchRequestArguments)).toBe('simple');
@@ -167,9 +181,24 @@ describe('launch-args', () => {
     expect(merged.platform).toBe('tec1g');
   });
 
-  it('hydrates tec1g launch paths from bundled profile assets', () => {
+  it('hydrates tec1g launch paths from bundled profile assets when workspace copies are absent', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-profile-bundle-tec1g-'));
     const configPath = path.join(dir, 'debug80.json');
+    const extensionRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-extension-'));
+    const bundledRom = path.join(extensionRoot, 'resources', 'bundles', 'tec1g', 'mon3', 'v1', 'mon3.bin');
+    const bundledListing = path.join(
+      extensionRoot,
+      'resources',
+      'bundles',
+      'tec1g',
+      'mon3',
+      'v1',
+      'mon3.lst'
+    );
+    fs.mkdirSync(path.dirname(bundledRom), { recursive: true });
+    fs.writeFileSync(bundledRom, 'rom');
+    fs.writeFileSync(bundledListing, 'lst');
+    getExtension.mockReturnValue({ extensionPath: extensionRoot } as never);
     fs.writeFileSync(
       configPath,
       JSON.stringify({
@@ -207,13 +236,36 @@ describe('launch-args', () => {
     );
 
     expect(merged.platform).toBe('tec1g');
-    expect(merged.tec1g?.romHex).toBe('roms/tec1g/mon3/mon3.bin');
-    expect(merged.tec1g?.extraListings).toEqual(['roms/tec1g/mon3/mon3.lst']);
+    expect(merged.tec1g?.romHex).toBe(bundledRom);
+    expect(merged.tec1g?.extraListings).toEqual([bundledListing]);
   });
 
-  it('hydrates tec1 launch paths from bundled profile assets', () => {
+  it('hydrates tec1 launch paths from bundled profile assets when workspace copies are absent', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-profile-bundle-tec1-'));
     const configPath = path.join(dir, 'debug80.json');
+    const extensionRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-extension-'));
+    const bundledRom = path.join(
+      extensionRoot,
+      'resources',
+      'bundles',
+      'tec1',
+      'mon1b',
+      'v1',
+      'mon-1b.bin'
+    );
+    const bundledListing = path.join(
+      extensionRoot,
+      'resources',
+      'bundles',
+      'tec1',
+      'mon1b',
+      'v1',
+      'mon-1b.lst'
+    );
+    fs.mkdirSync(path.dirname(bundledRom), { recursive: true });
+    fs.writeFileSync(bundledRom, 'rom');
+    fs.writeFileSync(bundledListing, 'lst');
+    getExtension.mockReturnValue({ extensionPath: extensionRoot } as never);
     fs.writeFileSync(
       configPath,
       JSON.stringify({
@@ -251,8 +303,60 @@ describe('launch-args', () => {
     );
 
     expect(merged.platform).toBe('tec1');
-    expect(merged.tec1?.romHex).toBe('roms/tec1/mon1b/mon-1b.bin');
-    expect(merged.tec1?.extraListings).toEqual(['roms/tec1/mon1b/mon-1b.lst']);
+    expect(merged.tec1?.romHex).toBe(bundledRom);
+    expect(merged.tec1?.extraListings).toEqual([bundledListing]);
+  });
+
+  it('prefers workspace-local bundle overrides when they exist', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-profile-local-tec1g-'));
+    const configPath = path.join(dir, 'debug80.json');
+    const workspaceRom = path.join(dir, 'roms', 'tec1g', 'mon3', 'mon3.bin');
+    const workspaceListing = path.join(dir, 'roms', 'tec1g', 'mon3', 'mon3.lst');
+    fs.mkdirSync(path.dirname(workspaceRom), { recursive: true });
+    fs.writeFileSync(workspaceRom, 'rom');
+    fs.writeFileSync(workspaceListing, 'lst');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        defaultTarget: 'app',
+        defaultProfile: 'mon3',
+        profiles: {
+          mon3: {
+            platform: 'tec1g',
+            bundledAssets: {
+              romHex: {
+                bundleId: 'tec1g/mon3/v1',
+                path: 'mon3.bin',
+                destination: 'roms/tec1g/mon3/mon3.bin',
+              },
+              listing: {
+                bundleId: 'tec1g/mon3/v1',
+                path: 'mon3.lst',
+                destination: 'roms/tec1g/mon3/mon3.lst',
+              },
+            },
+          },
+        },
+        targets: {
+          app: {
+            asm: 'src/main.asm',
+            profile: 'mon3',
+            tec1g: {
+              romHex: 'roms/tec1g/mon3/mon3.bin',
+              extraListings: ['roms/tec1g/mon3/mon3.lst'],
+            },
+          },
+        },
+      })
+    );
+
+    const merged = populateFromConfig(
+      { projectConfig: configPath } as LaunchRequestArguments,
+      { resolveBaseDir: () => dir }
+    );
+
+    expect(merged.tec1g?.romHex).toBe(workspaceRom);
+    expect(merged.tec1g?.extraListings).toEqual([workspaceListing]);
   });
 
   it('deep-merges tec1g so target overrides do not drop root romHex', () => {
@@ -285,7 +389,7 @@ describe('launch-args', () => {
       { projectConfig: configPath, target: 'matrix' } as LaunchRequestArguments,
       { resolveBaseDir: () => dir }
     );
-    expect(mergedMatrix.tec1g?.romHex).toBe('roms/mon-3.hex');
+    expect(mergedMatrix.tec1g?.romHex).toBe(path.join(dir, 'roms/mon-3.hex'));
     expect(mergedMatrix.tec1g?.entry).toBe(0);
     expect(mergedMatrix.tec1g?.appStart).toBe(16384);
 
@@ -293,7 +397,7 @@ describe('launch-args', () => {
       { projectConfig: configPath, target: 'asmDemo' } as LaunchRequestArguments,
       { resolveBaseDir: () => dir }
     );
-    expect(mergedAsm.tec1g?.romHex).toBe('roms/mon-3.hex');
+    expect(mergedAsm.tec1g?.romHex).toBe(path.join(dir, 'roms/mon-3.hex'));
     expect(mergedAsm.asm).toBe('src/matrix-demo.asm');
   });
 
@@ -327,7 +431,7 @@ describe('launch-args', () => {
       { projectConfig: configPath, target: 'matrix' } as LaunchRequestArguments,
       { resolveBaseDir: () => dir }
     );
-    expect(merged.tec1g?.romHex).toBe('roms/mon-3.hex');
+    expect(merged.tec1g?.romHex).toBe(path.join(dir, 'roms/mon-3.hex'));
     expect(merged.tec1g?.appStart).toBe(16384);
     expect(merged.tec1g?.entry).toBe(0);
   });

--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -345,7 +345,7 @@ describe('project-scaffolding helpers', () => {
     expect(showInputBox).not.toHaveBeenCalled();
   });
 
-  it('writes a tec1g config and materializes MON-3 bundle files during scaffold', async () => {
+  it('writes a tec1g config without copying MON-3 bundle files during scaffold', async () => {
     const fs = await import('fs');
     const actualFs = await vi.importActual<typeof import('fs')>('fs');
     const writeFileSync = vi.mocked(fs.writeFileSync);
@@ -414,8 +414,11 @@ describe('project-scaffolding helpers', () => {
         })
       );
 
-      expect(actualFs.existsSync(path.join(workspaceRoot, 'roms/tec1g/mon3/mon3.bin'))).toBe(true);
-      expect(actualFs.existsSync(path.join(workspaceRoot, 'roms/tec1g/mon3/mon3.lst'))).toBe(true);
+      expect(
+        writeFileSync.mock.calls
+          .map(([filePath]) => String(filePath).replace(/\\/g, '/'))
+          .filter((filePath) => filePath.includes('/roms/'))
+      ).toEqual([]);
       expect(showInformationMessage).toHaveBeenCalledWith(
         'Debug80: Created TEC-1G / MON-3 project in debug80.json targeting src/main.asm.'
       );
@@ -425,7 +428,7 @@ describe('project-scaffolding helpers', () => {
     }
   });
 
-  it('writes a tec1 config and materializes MON-1B bundle files during scaffold', async () => {
+  it('writes a tec1 config without copying MON-1B bundle files during scaffold', async () => {
     const fs = await import('fs');
     const actualFs = await vi.importActual<typeof import('fs')>('fs');
     const writeFileSync = vi.mocked(fs.writeFileSync);
@@ -482,8 +485,11 @@ describe('project-scaffolding helpers', () => {
         })
       );
 
-      expect(actualFs.existsSync(path.join(workspaceRoot, 'roms/tec1/mon1b/mon-1b.bin'))).toBe(true);
-      expect(actualFs.existsSync(path.join(workspaceRoot, 'roms/tec1/mon1b/mon-1b.lst'))).toBe(true);
+      expect(
+        writeFileSync.mock.calls
+          .map(([filePath]) => String(filePath).replace(/\\/g, '/'))
+          .filter((filePath) => filePath.includes('/roms/'))
+      ).toEqual([]);
       expect(showInformationMessage).toHaveBeenCalledWith(
         'Debug80: Created TEC-1 / MON-1B project in debug80.json targeting src/main.asm.'
       );

--- a/tests/platforms/provider.test.ts
+++ b/tests/platforms/provider.test.ts
@@ -5,6 +5,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DebugProtocol } from '@vscode/debugprotocol';
 
+const { getExtension } = vi.hoisted(() => ({
+  getExtension: vi.fn(),
+}));
+
 const {
   buildPlatformIoHandlers,
   createTec1gMemoryHooks,
@@ -17,6 +21,15 @@ const {
     expandBanks: ['bank'],
   })),
   applyCartridgeMemory: vi.fn(() => undefined),
+}));
+
+vi.mock('vscode', () => ({
+  extensions: {
+    getExtension,
+  },
+  workspace: {
+    workspaceFolders: undefined,
+  },
 }));
 
 vi.mock('../../src/debug/platform-host', () => ({


### PR DESCRIPTION
Issue #280 final slice: stop copying bundled monitor assets during scaffold, keep bundled refs in project metadata, and resolve bundle-backed runtime paths directly when workspace overrides are absent. Includes doc updates and regression coverage for fresh scaffolded MON-1B / MON-3 projects.