### PR TITLE
Open and reveal Debug80 view

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         {
           "type": "webview",
           "id": "debug80.platformView",
-          "name": "Platform"
+          "name": "Debug80"
         }
       ]
     },
@@ -189,6 +189,10 @@
       {
         "command": "debug80.openProjectConfigPanel",
         "title": "Debug80: Open Project Configuration Panel"
+      },
+      {
+        "command": "debug80.openDebug80View",
+        "title": "Debug80: Open Debug80 View"
       },
       {
         "command": "debug80.materializeBundledRom",

--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -498,11 +498,19 @@ export function registerExtensionCommands({
         if (created) {
           workspaceSelection.rememberWorkspace(folder);
           platformViewProvider.refreshIdleView();
+          platformViewProvider.reveal?.(false);
         }
         return created;
       } finally {
         creatingProject = false;
       }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('debug80.openDebug80View', () => {
+      platformViewProvider.reveal(true);
+      return true;
     })
   );
 
@@ -637,6 +645,7 @@ export function registerExtensionCommands({
 
         workspaceSelection.rememberWorkspace(folder);
         platformViewProvider.refreshIdleView();
+        platformViewProvider.reveal?.(false);
 
         let restartedForRootChange = false;
         const activeSession = vscode.debug.activeDebugSession;

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -209,10 +209,11 @@ describe('registerExtensionCommands', () => {
     };
     const rememberWorkspace = vi.fn();
     const refreshIdleView = vi.fn();
+    const reveal = vi.fn();
 
     registerExtensionCommands({
       context: { subscriptions: [] } as never,
-      platformViewProvider: { refreshIdleView } as never,
+      platformViewProvider: { refreshIdleView, reveal } as never,
       sourceColumns: {} as never,
       terminalPanel: {} as never,
       workspaceSelection: {
@@ -232,7 +233,34 @@ describe('registerExtensionCommands', () => {
     expect(result).toBe(true);
     expect(rememberWorkspace).toHaveBeenCalledWith(folder);
     expect(refreshIdleView).toHaveBeenCalled();
+    expect(reveal).toHaveBeenCalledWith(false);
     expect(scaffoldProject).toHaveBeenCalledWith(folder, false, undefined, undefined);
+  });
+
+  it('reveals the Debug80 view through the dedicated command', async () => {
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    const reveal = vi.fn();
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn(), reveal } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder: vi.fn(),
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {} as never,
+    });
+
+    const openDebug80View = registeredCommands.get('debug80.openDebug80View');
+    expect(openDebug80View).toBeTypeOf('function');
+
+    const result = await openDebug80View?.();
+
+    expect(result).toBe(true);
+    expect(reveal).toHaveBeenCalledWith(true);
   });
 
   it('materializes manifest-backed bundled asset references from the project config', async () => {
@@ -384,10 +412,11 @@ describe('registerExtensionCommands', () => {
     const selectWorkspaceFolder = vi.fn().mockResolvedValue(folder);
     const rememberWorkspace = vi.fn();
     const refreshIdleView = vi.fn();
+    const reveal = vi.fn();
 
     registerExtensionCommands({
       context: { subscriptions: [] } as never,
-      platformViewProvider: { refreshIdleView } as never,
+      platformViewProvider: { refreshIdleView, reveal } as never,
       sourceColumns: {} as never,
       terminalPanel: {} as never,
       workspaceSelection: {
@@ -406,6 +435,7 @@ describe('registerExtensionCommands', () => {
     expect(result).toEqual(folder);
     expect(rememberWorkspace).toHaveBeenCalledWith(folder);
     expect(refreshIdleView).toHaveBeenCalled();
+    expect(reveal).toHaveBeenCalledWith(false);
     expect(startDebugging).not.toHaveBeenCalled();
   });
 
@@ -419,9 +449,10 @@ describe('registerExtensionCommands', () => {
     };
 
     const refreshIdleView = vi.fn();
+    const reveal = vi.fn();
     registerExtensionCommands({
       context: { subscriptions: [] } as never,
-      platformViewProvider: { refreshIdleView } as never,
+      platformViewProvider: { refreshIdleView, reveal } as never,
       sourceColumns: {} as never,
       terminalPanel: {} as never,
       workspaceState: { get: vi.fn(() => undefined), update: vi.fn() },
@@ -440,6 +471,7 @@ describe('registerExtensionCommands', () => {
 
     expect(result).toEqual(folder);
     expect(refreshIdleView).toHaveBeenCalled();
+    expect(reveal).toHaveBeenCalledWith(false);
     expect(startDebugging).not.toHaveBeenCalled();
   });
 

--- a/tests/extension/extension.test.ts
+++ b/tests/extension/extension.test.ts
@@ -132,6 +132,7 @@ describe('extension activation', () => {
     expect(registerCommand).toHaveBeenCalledWith('debug80.openTec1', expect.anything());
     expect(registerCommand).toHaveBeenCalledWith('debug80.openTec1Memory', expect.anything());
     expect(registerCommand).toHaveBeenCalledWith('debug80.openRomSource', expect.anything());
+    expect(registerCommand).toHaveBeenCalledWith('debug80.openDebug80View', expect.anything());
     expect(context.subscriptions.length).toBeGreaterThan(0);
     expect(api.listPlatforms()).toEqual([
       expect.objectContaining({ id: 'simple', displayName: 'Simple' }),


### PR DESCRIPTION
## Summary
- rename the Platform view label to Debug80
- add a dedicated command to reveal the Debug80 view
- reveal the Debug80 view after project creation and root selection

## Testing
- /opt/homebrew/bin/node node_modules/vitest/vitest.mjs run tests/extension/commands.test.ts tests/extension/extension.test.ts