### PR TITLE
Remove timer-based ROM source auto-open

### DIFF
--- a/src/extension/debug-session-events.ts
+++ b/src/extension/debug-session-events.ts
@@ -77,24 +77,6 @@ export function registerDebugSessionHandlers({
         platformViewProvider.clear();
         sessionState.sessionPlatforms.delete(session.id);
         sourceColumns.onSessionStarted(session);
-        const openRomSources = session.configuration?.openRomSourcesOnLaunch !== false;
-        if (openRomSources) {
-          const sessionId = session.id;
-          const column = sourceColumns.getSessionColumns(session).source;
-          setTimeout(() => {
-            if (!sessionState.activeZ80Sessions.has(sessionId)) {
-              return;
-            }
-            if (sessionState.romSourcesOpenedSessions.has(sessionId)) {
-              return;
-            }
-            void openRomSourcesForSession(session, column).then((opened) => {
-              if (opened) {
-                sessionState.romSourcesOpenedSessions.add(sessionId);
-              }
-            });
-          }, 200);
-        }
       }
     })
   );

--- a/tests/extension/debug-session-events.test.ts
+++ b/tests/extension/debug-session-events.test.ts
@@ -9,6 +9,9 @@ import { registerDebugSessionHandlers } from '../../src/extension/debug-session-
 const onDidStartDebugSession = vi.fn(() => ({ dispose: vi.fn() }));
 const onDidTerminateDebugSession = vi.fn(() => ({ dispose: vi.fn() }));
 const onDidReceiveDebugSessionCustomEvent = vi.fn(() => ({ dispose: vi.fn() }));
+const { openRomSourcesForSession } = vi.hoisted(() => ({
+  openRomSourcesForSession: vi.fn(() => Promise.resolve(true)),
+}));
 
 const startHandlers: Array<(session: { id: string; type: string; configuration?: Record<string, unknown>; workspaceFolder?: unknown }) => void> = [];
 const terminateHandlers: Array<(session: { id: string; type: string }) => void> = [];
@@ -32,6 +35,11 @@ vi.mock('vscode', () => ({
   commands: { executeCommand: vi.fn(() => Promise.resolve(true)) },
   workspace: {
     workspaceFolders: undefined,
+    openTextDocument: vi.fn((path: string) => Promise.resolve({ uri: { fsPath: path } })),
+  },
+  window: {
+    showTextDocument: vi.fn(() => Promise.resolve(undefined)),
+    showErrorMessage: vi.fn(),
   },
   Uri: {
     file: (value: string) => ({ fsPath: value }),
@@ -54,12 +62,17 @@ vi.mock('vscode', () => ({
   DiagnosticSeverity: { Error: 0 },
 }));
 
+vi.mock('../../src/extension/rom-sources', () => ({
+  openRomSourcesForSession,
+}));
+
 describe('debug session status bridge', () => {
   beforeEach(() => {
     startHandlers.length = 0;
     terminateHandlers.length = 0;
     customHandlers.length = 0;
     vi.clearAllMocks();
+    openRomSourcesForSession.mockResolvedValue(true);
   });
 
   it('forwards start, custom status, and termination events to the platform view', () => {
@@ -131,5 +144,91 @@ describe('debug session status bridge', () => {
     expect(platformViewProvider.setSessionStatus).toHaveBeenNthCalledWith(2, 'running');
     expect(platformViewProvider.setSessionStatus).toHaveBeenNthCalledWith(3, 'paused');
     expect(platformViewProvider.handleSessionTerminated).toHaveBeenCalledWith('session-1');
+  });
+
+  it('opens ROM sources from session lifecycle events without using a start-time timer', async () => {
+    const platformViewProvider = {
+      setSessionStatus: vi.fn(),
+      clear: vi.fn(),
+      handleSessionTerminated: vi.fn(),
+      setPlatform: vi.fn(),
+      setTec1gUiVisibility: vi.fn(),
+      updateTec1: vi.fn(),
+      updateTec1g: vi.fn(),
+      appendTec1Serial: vi.fn(),
+      appendTec1gSerial: vi.fn(),
+    } as never;
+    const sessionState = new SessionStateManager();
+    const sourceColumns = {
+      onSessionStarted: vi.fn(),
+      onSessionTerminated: vi.fn(),
+      getSessionColumns: vi.fn(() => ({ source: 1, panel: 2 })),
+    } as never;
+    const terminalPanel = {
+      clear: vi.fn(),
+      open: vi.fn(),
+      hasPanel: vi.fn(() => false),
+      appendOutput: vi.fn(),
+    } as never;
+    const workspaceSelection = {
+      rememberWorkspace: vi.fn(),
+    } as never;
+    const context = { subscriptions: [] as Array<{ dispose: () => void }> } as never;
+    const rebuildDiagnostics = { clear: vi.fn(), delete: vi.fn() } as never;
+    const assemblyDiagnostics = { clear: vi.fn(), set: vi.fn() } as never;
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    registerDebugSessionHandlers({
+      context,
+      rebuildDiagnostics,
+      assemblyDiagnostics,
+      platformViewProvider,
+      sessionState,
+      sourceColumns,
+      terminalPanel,
+      workspaceSelection,
+    });
+
+    const session = {
+      id: 'session-2',
+      type: 'z80',
+      configuration: {
+        openRomSourcesOnLaunch: true,
+        openMainSourceOnLaunch: true,
+      },
+      workspaceFolder: undefined,
+    };
+
+    startHandlers[0]?.(session);
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+    expect(openRomSourcesForSession).not.toHaveBeenCalled();
+
+    customHandlers[0]?.({
+      session,
+      event: 'debug80/platform',
+      body: { id: 'tec1g' },
+    });
+    expect(openRomSourcesForSession).not.toHaveBeenCalled();
+
+    customHandlers[0]?.({
+      session,
+      event: 'debug80/mainSource',
+      body: { path: '/workspace/main.asm' },
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(openRomSourcesForSession).toHaveBeenCalledTimes(1);
+    expect(openRomSourcesForSession).toHaveBeenCalledWith(session, 1);
+    expect(sessionState.romSourcesOpenedSessions.has('session-2')).toBe(true);
+
+    customHandlers[0]?.({
+      session,
+      event: 'debug80/platform',
+      body: { id: 'tec1g' },
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(openRomSourcesForSession).toHaveBeenCalledTimes(1);
+    setTimeoutSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Refs jhlagado/debug80#269.

- Removes the fixed 200ms start-time timer in debug-session-events
- Uses existing session lifecycle events for ROM source auto-open
- Preserves duplicate-open guards
- Adds regression coverage for lifecycle-driven ROM source opening