### PR TITLE
Fix auto-restart when selected root changes platform

### DIFF
--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -373,20 +373,6 @@ function resolveSessionProjectPlatform(session: vscode.DebugSession): string | u
   return resolveProjectPlatform(readProjectConfig(projectConfigPath));
 }
 
-function resolveSessionProjectConfigPath(session: vscode.DebugSession): string | undefined {
-  const projectConfigRaw = projectConfigFromSession(session);
-  if (projectConfigRaw === undefined) {
-    return undefined;
-  }
-  if (path.isAbsolute(projectConfigRaw)) {
-    return path.normalize(projectConfigRaw);
-  }
-  if (session.workspaceFolder !== undefined) {
-    return path.normalize(path.join(session.workspaceFolder.uri.fsPath, projectConfigRaw));
-  }
-  return path.normalize(projectConfigRaw);
-}
-
 function normalizeBundledAssetInstallPlan(
   label: string,
   references: BundledAssetReference[]
@@ -650,32 +636,19 @@ export function registerExtensionCommands({
         let restartedForRootChange = false;
         const activeSession = vscode.debug.activeDebugSession;
         if (activeSession?.type === 'z80') {
-          const nextProjectConfigPath = findProjectConfigPath(folder);
-          const previousProjectConfigPath = resolveSessionProjectConfigPath(activeSession);
           const previousPlatform = resolveSessionProjectPlatform(activeSession);
           const nextPlatform = resolveProjectPlatformForFolder(folder);
-          const projectChanged =
-            previousProjectConfigPath !== undefined &&
-            nextProjectConfigPath !== undefined &&
-            previousProjectConfigPath !== path.normalize(nextProjectConfigPath);
           if (
-            projectChanged ||
-            (previousPlatform !== undefined &&
-              nextPlatform !== undefined &&
-              previousPlatform !== nextPlatform)
+            previousPlatform !== undefined &&
+            nextPlatform !== undefined &&
+            previousPlatform !== nextPlatform
           ) {
             await vscode.debug.stopDebugging(activeSession);
             const restarted = await startCurrentProjectDebugging(folder, workspaceSelection);
             restartedForRootChange = restarted;
             if (restarted) {
-              const reason =
-                previousPlatform !== undefined &&
-                nextPlatform !== undefined &&
-                previousPlatform !== nextPlatform
-                  ? nextPlatform
-                  : 'selected project';
               void vscode.window.showInformationMessage(
-                `Debug80: Selected root ${folder.name}; restarted debugging for ${reason}.`
+                `Debug80: Selected root ${folder.name}; restarted debugging for ${nextPlatform}.`
               );
             }
           }

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -549,7 +549,7 @@ describe('registerExtensionCommands', () => {
     );
   });
 
-  it('restarts active z80 session when selected root changes project config', async () => {
+  it('does not restart an active z80 session when selected root keeps the same platform', async () => {
     const vscode = await import('vscode');
     const { registerExtensionCommands } = await import('../../src/extension/commands');
 
@@ -570,7 +570,10 @@ describe('registerExtensionCommands', () => {
       if (normalized === configAPath || normalized === configBPath) {
         return JSON.stringify({
           projectPlatform: 'tec1',
-          targets: { serial: { sourceFile: 'src/serial.asm' } },
+          targets: {
+            app: { sourceFile: 'src/main.asm' },
+            serial: { sourceFile: 'src/serial.asm' },
+          },
         });
       }
       return JSON.stringify({ targets: {} });
@@ -604,17 +607,8 @@ describe('registerExtensionCommands', () => {
     const result = await selectRoot?.({ rootPath: rootB });
 
     expect(result).toEqual(expect.objectContaining({ uri: { fsPath: rootB } }));
-    expect(stopDebugging).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'z80', id: 'session-root-change' })
-    );
-    expect(startDebugging).toHaveBeenCalledWith(
-      expect.objectContaining({ uri: { fsPath: rootB } }),
-      expect.objectContaining({
-        type: 'z80',
-        request: 'launch',
-        projectConfig: configBPath,
-      })
-    );
+    expect(stopDebugging).not.toHaveBeenCalled();
+    expect(startDebugging).not.toHaveBeenCalled();
   });
 
   it('auto-starts when a selected root exposes exactly one target', async () => {


### PR DESCRIPTION
## Summary
- restart the active z80 session on root selection only when the effective platform changes
- preserve same-platform root changes without forcing a restart
- cover both the platform-change restart path and same-platform no-regression path in command tests

## Testing
- npm run build
- ./node_modules/.bin/vitest run tests/extension/commands.test.ts