### PR TITLE
Unify .source.* fallback policy

### DIFF
--- a/docs/design-zax-source-support.md
+++ b/docs/design-zax-source-support.md
@@ -118,15 +118,17 @@ both `ensureAsmLanguage(doc)` and `ensureZaxLanguage(doc)` for each document.
 `.asm`/`z80-asm`, once for `.zax`/`zax`. Either approach is acceptable; the key constraint
 is that both languages are enforced.
 
-### 7. `src/debug/breakpoint-manager.ts` — Alternate source path (no change needed)
+### 7. `src/debug/breakpoint-manager.ts` — Source-path policy
 
-The existing `resolveAlternateSourcePath()` handles `.asm` ↔ `.source.asm` pairs. This is
-an asm80-specific convention. ZAX does not use `.source.zax` files, so **no change is
-required** in `breakpoint-manager.ts`. Note this for awareness only.
+Breakpoint resolution should use direct mapped source paths plus basename matching for path
+normalization differences. `.source.*` fallback pairs are deprecated and should not be
+reintroduced for either asm80 or ZAX sources.
 
-### 8. `src/debug/path-resolver.ts` — No change needed
+### 8. `src/debug/path-resolver.ts` — Listing-adjacent source lookup
 
-`resolveAsmPath()` is extension-agnostic — it resolves any path. No change required.
+Listing-adjacent source lookup should only consider direct sibling source files such as
+`.asm`, `.zax`, or `.z80`. Deprecated `.source.*` companions are outside the supported
+policy.
 
 ---
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -261,7 +261,7 @@ Extra ROM listings:
 - Use `extraListings` to load ROM listings that live outside the project (for example, in a
   platform repo). Paths are resolved relative to the `debug80.json` base directory; absolute
   paths also work.
-- If a listing sits next to a `.source.asm` or `.asm`, Debug80 will offer that source in the
+- If a listing sits next to a matching `.asm`, `.zax`, or `.z80` source file, Debug80 will offer that source in the
   ROM source picker and use it for line-based breakpoints.
 - Debug80 caches a D8 debug map under `<workspace>/.debug80/cache` as
   `<listing-base>.<hash>.d8.json` (hash from the listing path). If the workspace cache

--- a/src/debug/breakpoint-manager.ts
+++ b/src/debug/breakpoint-manager.ts
@@ -130,13 +130,6 @@ export class BreakpointManager {
     if (direct.length > 0) {
       return direct;
     }
-    const alternate = this.resolveAlternateSourcePath(sourcePath);
-    if (alternate !== null) {
-      const mapped = resolveLocation(mappingIndex, alternate, line);
-      if (mapped.length > 0) {
-        return mapped;
-      }
-    }
     return this.resolveByBasename(mappingIndex, sourcePath, line);
   }
 
@@ -163,30 +156,6 @@ export class BreakpointManager {
 
   private isListingSource(listingPath: string, sourcePath: string): boolean {
     return pathsEqual(sourcePath, listingPath);
-  }
-
-  private resolveAlternateSourcePath(sourcePath: string): string | null {
-    const normalized = path.resolve(sourcePath);
-    const lower = normalized.toLowerCase();
-    if (lower.endsWith('.source.asm')) {
-      return normalized.slice(0, -'.source.asm'.length) + '.asm';
-    }
-    if (lower.endsWith('.asm')) {
-      return normalized.slice(0, -'.asm'.length) + '.source.asm';
-    }
-    if (lower.endsWith('.source.zax')) {
-      return normalized.slice(0, -'.source.zax'.length) + '.zax';
-    }
-    if (lower.endsWith('.zax')) {
-      return normalized.slice(0, -'.zax'.length) + '.source.zax';
-    }
-    if (lower.endsWith('.source.z80')) {
-      return normalized.slice(0, -'.source.z80'.length) + '.z80';
-    }
-    if (lower.endsWith('.z80')) {
-      return normalized.slice(0, -'.z80'.length) + '.source.z80';
-    }
-    return null;
   }
 
   private resolveListingLineAddress(listing: ListingInfo, line: number): number | undefined {

--- a/src/debug/path-resolver.ts
+++ b/src/debug/path-resolver.ts
@@ -346,7 +346,7 @@ export function resolveExtraListingPaths(
 export function resolveListingSourcePath(listingPath: string): string | undefined {
   const dir = path.dirname(listingPath);
   const base = path.basename(listingPath, path.extname(listingPath));
-  const candidates = [`${base}.source.asm`, `${base}.asm`, `${base}.zax`, `${base}.z80`];
+  const candidates = [`${base}.asm`, `${base}.zax`, `${base}.z80`];
 
   for (const candidate of candidates) {
     const candidatePath = path.join(dir, candidate);

--- a/tests/debug/breakpoint-manager.test.ts
+++ b/tests/debug/breakpoint-manager.test.ts
@@ -102,7 +102,7 @@ describe('BreakpointManager', () => {
     expect(applied[0]?.verified).toBe(true);
   });
 
-  it('falls back to .source.asm when resolving breakpoints', () => {
+  it('does not fall back to .source.asm when resolving breakpoints', () => {
     const mgr = new BreakpointManager();
     const listing = createMockListing(new Map());
     const baseDir = path.join(path.parse(process.cwd()).root, 'test');
@@ -117,10 +117,10 @@ describe('BreakpointManager', () => {
     const applied = mgr.applyForSource(listing, listingPath, index, sourcePath, [{ line: 42 }]);
 
     expect(applied.length).toBe(1);
-    expect(applied[0]?.verified).toBe(true);
+    expect(applied[0]?.verified).toBe(false);
   });
 
-  it('falls back to .source.z80 when resolving breakpoints', () => {
+  it('does not fall back to .source.z80 when resolving breakpoints', () => {
     const mgr = new BreakpointManager();
     const listing = createMockListing(new Map());
     const baseDir = path.join(path.parse(process.cwd()).root, 'test');
@@ -135,7 +135,7 @@ describe('BreakpointManager', () => {
     const applied = mgr.applyForSource(listing, listingPath, index, sourcePath, [{ line: 171 }]);
 
     expect(applied.length).toBe(1);
-    expect(applied[0]?.verified).toBe(true);
+    expect(applied[0]?.verified).toBe(false);
   });
 
   it('falls back by basename when mapped path differs', () => {

--- a/tests/debug/path-resolver.test.ts
+++ b/tests/debug/path-resolver.test.ts
@@ -108,7 +108,7 @@ describe('path-resolver', () => {
     expect(resolved).toEqual([listingB]);
   });
 
-  it('resolves listing source path from .source.asm when present', () => {
+  it('does not resolve listing source path from .source.asm', () => {
     const dir = path.join(tmpDir, 'build');
     fs.mkdirSync(dir, { recursive: true });
     const listing = path.join(dir, 'demo.lst');
@@ -116,7 +116,7 @@ describe('path-resolver', () => {
     fs.writeFileSync(listing, 'LIST');
     fs.writeFileSync(source, 'NOP');
 
-    expect(resolveListingSourcePath(listing)).toBe(source);
+    expect(resolveListingSourcePath(listing)).toBeUndefined();
   });
 
   it('resolves listing source path from .z80 when present', () => {


### PR DESCRIPTION
## Summary
- remove deprecated `.source.*` fallback from breakpoint resolution
- align listing-adjacent source lookup with the same direct-sibling policy
- update focused tests and docs to reflect the single supported behavior

Closes #292.

Issue #273 is not subsumed by this change; it remains a separate breakpoint-manager refactor follow-up.