### PR TITLE
Implement explicit uninitialized state in shared panel

### DIFF
--- a/src/contracts/platform-view.ts
+++ b/src/contracts/platform-view.ts
@@ -6,6 +6,7 @@ export type PlatformId = 'simple' | 'tec1' | 'tec1g';
 export type ProjectStatusPayload = {
   rootName?: string;
   rootPath?: string;
+  projectState?: 'noWorkspace' | 'uninitialized' | 'initialized';
   hasProject?: boolean;
   targetName?: string;
   entrySource?: string;

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -81,7 +81,6 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   private currentSessionId: string | undefined;
   private uiRevision = 0;
   private selectedWorkspace: vscode.WorkspaceFolder | undefined;
-  private hasProject = false;
   private sessionStatus: DebugSessionStatus = 'not running';
   private readonly workspaceState: vscode.Memento | undefined;
   private readonly extensionUri: vscode.Uri;
@@ -120,7 +119,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   }
 
   setHasProject(value: boolean): void {
-    this.hasProject = value;
+    void value;
     this.refreshProjectStatus();
   }
 
@@ -587,28 +586,28 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     const roots = (vscode.workspace.workspaceFolders ?? []).map((folder) => ({
       name: folder.name,
       path: folder.uri.fsPath,
-      hasProject:
-        this.selectedWorkspace?.uri.fsPath === folder.uri.fsPath
-          ? this.hasProject
-          : findProjectConfigPath(folder) !== undefined,
+      hasProject: findProjectConfigPath(folder) !== undefined,
     }));
     const folder = this.selectedWorkspace;
     if (folder === undefined) {
-      return { roots, targets: [] };
+      return { roots, targets: [], projectState: 'noWorkspace' };
     }
 
     const projectConfigPath = findProjectConfigPath(folder);
+    const hasProject = projectConfigPath !== undefined;
     const projectStatus =
-      this.workspaceState !== undefined
+      hasProject && this.workspaceState !== undefined
         ? resolveProjectStatusSummary(this.workspaceState, folder)
         : undefined;
-    if (projectStatus === undefined || projectConfigPath === undefined) {
+    if (!hasProject) {
       return {
         roots,
         targets: [],
         rootName: folder.name,
         rootPath: folder.uri.fsPath,
+        projectState: 'uninitialized',
         hasProject: false,
+        platform: this.currentPlatform ?? 'simple',
         stopOnEntry: this.stopOnEntry,
       };
     }
@@ -621,11 +620,14 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       targets: listProjectTargetChoices(projectConfigPath),
       rootName: folder.name,
       rootPath: folder.uri.fsPath,
+      projectState: 'initialized',
       hasProject: true,
       platform,
       stopOnEntry: this.stopOnEntry,
-      ...(projectStatus.targetName !== undefined ? { targetName: projectStatus.targetName } : {}),
-      ...(projectStatus.entrySource !== undefined ? { entrySource: projectStatus.entrySource } : {}),
+      ...(projectStatus?.targetName !== undefined ? { targetName: projectStatus.targetName } : {}),
+      ...(projectStatus?.entrySource !== undefined
+        ? { entrySource: projectStatus.entrySource }
+        : {}),
     };
   }
 

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -206,6 +206,7 @@ describe('PlatformViewProvider', () => {
         message.type === 'projectStatus' &&
         message.rootName === 'demo' &&
         message.rootPath === '/workspace/demo' &&
+        message.projectState === 'initialized' &&
         message.hasProject === true &&
         message.targetName === 'app' &&
         message.entrySource === 'src/main.asm' &&
@@ -220,6 +221,44 @@ describe('PlatformViewProvider', () => {
       }
     }
     expect(found).toBe(true);
+  });
+
+  it('posts an uninitialized projectStatus when the selected folder has no config', () => {
+    findProjectConfigPath.mockImplementation(() => undefined);
+    try {
+      const provider = new PlatformViewProvider(extensionRoot, {
+        get: vi.fn(),
+        update: vi.fn(),
+      } as never);
+      const webviewView = createWebviewView();
+
+      provider.resolveWebviewView(
+        webviewView,
+        {} as vscode.WebviewViewResolveContext,
+        {
+          isCancellationRequested: false,
+          onCancellationRequested: vi.fn(),
+        } as vscode.CancellationToken
+      );
+
+      workspaceFolders = [{ name: 'demo', uri: { fsPath: '/workspace/demo' } }];
+      provider.setSelectedWorkspace({ name: 'demo', uri: { fsPath: '/workspace/demo' } } as never);
+      provider.setPlatform('tec1', undefined, { reveal: false, tab: 'ui' });
+
+      const statusMessages = findProjectStatusMessages(getPostMessageCalls(webviewView));
+      expect(statusMessages.at(-1)).toMatchObject({
+        rootName: 'demo',
+        rootPath: '/workspace/demo',
+        projectState: 'uninitialized',
+        hasProject: false,
+        platform: 'tec1',
+        targets: [],
+      });
+    } finally {
+      findProjectConfigPath.mockImplementation(
+        (folder: { uri: { fsPath: string } }) => `${folder.uri.fsPath}/debug80.json`
+      );
+    }
   });
 
   function getPostMessageCalls(webviewView: vscode.WebviewView): Array<[Record<string, unknown>]> {

--- a/tests/webview/common/project-state.test.ts
+++ b/tests/webview/common/project-state.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { resolveProjectViewState } from '../../../webview/common/project-state';
+
+describe('project view state resolver', () => {
+  it('prefers explicit projectState values', () => {
+    expect(resolveProjectViewState({ projectState: 'noWorkspace' })).toBe('noWorkspace');
+    expect(resolveProjectViewState({ projectState: 'uninitialized' })).toBe('uninitialized');
+    expect(resolveProjectViewState({ projectState: 'initialized' })).toBe('initialized');
+  });
+
+  it('falls back to initialized when hasProject is true', () => {
+    expect(resolveProjectViewState({ hasProject: true, rootPath: '/workspace/demo' })).toBe(
+      'initialized'
+    );
+  });
+
+  it('falls back to uninitialized when a root is selected without a project', () => {
+    expect(resolveProjectViewState({ rootPath: '/workspace/demo', hasProject: false })).toBe(
+      'uninitialized'
+    );
+  });
+
+  it('falls back to noWorkspace without a selected root', () => {
+    expect(resolveProjectViewState({ hasProject: false })).toBe('noWorkspace');
+  });
+});

--- a/tests/webview/common/setup-card-state.test.ts
+++ b/tests/webview/common/setup-card-state.test.ts
@@ -3,28 +3,38 @@ import { resolveSetupCardState } from '../../../webview/common/setup-card-state'
 
 describe('setup card state resolver', () => {
   it('returns open-folder action for missing workspace root', () => {
-    const state = resolveSetupCardState(undefined, 0);
+    const state = resolveSetupCardState(undefined, 'noWorkspace', 0);
     expect(state).not.toBeNull();
     expect(state?.primaryAction).toBe('openWorkspaceFolder');
     expect(state?.primaryLabel).toBe('Open Folder');
   });
 
-  it('returns create-project action for uninitialized root', () => {
+  it('returns initialize-project action for uninitialized root', () => {
     const state = resolveSetupCardState(
       { name: 'demo', path: '/workspace/demo', hasProject: false },
+      'uninitialized',
       0
     );
     expect(state).not.toBeNull();
     expect(state?.primaryAction).toBe('createProject');
-    expect(state?.primaryLabel).toBe('Create Project');
+    expect(state?.primaryLabel).toBe('Initialize Project');
+    expect(state?.text).toBe('Uninitialized Debug80 project');
   });
 
   it('returns null when configured root already has a project (card hidden)', () => {
     expect(
-      resolveSetupCardState({ name: 'demo', path: '/workspace/demo', hasProject: true }, 0)
+      resolveSetupCardState(
+        { name: 'demo', path: '/workspace/demo', hasProject: true },
+        'initialized',
+        0
+      )
     ).toBeNull();
     expect(
-      resolveSetupCardState({ name: 'demo', path: '/workspace/demo', hasProject: true }, 2)
+      resolveSetupCardState(
+        { name: 'demo', path: '/workspace/demo', hasProject: true },
+        'initialized',
+        2
+      )
     ).toBeNull();
   });
 });

--- a/webview/common/project-state.ts
+++ b/webview/common/project-state.ts
@@ -1,0 +1,20 @@
+import type { ProjectStatusPayload } from '../../src/contracts/platform-view';
+
+export type ProjectViewState = 'noWorkspace' | 'uninitialized' | 'initialized';
+
+export function resolveProjectViewState(payload: {
+  projectState?: ProjectStatusPayload['projectState'];
+  rootPath?: ProjectStatusPayload['rootPath'];
+  hasProject?: ProjectStatusPayload['hasProject'];
+}): ProjectViewState {
+  if (payload.projectState === 'noWorkspace' || payload.projectState === 'uninitialized' || payload.projectState === 'initialized') {
+    return payload.projectState;
+  }
+  if (payload.hasProject === true) {
+    return 'initialized';
+  }
+  if (typeof payload.rootPath === 'string' && payload.rootPath.length > 0) {
+    return 'uninitialized';
+  }
+  return 'noWorkspace';
+}

--- a/webview/common/setup-card-state.ts
+++ b/webview/common/setup-card-state.ts
@@ -4,6 +4,8 @@ export type SetupRootOption = {
   hasProject: boolean;
 };
 
+export type SetupProjectState = 'noWorkspace' | 'uninitialized' | 'initialized';
+
 export type SetupPrimaryAction = 'openWorkspaceFolder' | 'createProject';
 
 export type SetupCardState = {
@@ -18,19 +20,20 @@ export type SetupCardState = {
  */
 export function resolveSetupCardState(
   selectedRoot: SetupRootOption | undefined,
+  projectState: SetupProjectState,
   targetCount: number
 ): SetupCardState | null {
-  if (selectedRoot === undefined) {
+  if (projectState === 'noWorkspace' || selectedRoot === undefined) {
     return {
       text: 'No workspace folder is open. Open a folder to start with Debug80.',
       primaryLabel: 'Open Folder',
       primaryAction: 'openWorkspaceFolder',
     };
   }
-  if (!selectedRoot.hasProject) {
+  if (projectState === 'uninitialized') {
     return {
-      text: `No Debug80 project found in ${selectedRoot.name}.`,
-      primaryLabel: 'Create Project',
+      text: 'Uninitialized Debug80 project',
+      primaryLabel: 'Initialize Project',
       primaryAction: 'createProject',
     };
   }

--- a/webview/simple/index.ts
+++ b/webview/simple/index.ts
@@ -143,7 +143,7 @@ function applyProjectStatus(payload: {
     platformSelectEl.value = payload.platform;
   }
   if (platformControl) {
-    platformControl.hidden = false;
+    platformControl.hidden = initialized;
   }
   stopOnEntryControl.applyProjectStatus({
     hasProject: initialized,

--- a/webview/simple/index.ts
+++ b/webview/simple/index.ts
@@ -7,6 +7,7 @@ import { MemoryPanel } from '../common/memory-panel';
 import { createSessionStatusController } from '../common/session-status';
 import { wireStopOnEntryControl } from '../common/stop-on-entry-control';
 import { createProjectRootButtonController } from '../common/project-root-button';
+import { resolveProjectViewState } from '../common/project-state';
 import { resolveSetupCardState } from '../common/setup-card-state';
 import { acquireVscodeApi } from '../common/vscode';
 import type { ProjectStatusPayload } from '../../src/contracts/platform-view';
@@ -23,6 +24,9 @@ const sessionStatusButton = document.getElementById('sessionStatus') as HTMLButt
 const stopOnEntryInput = document.getElementById('stopOnEntry') as HTMLInputElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const platformSelectEl = document.getElementById('platformSelect') as HTMLSelectElement | null;
+const targetControl = homeTargetSelect?.closest('.project-control') as HTMLElement | null;
+const platformControl = platformSelectEl?.closest('.project-control') as HTMLElement | null;
+const tabsEl = document.querySelector('.tabs') as HTMLElement | null;
 const panelUi = document.getElementById('panel-ui') as HTMLElement;
 const panelMemory = document.getElementById('panel-memory') as HTMLElement;
 const tabButtons = Array.from(document.querySelectorAll<HTMLElement>('[data-tab]'));
@@ -117,10 +121,13 @@ function applyProjectStatus(payload: {
   roots?: ProjectStatusPayload['roots'];
   targets?: ProjectStatusPayload['targets'];
   targetName?: ProjectStatusPayload['targetName'];
+  projectState?: ProjectStatusPayload['projectState'];
   platform?: string;
   hasProject?: ProjectStatusPayload['hasProject'];
   stopOnEntry?: ProjectStatusPayload['stopOnEntry'];
 }): void {
+  const projectState = resolveProjectViewState(payload);
+  const initialized = projectState === 'initialized';
   currentRootPath = payload.rootPath ?? '';
   currentRoots = payload.roots ?? [];
   projectRootController.applyProjectStatus({
@@ -129,19 +136,36 @@ function applyProjectStatus(payload: {
     targetCount: payload.targets?.length ?? 0,
   });
   setTargetOptions(payload.targets ?? [], payload.targetName);
+  if (targetControl) {
+    targetControl.hidden = !initialized;
+  }
   if (platformSelectEl && payload.platform !== undefined) {
     platformSelectEl.value = payload.platform;
   }
+  if (platformControl) {
+    platformControl.hidden = false;
+  }
   stopOnEntryControl.applyProjectStatus({
-    hasProject: payload.hasProject === true,
+    hasProject: initialized,
     stopOnEntry: payload.stopOnEntry,
   });
+  if (stopOnEntryInput?.parentElement) {
+    stopOnEntryInput.parentElement.hidden = !initialized;
+  }
+  if (sessionStatusButton) {
+    sessionStatusButton.hidden = !initialized;
+  }
+  if (tabsEl) {
+    tabsEl.hidden = !initialized;
+  }
+  panelUi.hidden = !initialized;
+  panelMemory.hidden = !initialized;
   const selected = currentRoots.find((r) => r.path === currentRootPath) ?? currentRoots[0];
   const targetCount = payload.targets?.length ?? 0;
   if (!setupCard || !setupCardText || !setupPrimaryAction) {
     return;
   }
-  const setupState = resolveSetupCardState(selected, targetCount);
+  const setupState = resolveSetupCardState(selected, projectState, targetCount);
   if (setupState === null) {
     setupCard.hidden = true;
     return;

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -3,6 +3,7 @@ import { MemoryPanel } from '../common/memory-panel';
 import { createSessionStatusController } from '../common/session-status';
 import { wireStopOnEntryControl } from '../common/stop-on-entry-control';
 import { createProjectRootButtonController } from '../common/project-root-button';
+import { resolveProjectViewState } from '../common/project-state';
 import { resolveSetupCardState } from '../common/setup-card-state';
 import { acquireVscodeApi } from '../common/vscode';
 import type { ProjectStatusPayload } from '../../src/contracts/platform-view';
@@ -24,6 +25,7 @@ const setupPrimaryAction = document.getElementById('setupPrimaryAction') as HTML
 const sessionStatusButton = document.getElementById('sessionStatus') as HTMLButtonElement | null;
 const stopOnEntryInput = document.getElementById('stopOnEntry') as HTMLInputElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
+const targetControl = homeTargetSelect?.closest('.project-control') as HTMLElement | null;
 const displayEl = document.getElementById('display') as HTMLElement;
 const keypadEl = document.getElementById('keypad') as HTMLElement;
 const speakerEl = document.getElementById('speaker') as HTMLElement;
@@ -34,8 +36,10 @@ const tabButtons = Array.from(document.querySelectorAll<HTMLElement>('[data-tab]
 const panelUi = document.getElementById('panel-ui') as HTMLElement;
 const panelMemory = document.getElementById('panel-memory') as HTMLElement;
 const platformSelectEl = document.getElementById('platformSelect') as HTMLSelectElement | null;
+const platformControl = platformSelectEl?.closest('.project-control') as HTMLElement | null;
 const registerStrip = document.getElementById('registerStrip') as HTMLElement;
 const memoryPanel = document.getElementById('memoryPanel') as HTMLElement;
+const tabsEl = document.querySelector('.tabs') as HTMLElement | null;
 const SHIFT_BIT = 0x20;
 const DIGITS = 6;
 const digitEls = [];
@@ -155,9 +159,12 @@ function applyProjectStatus(payload: {
   roots?: ProjectStatusPayload['roots'];
   targets?: ProjectStatusPayload['targets'];
   targetName?: ProjectStatusPayload['targetName'];
+  projectState?: ProjectStatusPayload['projectState'];
   hasProject?: ProjectStatusPayload['hasProject'];
   stopOnEntry?: ProjectStatusPayload['stopOnEntry'];
 }): void {
+  const projectState = resolveProjectViewState(payload);
+  const initialized = projectState === 'initialized';
   currentRootPath = payload.rootPath ?? '';
   currentRoots = payload.roots ?? [];
   projectRootController.applyProjectStatus({
@@ -166,16 +173,33 @@ function applyProjectStatus(payload: {
     targetCount: payload.targets?.length ?? 0,
   });
   setTargetOptions(payload.targets ?? [], payload.targetName);
+  if (targetControl) {
+    targetControl.hidden = !initialized;
+  }
+  if (platformControl) {
+    platformControl.hidden = false;
+  }
   stopOnEntryControl.applyProjectStatus({
-    hasProject: payload.hasProject === true,
+    hasProject: initialized,
     stopOnEntry: payload.stopOnEntry,
   });
+  if (stopOnEntryInput?.parentElement) {
+    stopOnEntryInput.parentElement.hidden = !initialized;
+  }
+  if (sessionStatusButton) {
+    sessionStatusButton.hidden = !initialized;
+  }
+  if (tabsEl) {
+    tabsEl.hidden = !initialized;
+  }
+  panelUi.hidden = !initialized;
+  panelMemory.hidden = !initialized;
   const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
   const targetCount = payload.targets?.length ?? 0;
   if (!setupCard || !setupCardText || !setupPrimaryAction) {
     return;
   }
-  const setupState = resolveSetupCardState(selected, targetCount);
+  const setupState = resolveSetupCardState(selected, projectState, targetCount);
   if (setupState === null) {
     setupCard.hidden = true;
     return;

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -177,7 +177,7 @@ function applyProjectStatus(payload: {
     targetControl.hidden = !initialized;
   }
   if (platformControl) {
-    platformControl.hidden = false;
+    platformControl.hidden = initialized;
   }
   stopOnEntryControl.applyProjectStatus({
     hasProject: initialized,

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -86,6 +86,11 @@ const projectStatusUi = createTec1gProjectStatusUi(vscode, {
   setupCardText,
   setupPrimaryAction,
   homeTargetSelect,
+  sessionStatusButton,
+  stopOnEntryInput,
+  tabs: document.querySelector('.tabs') as HTMLElement | null,
+  panelUi,
+  panelMemory,
   getPlatform: () => platformSelectEl?.value ?? undefined,
 });
 

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -86,6 +86,7 @@ const projectStatusUi = createTec1gProjectStatusUi(vscode, {
   setupCardText,
   setupPrimaryAction,
   homeTargetSelect,
+  platformSelect: platformSelectEl,
   sessionStatusButton,
   stopOnEntryInput,
   tabs: document.querySelector('.tabs') as HTMLElement | null,

--- a/webview/tec1g/tec1g-project-status-ui.ts
+++ b/webview/tec1g/tec1g-project-status-ui.ts
@@ -14,6 +14,7 @@ export type Tec1gProjectStatusElements = {
   setupCardText: HTMLElement | null;
   setupPrimaryAction: HTMLButtonElement | null;
   homeTargetSelect: HTMLSelectElement | null;
+  platformSelect?: HTMLSelectElement | null;
   sessionStatusButton?: HTMLButtonElement | null;
   stopOnEntryInput?: HTMLInputElement | null;
   tabs?: HTMLElement | null;
@@ -84,6 +85,7 @@ export function createTec1gProjectStatusUi(
     setupCardText,
     setupPrimaryAction,
     homeTargetSelect,
+    platformSelect,
     sessionStatusButton,
     stopOnEntryInput,
     tabs,
@@ -143,6 +145,10 @@ export function createTec1gProjectStatusUi(
       if (targetControl) {
         targetControl.hidden = !initialized;
       }
+    }
+    const platformControl = platformSelect?.closest('.project-control') as HTMLElement | null;
+    if (platformControl) {
+      platformControl.hidden = initialized;
     }
     if (stopOnEntryInput?.parentElement) {
       stopOnEntryInput.parentElement.hidden = !initialized;

--- a/webview/tec1g/tec1g-project-status-ui.ts
+++ b/webview/tec1g/tec1g-project-status-ui.ts
@@ -5,6 +5,7 @@
 import type { ProjectStatusPayload } from '../../src/contracts/platform-view';
 import type { VscodeApi } from '../common/vscode';
 import { createProjectRootButtonController } from '../common/project-root-button';
+import { resolveProjectViewState } from '../common/project-state';
 import { resolveSetupCardState } from '../common/setup-card-state';
 
 export type Tec1gProjectStatusElements = {
@@ -13,6 +14,11 @@ export type Tec1gProjectStatusElements = {
   setupCardText: HTMLElement | null;
   setupPrimaryAction: HTMLButtonElement | null;
   homeTargetSelect: HTMLSelectElement | null;
+  sessionStatusButton?: HTMLButtonElement | null;
+  stopOnEntryInput?: HTMLInputElement | null;
+  tabs?: HTMLElement | null;
+  panelUi?: HTMLElement | null;
+  panelMemory?: HTMLElement | null;
   getPlatform?: () => string | undefined;
 };
 
@@ -22,6 +28,7 @@ export type Tec1gProjectStatusUi = {
     roots?: ProjectStatusPayload['roots'];
     targets?: ProjectStatusPayload['targets'];
     targetName?: ProjectStatusPayload['targetName'];
+    projectState?: ProjectStatusPayload['projectState'];
   }) => void;
   dispose: () => void;
 };
@@ -77,6 +84,11 @@ export function createTec1gProjectStatusUi(
     setupCardText,
     setupPrimaryAction,
     homeTargetSelect,
+    sessionStatusButton,
+    stopOnEntryInput,
+    tabs,
+    panelUi,
+    panelMemory,
     getPlatform,
   } = elements;
 
@@ -114,7 +126,10 @@ export function createTec1gProjectStatusUi(
     roots?: ProjectStatusPayload['roots'];
     targets?: ProjectStatusPayload['targets'];
     targetName?: ProjectStatusPayload['targetName'];
+    projectState?: ProjectStatusPayload['projectState'];
   }): void {
+    const projectState = resolveProjectViewState(payload);
+    const initialized = projectState === 'initialized';
     currentRootPath = payload.rootPath ?? '';
     currentRoots = payload.roots ?? [];
     projectRootController.applyProjectStatus({
@@ -124,13 +139,32 @@ export function createTec1gProjectStatusUi(
     });
     if (homeTargetSelect) {
       setTargetOptions(homeTargetSelect, payload.targets ?? [], payload.targetName);
+      const targetControl = homeTargetSelect.closest('.project-control') as HTMLElement | null;
+      if (targetControl) {
+        targetControl.hidden = !initialized;
+      }
+    }
+    if (stopOnEntryInput?.parentElement) {
+      stopOnEntryInput.parentElement.hidden = !initialized;
+    }
+    if (sessionStatusButton) {
+      sessionStatusButton.hidden = !initialized;
+    }
+    if (tabs) {
+      tabs.hidden = !initialized;
+    }
+    if (panelUi) {
+      panelUi.hidden = !initialized;
+    }
+    if (panelMemory) {
+      panelMemory.hidden = !initialized;
     }
     const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
     const targetCount = payload.targets?.length ?? 0;
     if (!setupCard || !setupCardText || !setupPrimaryAction) {
       return;
     }
-    const setupState = resolveSetupCardState(selected, targetCount);
+    const setupState = resolveSetupCardState(selected, projectState, targetCount);
     if (setupState === null) {
       setupCard.hidden = true;
       return;


### PR DESCRIPTION
## Summary
- add an explicit uninitialized project state to the shared Debug80 panel payload
- hide initialized-only controls until a selected folder has a Debug80 config
- update setup-card copy/action and cover the new state with focused tests

## Testing
- ./node_modules/.bin/vitest run tests/extension/platform-view-provider.test.ts
- ./node_modules/.bin/vitest run -c vitest.webview.config.ts tests/webview/common/setup-card-state.test.ts tests/webview/common/project-state.test.ts tests/webview/session-status.test.ts
- npm run build