### PR TITLE
Implement project initialization flow

### DIFF
--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -536,6 +536,12 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     }
     const configPath = findProjectConfigPath(folder);
     if (configPath === undefined) {
+      const normalized = this.normalizePlatformId(platform);
+      if (normalized !== undefined) {
+        this.currentPlatform = normalized;
+        this.renderCurrentView(true);
+        return;
+      }
       void vscode.window.showErrorMessage('Debug80: No project config found in workspace.');
       return;
     }
@@ -556,6 +562,14 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       return;
     }
     void vscode.commands.executeCommand('debug80.restartDebug');
+  }
+
+  private normalizePlatformId(platform: string): PlatformId | undefined {
+    const normalized = platform.trim().toLowerCase();
+    if (normalized === 'simple' || normalized === 'tec1' || normalized === 'tec1g') {
+      return normalized;
+    }
+    return undefined;
   }
 
   private handleSetStopOnEntry(value: boolean): void {

--- a/src/extension/project-kits.ts
+++ b/src/extension/project-kits.ts
@@ -95,6 +95,12 @@ const PROJECT_KITS: Record<ProjectKitId, ProjectKit> = {
   },
 };
 
+const DEFAULT_PROJECT_KITS: Record<ScaffoldPlatform, ProjectKitId> = {
+  simple: 'simple/default',
+  tec1: 'tec1/mon1b',
+  tec1g: 'tec1g/mon3',
+};
+
 export type ProjectKitChoice = vscode.QuickPickItem & {
   kit: ProjectKit;
 };
@@ -116,6 +122,14 @@ export function getProjectKitById(id: string | undefined): ProjectKit | undefine
     return undefined;
   }
   return PROJECT_KITS[id as ProjectKitId];
+}
+
+export function getDefaultProjectKitForPlatform(platform: string | undefined): ProjectKit | undefined {
+  const normalized = platform?.trim().toLowerCase();
+  if (normalized !== 'simple' && normalized !== 'tec1' && normalized !== 'tec1g') {
+    return undefined;
+  }
+  return PROJECT_KITS[DEFAULT_PROJECT_KITS[normalized]];
 }
 
 export function getProjectKitChoices(preselectedPlatform?: string): ProjectKitChoice[] {

--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -20,6 +20,7 @@ import {
   TEC1G_ROM1_START,
 } from '../platforms/tec1g/constants';
 import {
+  getDefaultProjectKitForPlatform,
   getProjectKitChoices,
   readProjectKitStarterTemplate,
   type ProjectKit,
@@ -304,6 +305,22 @@ async function buildScaffoldPlan(
   inferred: { sourceFile: string; outputDir: string; artifactBase: string },
   preselectedPlatform?: string
 ): Promise<ScaffoldPlan | undefined> {
+  const defaultKit = getDefaultProjectKitForPlatform(preselectedPlatform);
+  if (defaultKit !== undefined) {
+    const sourceFile = 'src/main.asm';
+    return {
+      kit: defaultKit,
+      targetName: 'app',
+      sourceFile,
+      outputDir: inferred.outputDir,
+      artifactBase: path.basename(sourceFile, path.extname(sourceFile)) || inferred.artifactBase,
+      starterLanguage: 'asm',
+      starterFile: {
+        path: sourceFile,
+      },
+    };
+  }
+
   const kit = await chooseProjectKit(preselectedPlatform);
   if (kit === undefined) {
     return undefined;

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -228,13 +228,13 @@ describe('registerExtensionCommands', () => {
     expect(createProject).toBeTypeOf('function');
 
     scaffoldProject.mockResolvedValueOnce(true);
-    const result = await createProject?.({ rootPath: folder.uri.fsPath });
+    const result = await createProject?.({ rootPath: folder.uri.fsPath, platform: 'tec1g' });
 
     expect(result).toBe(true);
     expect(rememberWorkspace).toHaveBeenCalledWith(folder);
     expect(refreshIdleView).toHaveBeenCalled();
     expect(reveal).toHaveBeenCalledWith(false);
-    expect(scaffoldProject).toHaveBeenCalledWith(folder, false, undefined, undefined);
+    expect(scaffoldProject).toHaveBeenCalledWith(folder, false, undefined, 'tec1g');
   });
 
   it('reveals the Debug80 view through the dedicated command', async () => {

--- a/tests/extension/platform-view-messages.test.ts
+++ b/tests/extension/platform-view-messages.test.ts
@@ -29,7 +29,10 @@ describe('platform-view message routing', () => {
   it('routes control messages to the expected handlers', async () => {
     const deps = createDependencies('simple');
 
-    await handlePlatformViewMessage({ type: 'createProject', rootPath: '/workspace/a' }, deps);
+    await handlePlatformViewMessage(
+      { type: 'createProject', rootPath: '/workspace/a', platform: 'tec1g' },
+      deps
+    );
     await handlePlatformViewMessage({ type: 'selectProject', rootPath: '/workspace/a' }, deps);
     await handlePlatformViewMessage(
       { type: 'selectTarget', rootPath: '/workspace/a', targetName: 'app' },
@@ -44,7 +47,10 @@ describe('platform-view message routing', () => {
     await handlePlatformViewMessage({ type: 'serialSendFile' }, deps);
     await handlePlatformViewMessage({ type: 'serialSave', text: 'hello' }, deps);
 
-    expect(deps.handleCreateProject).toHaveBeenCalledWith({ rootPath: '/workspace/a' });
+    expect(deps.handleCreateProject).toHaveBeenCalledWith({
+      rootPath: '/workspace/a',
+      platform: 'tec1g',
+    });
     expect(deps.handleSelectProject).toHaveBeenCalledWith({ rootPath: '/workspace/a' });
     expect(deps.handleSelectTarget).toHaveBeenCalledWith({
       rootPath: '/workspace/a',

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -261,6 +261,48 @@ describe('PlatformViewProvider', () => {
     }
   });
 
+  it('treats platform changes as idle panel selection when the folder is uninitialized', async () => {
+    findProjectConfigPath.mockImplementation(() => undefined);
+    try {
+      const provider = new PlatformViewProvider(extensionRoot, {
+        get: vi.fn(),
+        update: vi.fn(),
+      } as never);
+      const webviewView = createWebviewView();
+
+      provider.resolveWebviewView(
+        webviewView,
+        {} as vscode.WebviewViewResolveContext,
+        {
+          isCancellationRequested: false,
+          onCancellationRequested: vi.fn(),
+        } as vscode.CancellationToken
+      );
+
+      workspaceFolders = [{ name: 'demo', uri: { fsPath: '/workspace/demo' } }];
+      provider.setSelectedWorkspace({ name: 'demo', uri: { fsPath: '/workspace/demo' } } as never);
+      provider.setPlatform('simple', undefined, { reveal: false, tab: 'ui' });
+
+      const handler = (webviewView.webview.onDidReceiveMessage as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[0] as ((msg: { type?: string; platform?: string }) => Promise<void>) | undefined;
+      expect(handler).toBeTypeOf('function');
+
+      (webviewView.webview.postMessage as ReturnType<typeof vi.fn>).mockClear();
+      await handler?.({ type: 'saveProjectConfig', platform: 'tec1g' });
+
+      const statusMessages = findProjectStatusMessages(getPostMessageCalls(webviewView));
+      expect(statusMessages.at(-1)).toMatchObject({
+        projectState: 'uninitialized',
+        platform: 'tec1g',
+      });
+      expect(executeCommand).not.toHaveBeenCalledWith('debug80.restartDebug');
+    } finally {
+      findProjectConfigPath.mockImplementation(
+        (folder: { uri: { fsPath: string } }) => `${folder.uri.fsPath}/debug80.json`
+      );
+    }
+  });
+
   function getPostMessageCalls(webviewView: vscode.WebviewView): Array<[Record<string, unknown>]> {
     return (
       webviewView.webview as unknown as {

--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -345,6 +345,72 @@ describe('project-scaffolding helpers', () => {
     expect(showInputBox).not.toHaveBeenCalled();
   });
 
+  it('initializes from the selected platform with the default project kit and starter target', async () => {
+    const fs = await import('fs');
+    const actualFs = await vi.importActual<typeof import('fs')>('fs');
+    const existsSync = vi.mocked(fs.existsSync);
+    const writeFileSync = vi.mocked(fs.writeFileSync);
+
+    const workspaceRoot = actualFs.mkdtempSync(path.join(os.tmpdir(), 'debug80-init-flow-'));
+    try {
+      existsSync.mockImplementation((candidate: string) => {
+        const normalized = candidate.replace(/\\/g, '/');
+        return (
+          !normalized.endsWith('/debug80.json') &&
+          !normalized.endsWith('/.debug80.json') &&
+          !normalized.endsWith('/src/main.asm')
+        );
+      });
+      showErrorMessage.mockImplementation((message: string) => {
+        throw new Error(message);
+      });
+
+      const created = await scaffoldProject(
+        { name: 'demo', uri: { fsPath: workspaceRoot }, index: 0 } as never,
+        false,
+        undefined,
+        'tec1'
+      );
+
+      expect(created).toBe(true);
+      expect(showQuickPick).not.toHaveBeenCalled();
+      expect(showInputBox).not.toHaveBeenCalled();
+
+      const configWrite = writeFileSync.mock.calls.find(([filePath]) =>
+        String(filePath).replace(/\\/g, '/').endsWith('/debug80.json')
+      );
+      expect(configWrite).toBeDefined();
+      const starterWrite = writeFileSync.mock.calls.find(([filePath]) =>
+        String(filePath).replace(/\\/g, '/').endsWith('/src/main.asm')
+      );
+      expect(starterWrite).toBeDefined();
+
+      const writtenConfig = JSON.parse(String(configWrite?.[1] ?? '{}')) as {
+        defaultTarget?: string;
+        defaultProfile?: string;
+        projectPlatform?: string;
+        targets?: Record<string, { sourceFile?: string; platform?: string; profile?: string }>;
+      };
+      expect(writtenConfig.projectPlatform).toBe('tec1');
+      expect(writtenConfig.defaultProfile).toBe('mon1b');
+      expect(writtenConfig.defaultTarget).toBe('app');
+      expect(writtenConfig.targets?.app).toEqual(
+        expect.objectContaining({
+          sourceFile: 'src/main.asm',
+          platform: 'tec1',
+          profile: 'mon1b',
+        })
+      );
+      expect(showInformationMessage).toHaveBeenCalledWith(
+        'Debug80: Created TEC-1 / MON-1B project in debug80.json targeting src/main.asm.'
+      );
+    } finally {
+      vi.mocked(fs.existsSync).mockImplementation(defaultExistsSync);
+      showErrorMessage.mockReset();
+      actualFs.rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   it('writes a tec1g config without copying MON-3 bundle files during scaffold', async () => {
     const fs = await import('fs');
     const actualFs = await vi.importActual<typeof import('fs')>('fs');


### PR DESCRIPTION
## Summary
- initialize unconfigured roots from the selected shared-panel platform using default bundle-first project kits
- keep idle/uninitialized platform selection in the shared panel without requiring a config write first
- cover the init flow and platform routing with focused extension tests

## Testing
- npm run build
- npx vitest run tests/extension/project-scaffolding.test.ts tests/extension/commands.test.ts tests/extension/platform-view-messages.test.ts tests/extension/platform-view-provider.test.ts
- npx vitest run -c vitest.webview.config.ts tests/webview/common/setup-card-state.test.ts tests/webview/common/project-root-button.test.ts tests/webview/common/project-state.test.ts