### PR TITLE
Simplify initialized project controls

### DIFF
--- a/src/contracts/platform-view.ts
+++ b/src/contracts/platform-view.ts
@@ -27,6 +27,7 @@ export type ProjectStatusPayload = {
 
 export type PlatformViewControlMessage =
   | { type: 'startDebug'; rootPath?: string }
+  | { type: 'restartDebug' }
   | { type: 'createProject'; rootPath?: string; platform?: string }
   | { type: 'openWorkspaceFolder' }
   | { type: 'selectProject'; rootPath?: string }

--- a/tests/webview/common/project-controls.test.ts
+++ b/tests/webview/common/project-controls.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { applyInitializedProjectControls } from '../../../webview/common/project-controls';
+
+function createElement(): HTMLElement {
+  return document.createElement('div');
+}
+
+describe('initialized project controls', () => {
+  it('shows only initialized controls after project setup', () => {
+    const targetControl = createElement();
+    const platformControl = createElement();
+    const stopOnEntryLabel = createElement();
+    const restartButton = createElement();
+    const tabs = createElement();
+    const panelUi = createElement();
+    const panelMemory = createElement();
+
+    const initialized = applyInitializedProjectControls(
+      { projectState: 'initialized', rootPath: '/workspace/demo', hasProject: true },
+      { targetControl, platformControl, stopOnEntryLabel, restartButton, tabs, panelUi, panelMemory }
+    );
+
+    expect(initialized).toBe(true);
+    expect(targetControl.hidden).toBe(false);
+    expect(platformControl.hidden).toBe(true);
+    expect(stopOnEntryLabel.hidden).toBe(false);
+    expect(restartButton.hidden).toBe(false);
+    expect(tabs.hidden).toBe(false);
+    expect(panelUi.hidden).toBe(false);
+    expect(panelMemory.hidden).toBe(false);
+  });
+
+  it('keeps platform visible until the project is initialized', () => {
+    const targetControl = createElement();
+    const platformControl = createElement();
+    const stopOnEntryLabel = createElement();
+    const restartButton = createElement();
+
+    const initialized = applyInitializedProjectControls(
+      { projectState: 'uninitialized', rootPath: '/workspace/demo', hasProject: false },
+      { targetControl, platformControl, stopOnEntryLabel, restartButton }
+    );
+
+    expect(initialized).toBe(false);
+    expect(targetControl.hidden).toBe(true);
+    expect(platformControl.hidden).toBe(false);
+    expect(stopOnEntryLabel.hidden).toBe(true);
+    expect(restartButton.hidden).toBe(true);
+  });
+});

--- a/tests/webview/session-status.test.ts
+++ b/tests/webview/session-status.test.ts
@@ -1,5 +1,5 @@
 /**
- * @file Regression tests: debugger session status badge contract.
+ * @file Regression tests: shared restart control contract.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -31,72 +31,73 @@ function createVscodeMock(messages: PostedMessage[]) {
   };
 }
 
-describe('debugger session status badge', () => {
-  it.each(HTML_PATHS)('renders the badge in the %s top bar', (_label, htmlPath) => {
+describe('shared restart control', () => {
+  it.each(HTML_PATHS)('renders restart in the %s top bar', (_label, htmlPath) => {
     buildDom(htmlPath);
-    const badge = document.getElementById('sessionStatus') as HTMLButtonElement | null;
+    const restartButton = document.getElementById('restartDebug') as HTMLButtonElement | null;
     const tabs = document.querySelector('.tabs');
 
     expect(tabs).not.toBeNull();
-    expect(badge).not.toBeNull();
-    if (!tabs || !badge) {
-      throw new Error('session status badge is missing');
+    expect(restartButton).not.toBeNull();
+    if (!tabs || !restartButton) {
+      throw new Error('restart button is missing');
     }
-    expect(tabs.contains(badge)).toBe(true);
+    expect(tabs.contains(restartButton)).toBe(true);
     const slot = document.querySelector('.tabs-status-slot');
     const stopOnEntry = document.getElementById('stopOnEntry') as HTMLInputElement | null;
     expect(slot).not.toBeNull();
-    expect(slot?.contains(badge)).toBe(true);
+    expect(slot?.contains(restartButton)).toBe(true);
     expect(stopOnEntry).not.toBeNull();
     expect(slot?.contains(stopOnEntry)).toBe(true);
-    expect(badge?.textContent).toBe('Not running');
-    expect(badge?.dataset.status).toBe('not-running');
-    expect(badge?.disabled).toBe(false);
-    expect(badge?.title).toBe('Click to start debugging');
-    expect(badge?.getAttribute('aria-label')).toBe(
-      'Not running. Click to start debugging'
+    expect(restartButton?.textContent).toBe('Restart');
+    expect(restartButton?.dataset.status).toBe('not-running');
+    expect(restartButton?.disabled).toBe(false);
+    expect(restartButton?.title).toBe(
+      'Relaunch the current project and target using the current launch options'
+    );
+    expect(restartButton?.getAttribute('aria-label')).toBe(
+      'Relaunch the current project and target using the current launch options'
     );
   });
 
-  it.each(HTML_PATHS)('updates the badge text for %s session states', (_label, htmlPath) => {
+  it.each(HTML_PATHS)('keeps restart explicit for %s session states', (_label, htmlPath) => {
     buildDom(htmlPath);
     const messages: PostedMessage[] = [];
     const controller = createSessionStatusController(
       createVscodeMock(messages),
-      document.getElementById('sessionStatus')
+      document.getElementById('restartDebug')
     );
-    const badge = document.getElementById('sessionStatus') as HTMLButtonElement | null;
+    const restartButton = document.getElementById('restartDebug') as HTMLButtonElement | null;
 
     controller.setStatus('starting');
-    expect(badge?.textContent).toBe('Starting...');
-    expect(badge?.dataset.status).toBe('starting');
-    expect(badge?.disabled).toBe(true);
-    expect(badge?.title).toBe('Debugger session is starting');
+    expect(restartButton?.textContent).toBe('Restart');
+    expect(restartButton?.dataset.status).toBe('starting');
+    expect(restartButton?.disabled).toBe(true);
 
     controller.setStatus('running');
-    expect(badge?.textContent).toBe('Running');
-    expect(badge?.dataset.status).toBe('running');
-    expect(badge?.title).toBe('Debugger session is running');
+    expect(restartButton?.textContent).toBe('Restart');
+    expect(restartButton?.dataset.status).toBe('running');
+    expect(restartButton?.disabled).toBe(false);
 
     controller.setStatus('paused');
-    expect(badge?.textContent).toBe('Paused');
-    expect(badge?.dataset.status).toBe('paused');
-    expect(badge?.title).toBe('Debugger session is paused');
+    expect(restartButton?.textContent).toBe('Restart');
+    expect(restartButton?.dataset.status).toBe('paused');
+    expect(restartButton?.disabled).toBe(false);
 
     controller.dispose();
   });
 
-  it.each(HTML_PATHS)('starts debugging when the %s badge is clicked in the idle state', (_label, htmlPath) => {
+  it.each(HTML_PATHS)('restarts debugging when the %s control is clicked', (_label, htmlPath) => {
     buildDom(htmlPath);
     const messages: PostedMessage[] = [];
     createSessionStatusController(
       createVscodeMock(messages),
-      document.getElementById('sessionStatus')
+      document.getElementById('restartDebug')
     );
 
-    const badge = document.getElementById('sessionStatus') as HTMLButtonElement | null;
-    badge?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const restartButton = document.getElementById('restartDebug') as HTMLButtonElement | null;
+    restartButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
-    expect(messages).toContainEqual({ type: 'startDebug' });
+    expect(messages).toContainEqual({ type: 'restartDebug' });
   });
 });

--- a/webview/common/project-controls.ts
+++ b/webview/common/project-controls.ts
@@ -1,0 +1,33 @@
+import type { ProjectStatusPayload } from '../../src/contracts/platform-view';
+import { resolveProjectViewState } from './project-state';
+
+export type SharedProjectControlElements = {
+  targetControl?: HTMLElement | null;
+  platformControl?: HTMLElement | null;
+  stopOnEntryLabel?: HTMLElement | null;
+  restartButton?: HTMLElement | null;
+  tabs?: HTMLElement | null;
+  panelUi?: HTMLElement | null;
+  panelMemory?: HTMLElement | null;
+};
+
+export function applyInitializedProjectControls(
+  payload: {
+    projectState?: ProjectStatusPayload['projectState'];
+    rootPath?: ProjectStatusPayload['rootPath'];
+    hasProject?: ProjectStatusPayload['hasProject'];
+  },
+  elements: SharedProjectControlElements
+): boolean {
+  const initialized = resolveProjectViewState(payload) === 'initialized';
+
+  elements.targetControl?.toggleAttribute('hidden', !initialized);
+  elements.platformControl?.toggleAttribute('hidden', initialized);
+  elements.stopOnEntryLabel?.toggleAttribute('hidden', !initialized);
+  elements.restartButton?.toggleAttribute('hidden', !initialized);
+  elements.tabs?.toggleAttribute('hidden', !initialized);
+  elements.panelUi?.toggleAttribute('hidden', !initialized);
+  elements.panelMemory?.toggleAttribute('hidden', !initialized);
+
+  return initialized;
+}

--- a/webview/common/session-status.ts
+++ b/webview/common/session-status.ts
@@ -7,19 +7,8 @@ export interface SessionStatusController {
   dispose: () => void;
 }
 
-const STATUS_LABELS: Record<SessionStatus, string> = {
-  starting: 'Starting...',
-  running: 'Running',
-  paused: 'Paused',
-  'not running': 'Not running',
-};
-
-const STATUS_TITLES: Record<SessionStatus, string> = {
-  starting: 'Debugger session is starting',
-  running: 'Debugger session is running',
-  paused: 'Debugger session is paused',
-  'not running': 'Click to start debugging',
-};
+const RESTART_LABEL = 'Restart';
+const RESTART_TITLE = 'Relaunch the current project and target using the current launch options';
 
 function statusClass(status: SessionStatus): string {
   return `session-status status-${status.replace(/\s+/g, '-')}`;
@@ -38,22 +27,22 @@ export function createSessionStatusController(
 
   let currentStatus: SessionStatus = 'not running';
   const handleClick = (): void => {
-    if (currentStatus !== 'not running') {
+    if (currentStatus === 'starting') {
       return;
     }
-    vscode.postMessage({ type: 'startDebug' });
+    vscode.postMessage({ type: 'restartDebug' });
   };
 
   const applyStatus = (status: SessionStatus): void => {
     currentStatus = status;
-    element.textContent = STATUS_LABELS[status];
+    element.textContent = RESTART_LABEL;
     element.dataset.status = status.replace(/\s+/g, '-');
     element.className = statusClass(status);
-    element.title = STATUS_TITLES[status];
-    element.setAttribute('aria-label', `${STATUS_LABELS[status]}. ${STATUS_TITLES[status]}`);
+    element.title = RESTART_TITLE;
+    element.setAttribute('aria-label', RESTART_TITLE);
     element.setAttribute('aria-live', 'polite');
     element.setAttribute('aria-atomic', 'true');
-    element.disabled = status !== 'not running';
+    element.disabled = status === 'starting';
   };
 
   element.type = 'button';

--- a/webview/simple/index.html
+++ b/webview/simple/index.html
@@ -48,14 +48,14 @@
       </label>
       <button
         class="session-status"
-        id="sessionStatus"
+        id="restartDebug"
         type="button"
         data-status="not-running"
-        title="Click to start debugging"
-        aria-label="Not running. Click to start debugging"
+        title="Relaunch the current project and target using the current launch options"
+        aria-label="Relaunch the current project and target using the current launch options"
         aria-live="polite"
         aria-atomic="true"
-      >Not running</button>
+      >Restart</button>
     </div>
   </div>
   <div class="panel panel-ui" id="panel-ui">

--- a/webview/simple/index.ts
+++ b/webview/simple/index.ts
@@ -4,10 +4,10 @@
 
 import { appendSerialText } from '../common/serial';
 import { MemoryPanel } from '../common/memory-panel';
+import { applyInitializedProjectControls } from '../common/project-controls';
 import { createSessionStatusController } from '../common/session-status';
 import { wireStopOnEntryControl } from '../common/stop-on-entry-control';
 import { createProjectRootButtonController } from '../common/project-root-button';
-import { resolveProjectViewState } from '../common/project-state';
 import { resolveSetupCardState } from '../common/setup-card-state';
 import { acquireVscodeApi } from '../common/vscode';
 import type { ProjectStatusPayload } from '../../src/contracts/platform-view';
@@ -20,13 +20,14 @@ const selectProjectButton = document.getElementById('selectProject') as HTMLButt
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
 const setupPrimaryAction = document.getElementById('setupPrimaryAction') as HTMLButtonElement | null;
-const sessionStatusButton = document.getElementById('sessionStatus') as HTMLButtonElement | null;
+const restartDebugButton = document.getElementById('restartDebug') as HTMLButtonElement | null;
 const stopOnEntryInput = document.getElementById('stopOnEntry') as HTMLInputElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const platformSelectEl = document.getElementById('platformSelect') as HTMLSelectElement | null;
 const targetControl = homeTargetSelect?.closest('.project-control') as HTMLElement | null;
 const platformControl = platformSelectEl?.closest('.project-control') as HTMLElement | null;
 const tabsEl = document.querySelector('.tabs') as HTMLElement | null;
+const stopOnEntryLabel = stopOnEntryInput?.closest('.stop-on-entry-label') as HTMLElement | null;
 const panelUi = document.getElementById('panel-ui') as HTMLElement;
 const panelMemory = document.getElementById('panel-memory') as HTMLElement;
 const tabButtons = Array.from(document.querySelectorAll<HTMLElement>('[data-tab]'));
@@ -42,7 +43,7 @@ let setupPrimaryActionType: 'openWorkspaceFolder' | 'createProject' = 'openWorks
 let memoryRowSize = 16;
 let resizeTimer: number | null = null;
 
-const sessionStatusController = createSessionStatusController(vscode, sessionStatusButton);
+const sessionStatusController = createSessionStatusController(vscode, restartDebugButton);
 const stopOnEntryControl = wireStopOnEntryControl(vscode, stopOnEntryInput);
 const projectRootController = createProjectRootButtonController(vscode, selectProjectButton);
 
@@ -126,8 +127,6 @@ function applyProjectStatus(payload: {
   hasProject?: ProjectStatusPayload['hasProject'];
   stopOnEntry?: ProjectStatusPayload['stopOnEntry'];
 }): void {
-  const projectState = resolveProjectViewState(payload);
-  const initialized = projectState === 'initialized';
   currentRootPath = payload.rootPath ?? '';
   currentRoots = payload.roots ?? [];
   projectRootController.applyProjectStatus({
@@ -136,30 +135,22 @@ function applyProjectStatus(payload: {
     targetCount: payload.targets?.length ?? 0,
   });
   setTargetOptions(payload.targets ?? [], payload.targetName);
-  if (targetControl) {
-    targetControl.hidden = !initialized;
-  }
   if (platformSelectEl && payload.platform !== undefined) {
     platformSelectEl.value = payload.platform;
   }
-  if (platformControl) {
-    platformControl.hidden = initialized;
-  }
+  const initialized = applyInitializedProjectControls(payload, {
+    targetControl,
+    platformControl,
+    stopOnEntryLabel,
+    restartButton: restartDebugButton,
+    tabs: tabsEl,
+    panelUi,
+    panelMemory,
+  });
   stopOnEntryControl.applyProjectStatus({
     hasProject: initialized,
     stopOnEntry: payload.stopOnEntry,
   });
-  if (stopOnEntryInput?.parentElement) {
-    stopOnEntryInput.parentElement.hidden = !initialized;
-  }
-  if (sessionStatusButton) {
-    sessionStatusButton.hidden = !initialized;
-  }
-  if (tabsEl) {
-    tabsEl.hidden = !initialized;
-  }
-  panelUi.hidden = !initialized;
-  panelMemory.hidden = !initialized;
   const selected = currentRoots.find((r) => r.path === currentRootPath) ?? currentRoots[0];
   const targetCount = payload.targets?.length ?? 0;
   if (!setupCard || !setupCardText || !setupPrimaryAction) {

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -48,14 +48,14 @@
         </label>
         <button
           class="session-status"
-          id="sessionStatus"
+          id="restartDebug"
           type="button"
           data-status="not-running"
-          title="Click to start debugging"
-          aria-label="Not running. Click to start debugging"
+          title="Relaunch the current project and target using the current launch options"
+          aria-label="Relaunch the current project and target using the current launch options"
           aria-live="polite"
           aria-atomic="true"
-        >Not running</button>
+        >Restart</button>
       </div>
     </div>
     <div class="panel panel-ui" id="panel-ui">

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -1,9 +1,9 @@
 import { createDigit } from '../common/digits';
+import { applyInitializedProjectControls } from '../common/project-controls';
 import { MemoryPanel } from '../common/memory-panel';
 import { createSessionStatusController } from '../common/session-status';
 import { wireStopOnEntryControl } from '../common/stop-on-entry-control';
 import { createProjectRootButtonController } from '../common/project-root-button';
-import { resolveProjectViewState } from '../common/project-state';
 import { resolveSetupCardState } from '../common/setup-card-state';
 import { acquireVscodeApi } from '../common/vscode';
 import type { ProjectStatusPayload } from '../../src/contracts/platform-view';
@@ -22,7 +22,7 @@ const selectProjectButton = document.getElementById('selectProject') as HTMLButt
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
 const setupPrimaryAction = document.getElementById('setupPrimaryAction') as HTMLButtonElement | null;
-const sessionStatusButton = document.getElementById('sessionStatus') as HTMLButtonElement | null;
+const restartDebugButton = document.getElementById('restartDebug') as HTMLButtonElement | null;
 const stopOnEntryInput = document.getElementById('stopOnEntry') as HTMLInputElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const targetControl = homeTargetSelect?.closest('.project-control') as HTMLElement | null;
@@ -40,6 +40,7 @@ const platformControl = platformSelectEl?.closest('.project-control') as HTMLEle
 const registerStrip = document.getElementById('registerStrip') as HTMLElement;
 const memoryPanel = document.getElementById('memoryPanel') as HTMLElement;
 const tabsEl = document.querySelector('.tabs') as HTMLElement | null;
+const stopOnEntryLabel = stopOnEntryInput?.closest('.stop-on-entry-label') as HTMLElement | null;
 const SHIFT_BIT = 0x20;
 const DIGITS = 6;
 const digitEls = [];
@@ -90,7 +91,7 @@ platformSelectEl?.addEventListener('change', () => {
 });
 const lcdRenderer = createLcdRenderer();
 const matrixRenderer = createMatrixRenderer();
-const sessionStatusController = createSessionStatusController(vscode, sessionStatusButton);
+const sessionStatusController = createSessionStatusController(vscode, restartDebugButton);
 const stopOnEntryControl = wireStopOnEntryControl(vscode, stopOnEntryInput);
 const projectRootController = createProjectRootButtonController(vscode, selectProjectButton);
 
@@ -163,8 +164,6 @@ function applyProjectStatus(payload: {
   hasProject?: ProjectStatusPayload['hasProject'];
   stopOnEntry?: ProjectStatusPayload['stopOnEntry'];
 }): void {
-  const projectState = resolveProjectViewState(payload);
-  const initialized = projectState === 'initialized';
   currentRootPath = payload.rootPath ?? '';
   currentRoots = payload.roots ?? [];
   projectRootController.applyProjectStatus({
@@ -173,27 +172,19 @@ function applyProjectStatus(payload: {
     targetCount: payload.targets?.length ?? 0,
   });
   setTargetOptions(payload.targets ?? [], payload.targetName);
-  if (targetControl) {
-    targetControl.hidden = !initialized;
-  }
-  if (platformControl) {
-    platformControl.hidden = initialized;
-  }
+  const initialized = applyInitializedProjectControls(payload, {
+    targetControl,
+    platformControl,
+    stopOnEntryLabel,
+    restartButton: restartDebugButton,
+    tabs: tabsEl,
+    panelUi,
+    panelMemory,
+  });
   stopOnEntryControl.applyProjectStatus({
     hasProject: initialized,
     stopOnEntry: payload.stopOnEntry,
   });
-  if (stopOnEntryInput?.parentElement) {
-    stopOnEntryInput.parentElement.hidden = !initialized;
-  }
-  if (sessionStatusButton) {
-    sessionStatusButton.hidden = !initialized;
-  }
-  if (tabsEl) {
-    tabsEl.hidden = !initialized;
-  }
-  panelUi.hidden = !initialized;
-  panelMemory.hidden = !initialized;
   const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
   const targetCount = payload.targets?.length ?? 0;
   if (!setupCard || !setupCardText || !setupPrimaryAction) {

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -48,14 +48,14 @@
         </label>
         <button
           class="session-status"
-          id="sessionStatus"
+          id="restartDebug"
           type="button"
           data-status="not-running"
-          title="Click to start debugging"
-          aria-label="Not running. Click to start debugging"
+          title="Relaunch the current project and target using the current launch options"
+          aria-label="Relaunch the current project and target using the current launch options"
           aria-live="polite"
           aria-atomic="true"
-        >Not running</button>
+        >Restart</button>
       </div>
     </div>
     <div class="panel panel-ui" id="panel-ui">

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -4,6 +4,7 @@
 
 import { createDigit } from '../common/digits';
 import { MemoryPanel } from '../common/memory-panel';
+import { applyInitializedProjectControls } from '../common/project-controls';
 import { createSessionStatusController } from '../common/session-status';
 import { wireStopOnEntryControl } from '../common/stop-on-entry-control';
 import { acquireVscodeApi } from '../common/vscode';
@@ -32,7 +33,7 @@ const selectProjectButton = document.getElementById('selectProject') as HTMLButt
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
 const setupPrimaryAction = document.getElementById('setupPrimaryAction') as HTMLButtonElement | null;
-const sessionStatusButton = document.getElementById('sessionStatus') as HTMLButtonElement | null;
+const restartDebugButton = document.getElementById('restartDebug') as HTMLButtonElement | null;
 const stopOnEntryInput = document.getElementById('stopOnEntry') as HTMLInputElement | null;
 const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSelectElement | null;
 const displayEl = document.getElementById('display') as HTMLElement;
@@ -49,6 +50,10 @@ const tabButtons = Array.from(document.querySelectorAll<HTMLElement>('[data-tab]
 const panelUi = document.getElementById('panel-ui') as HTMLElement;
 const panelMemory = document.getElementById('panel-memory') as HTMLElement;
 const platformSelectEl = document.getElementById('platformSelect') as HTMLSelectElement | null;
+const targetControl = homeTargetSelect?.closest('.project-control') as HTMLElement | null;
+const platformControl = platformSelectEl?.closest('.project-control') as HTMLElement | null;
+const tabsEl = document.querySelector('.tabs') as HTMLElement | null;
+const stopOnEntryLabel = stopOnEntryInput?.closest('.stop-on-entry-label') as HTMLElement | null;
 const registerStrip = document.getElementById('registerStrip') as HTMLElement;
 const memoryPanelEl = document.getElementById('memoryPanel') as HTMLElement;
 
@@ -59,7 +64,7 @@ for (let i = 0; i < TEC1G_DIGITS; i++) {
   displayEl.appendChild(digit);
 }
 
-const sessionStatusController = createSessionStatusController(vscode, sessionStatusButton);
+const sessionStatusController = createSessionStatusController(vscode, restartDebugButton);
 const stopOnEntryControl = wireStopOnEntryControl(vscode, stopOnEntryInput);
 
 const glcdRenderer = createGlcdRenderer();
@@ -86,12 +91,6 @@ const projectStatusUi = createTec1gProjectStatusUi(vscode, {
   setupCardText,
   setupPrimaryAction,
   homeTargetSelect,
-  platformSelect: platformSelectEl,
-  sessionStatusButton,
-  stopOnEntryInput,
-  tabs: document.querySelector('.tabs') as HTMLElement | null,
-  panelUi,
-  panelMemory,
   getPlatform: () => platformSelectEl?.value ?? undefined,
 });
 
@@ -164,8 +163,17 @@ window.addEventListener('message', (event: MessageEvent<IncomingMessage | undefi
     if (platformSelectEl && message.platform !== undefined) {
       platformSelectEl.value = message.platform;
     }
+    const initialized = applyInitializedProjectControls(message, {
+      targetControl,
+      platformControl,
+      stopOnEntryLabel,
+      restartButton: restartDebugButton,
+      tabs: tabsEl,
+      panelUi,
+      panelMemory,
+    });
     stopOnEntryControl.applyProjectStatus({
-      hasProject: message.hasProject === true,
+      hasProject: initialized,
       stopOnEntry: message.stopOnEntry,
     });
     return;

--- a/webview/tec1g/tec1g-project-status-ui.ts
+++ b/webview/tec1g/tec1g-project-status-ui.ts
@@ -14,12 +14,6 @@ export type Tec1gProjectStatusElements = {
   setupCardText: HTMLElement | null;
   setupPrimaryAction: HTMLButtonElement | null;
   homeTargetSelect: HTMLSelectElement | null;
-  platformSelect?: HTMLSelectElement | null;
-  sessionStatusButton?: HTMLButtonElement | null;
-  stopOnEntryInput?: HTMLInputElement | null;
-  tabs?: HTMLElement | null;
-  panelUi?: HTMLElement | null;
-  panelMemory?: HTMLElement | null;
   getPlatform?: () => string | undefined;
 };
 
@@ -85,12 +79,6 @@ export function createTec1gProjectStatusUi(
     setupCardText,
     setupPrimaryAction,
     homeTargetSelect,
-    platformSelect,
-    sessionStatusButton,
-    stopOnEntryInput,
-    tabs,
-    panelUi,
-    panelMemory,
     getPlatform,
   } = elements;
 
@@ -130,8 +118,6 @@ export function createTec1gProjectStatusUi(
     targetName?: ProjectStatusPayload['targetName'];
     projectState?: ProjectStatusPayload['projectState'];
   }): void {
-    const projectState = resolveProjectViewState(payload);
-    const initialized = projectState === 'initialized';
     currentRootPath = payload.rootPath ?? '';
     currentRoots = payload.roots ?? [];
     projectRootController.applyProjectStatus({
@@ -141,35 +127,13 @@ export function createTec1gProjectStatusUi(
     });
     if (homeTargetSelect) {
       setTargetOptions(homeTargetSelect, payload.targets ?? [], payload.targetName);
-      const targetControl = homeTargetSelect.closest('.project-control') as HTMLElement | null;
-      if (targetControl) {
-        targetControl.hidden = !initialized;
-      }
-    }
-    const platformControl = platformSelect?.closest('.project-control') as HTMLElement | null;
-    if (platformControl) {
-      platformControl.hidden = initialized;
-    }
-    if (stopOnEntryInput?.parentElement) {
-      stopOnEntryInput.parentElement.hidden = !initialized;
-    }
-    if (sessionStatusButton) {
-      sessionStatusButton.hidden = !initialized;
-    }
-    if (tabs) {
-      tabs.hidden = !initialized;
-    }
-    if (panelUi) {
-      panelUi.hidden = !initialized;
-    }
-    if (panelMemory) {
-      panelMemory.hidden = !initialized;
     }
     const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
     const targetCount = payload.targets?.length ?? 0;
     if (!setupCard || !setupCardText || !setupPrimaryAction) {
       return;
     }
+    const projectState = resolveProjectViewState(payload);
     const setupState = resolveSetupCardState(selected, projectState, targetCount);
     if (setupState === null) {
       setupCard.hidden = true;


### PR DESCRIPTION
## Summary
- replace the shared initialized-project session badge with an explicit Restart control
- hide the shared Platform selector once a project is initialized while keeping Project, Target, and Stop On Entry visible
- centralize initialized-project control visibility and cover it with focused webview tests

## Testing
- npm run typecheck
- npx vitest run tests/extension/platform-view-messages.test.ts tests/webview/session-status.test.ts tests/webview/common/project-controls.test.ts
- npx vitest run -c vitest.webview.config.ts tests/webview/session-status.test.ts tests/webview/common/project-controls.test.ts
- npm run build

Closes #301