### PR TITLE
Fix restart semantics for project, target, and stop-on-entry

### DIFF
--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -363,17 +363,18 @@ function projectConfigFromSession(session: vscode.DebugSession): string | undefi
   return projectConfigRaw;
 }
 
-function resolveSessionProjectPlatform(session: vscode.DebugSession): string | undefined {
+function resolveSessionProjectConfigPath(session: vscode.DebugSession): string | undefined {
   const projectConfigRaw = projectConfigFromSession(session);
   if (projectConfigRaw === undefined) {
     return undefined;
   }
-  const projectConfigPath = path.isAbsolute(projectConfigRaw)
-    ? projectConfigRaw
-    : session.workspaceFolder !== undefined
-      ? path.join(session.workspaceFolder.uri.fsPath, projectConfigRaw)
-      : projectConfigRaw;
-  return resolveProjectPlatform(readProjectConfig(projectConfigPath));
+  return path.normalize(
+    path.isAbsolute(projectConfigRaw)
+      ? projectConfigRaw
+      : session.workspaceFolder !== undefined
+        ? path.join(session.workspaceFolder.uri.fsPath, projectConfigRaw)
+        : projectConfigRaw
+  );
 }
 
 function normalizeBundledAssetInstallPlan(
@@ -639,19 +640,22 @@ export function registerExtensionCommands({
         let restartedForRootChange = false;
         const activeSession = vscode.debug.activeDebugSession;
         if (activeSession?.type === 'z80') {
-          const previousPlatform = resolveSessionProjectPlatform(activeSession);
-          const nextPlatform = resolveProjectPlatformForFolder(folder);
+          const previousProjectConfig = resolveSessionProjectConfigPath(activeSession);
+          const nextProjectConfig = findProjectConfigPath(folder);
           if (
-            previousPlatform !== undefined &&
-            nextPlatform !== undefined &&
-            previousPlatform !== nextPlatform
+            previousProjectConfig !== undefined &&
+            nextProjectConfig !== undefined &&
+            path.normalize(nextProjectConfig) !== previousProjectConfig
           ) {
             await vscode.debug.stopDebugging(activeSession);
             const restarted = await startCurrentProjectDebugging(folder, workspaceSelection, platformViewProvider.stopOnEntry);
             restartedForRootChange = restarted;
             if (restarted) {
+              const nextPlatform = resolveProjectPlatformForFolder(folder);
               void vscode.window.showInformationMessage(
-                `Debug80: Selected root ${folder.name}; restarted debugging for ${nextPlatform}.`
+                nextPlatform !== undefined
+                  ? `Debug80: Selected root ${folder.name}; restarted debugging for ${nextPlatform}.`
+                  : `Debug80: Selected root ${folder.name}; restarted debugging.`
               );
             }
           }

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -575,7 +575,6 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   private handleSetStopOnEntry(value: boolean): void {
     this.stopOnEntry = value;
     this.postProjectStatus();
-    void vscode.commands.executeCommand('debug80.restartDebug');
   }
 
   // -------------------------------------------------------------------------

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -549,7 +549,7 @@ describe('registerExtensionCommands', () => {
     );
   });
 
-  it('does not restart an active z80 session when selected root keeps the same platform', async () => {
+  it('restarts an active z80 session when selected root changes project but keeps the same platform', async () => {
     const vscode = await import('vscode');
     const { registerExtensionCommands } = await import('../../src/extension/commands');
 
@@ -607,8 +607,17 @@ describe('registerExtensionCommands', () => {
     const result = await selectRoot?.({ rootPath: rootB });
 
     expect(result).toEqual(expect.objectContaining({ uri: { fsPath: rootB } }));
-    expect(stopDebugging).not.toHaveBeenCalled();
-    expect(startDebugging).not.toHaveBeenCalled();
+    expect(stopDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'z80', id: 'session-root-change' })
+    );
+    expect(startDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: { fsPath: rootB } }),
+      expect.objectContaining({
+        type: 'z80',
+        request: 'launch',
+        projectConfig: configBPath,
+      })
+    );
   });
 
   it('auto-starts when a selected root exposes exactly one target', async () => {
@@ -1113,6 +1122,53 @@ describe('registerExtensionCommands', () => {
         type: 'z80',
         request: 'launch',
         projectConfig: projectConfigPath,
+      })
+    );
+  });
+
+  it('restarts with the current stop-on-entry state', async () => {
+    const vscode = await import('vscode');
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    const resolveWorkspaceFolder = vi.fn().mockResolvedValue({
+      name: 'tec1g-mon3',
+      uri: { fsPath: '/workspace/tec1g-mon3' },
+      index: 0,
+    });
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn(), stopOnEntry: true } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder,
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {} as never,
+    });
+
+    const restartDebug = registeredCommands.get('debug80.restartDebug');
+    expect(restartDebug).toBeTypeOf('function');
+
+    startDebugging.mockResolvedValueOnce(true);
+    stopDebugging.mockResolvedValueOnce(undefined);
+    (vscode.debug as { activeDebugSession?: unknown }).activeDebugSession = {
+      type: 'z80',
+      id: 'session-stop-on-entry',
+    };
+
+    const result = await restartDebug?.();
+
+    expect(result).toBe(true);
+    expect(startDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: { fsPath: '/workspace/tec1g-mon3' } }),
+      expect.objectContaining({
+        type: 'z80',
+        request: 'launch',
+        projectConfig: projectConfigPath,
+        stopOnEntry: true,
       })
     );
   });

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -303,6 +303,37 @@ describe('PlatformViewProvider', () => {
     }
   });
 
+  it('updates stop-on-entry state without restarting the session', async () => {
+    const provider = new PlatformViewProvider(extensionRoot, {
+      get: vi.fn(),
+      update: vi.fn(),
+    } as never);
+    const webviewView = createWebviewView();
+
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
+
+    workspaceFolders = [{ name: 'demo', uri: { fsPath: '/workspace/demo' } }];
+    provider.setSelectedWorkspace({ name: 'demo', uri: { fsPath: '/workspace/demo' } } as never);
+    provider.setPlatform('tec1g', undefined, { reveal: false, tab: 'ui' });
+
+    const handler = (webviewView.webview.onDidReceiveMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as ((msg: { type?: string; stopOnEntry?: boolean }) => Promise<void>) | undefined;
+    expect(handler).toBeTypeOf('function');
+
+    executeCommand.mockClear();
+    await handler?.({ type: 'setStopOnEntry', stopOnEntry: true });
+
+    expect(provider.stopOnEntry).toBe(true);
+    expect(executeCommand).not.toHaveBeenCalledWith('debug80.restartDebug');
+  });
+
   function getPostMessageCalls(webviewView: vscode.WebviewView): Array<[Record<string, unknown>]> {
     return (
       webviewView.webview as unknown as {


### PR DESCRIPTION
## Summary
- restart active debugging when the selected project changes, even if the platform stays the same
- keep stop-on-entry as pending launch state only so it applies on explicit restart instead of auto-restarting
- add focused command/provider coverage for project change, restart, and stop-on-entry behavior

Closes #300