### PR TITLE
Align Stop On Entry panel wording

### DIFF
--- a/tests/webview/session-status.test.ts
+++ b/tests/webview/session-status.test.ts
@@ -45,10 +45,15 @@ describe('shared restart control', () => {
     expect(tabs.contains(restartButton)).toBe(true);
     const slot = document.querySelector('.tabs-status-slot');
     const stopOnEntry = document.getElementById('stopOnEntry') as HTMLInputElement | null;
+    const stopOnEntryLabel = document.querySelector('.stop-on-entry-label');
     expect(slot).not.toBeNull();
     expect(slot?.contains(restartButton)).toBe(true);
     expect(stopOnEntry).not.toBeNull();
     expect(slot?.contains(stopOnEntry)).toBe(true);
+    expect(stopOnEntryLabel).not.toBeNull();
+    expect(stopOnEntryLabel?.title).toBe(
+      'Pause at the program entry point when starting or restarting debugging. This applies to the current launch state only.'
+    );
     expect(restartButton?.textContent).toBe('Restart');
     expect(restartButton?.dataset.status).toBe('not-running');
     expect(restartButton?.disabled).toBe(false);

--- a/webview/simple/index.html
+++ b/webview/simple/index.html
@@ -41,7 +41,7 @@
     <div class="tabs-status-slot">
       <label
         class="stop-on-entry-label"
-        title="Pause at the program entry point when starting a debug session (saved to debug80.json)."
+        title="Pause at the program entry point when starting or restarting debugging. This applies to the current launch state only."
       >
         <input type="checkbox" id="stopOnEntry" />
         Stop on entry

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -41,7 +41,7 @@
       <div class="tabs-status-slot">
         <label
           class="stop-on-entry-label"
-          title="Pause at the program entry point when starting a debug session (saved to debug80.json)."
+          title="Pause at the program entry point when starting or restarting debugging. This applies to the current launch state only."
         >
           <input type="checkbox" id="stopOnEntry" />
           Stop on entry

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -41,7 +41,7 @@
       <div class="tabs-status-slot">
         <label
           class="stop-on-entry-label"
-          title="Pause at the program entry point when starting a debug session (saved to debug80.json)."
+          title="Pause at the program entry point when starting or restarting debugging. This applies to the current launch state only."
         >
           <input type="checkbox" id="stopOnEntry" />
           Stop on entry


### PR DESCRIPTION
## Summary
- update the Stop on entry tooltip in all shared panel variants to describe current launch/session state semantics
- remove the incorrect implication that the setting is saved to debug80.json
- add a focused webview regression assertion for the shared top-bar copy

Closes #310