### PR TITLE
fix(webview): align Stop on entry tooltip with panel session state (#312)

### DIFF
--- a/src/contracts/platform-view.ts
+++ b/src/contracts/platform-view.ts
@@ -11,7 +11,7 @@ export type ProjectStatusPayload = {
   targetName?: string;
   entrySource?: string;
   platform?: string;
-  /** Effective stop-on-entry for the current target (merged from target + project root). */
+  /** Panel stop-on-entry toggle for this window session (not read from or written to debug80.json). */
   stopOnEntry?: boolean;
   roots: Array<{
     name: string;

--- a/tests/webview/session-status.test.ts
+++ b/tests/webview/session-status.test.ts
@@ -52,7 +52,7 @@ describe('shared restart control', () => {
     expect(slot?.contains(stopOnEntry)).toBe(true);
     expect(stopOnEntryLabel).not.toBeNull();
     expect(stopOnEntryLabel?.title).toBe(
-      'Pause at the program entry point when starting or restarting debugging. This applies to the current launch state only.'
+      'Pause at the program entry point when starting or restarting debugging. Kept in the Debug80 panel for this VS Code window session only; not written to debug80.json.'
     );
     expect(restartButton?.textContent).toBe('Restart');
     expect(restartButton?.dataset.status).toBe('not-running');

--- a/webview/common/stop-on-entry-control.ts
+++ b/webview/common/stop-on-entry-control.ts
@@ -1,5 +1,5 @@
 /**
- * @file Stop-on-entry checkbox: syncs with projectStatus and persists via setStopOnEntry.
+ * @file Stop-on-entry checkbox: syncs with projectStatus; changes post setStopOnEntry (panel session state).
  */
 
 import type { VscodeApi } from './vscode';

--- a/webview/simple/index.html
+++ b/webview/simple/index.html
@@ -41,7 +41,7 @@
     <div class="tabs-status-slot">
       <label
         class="stop-on-entry-label"
-        title="Pause at the program entry point when starting or restarting debugging. This applies to the current launch state only."
+        title="Pause at the program entry point when starting or restarting debugging. Kept in the Debug80 panel for this VS Code window session only; not written to debug80.json."
       >
         <input type="checkbox" id="stopOnEntry" />
         Stop on entry

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -41,7 +41,7 @@
       <div class="tabs-status-slot">
         <label
           class="stop-on-entry-label"
-          title="Pause at the program entry point when starting or restarting debugging. This applies to the current launch state only."
+          title="Pause at the program entry point when starting or restarting debugging. Kept in the Debug80 panel for this VS Code window session only; not written to debug80.json."
         >
           <input type="checkbox" id="stopOnEntry" />
           Stop on entry

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -41,7 +41,7 @@
       <div class="tabs-status-slot">
         <label
           class="stop-on-entry-label"
-          title="Pause at the program entry point when starting or restarting debugging. This applies to the current launch state only."
+          title="Pause at the program entry point when starting or restarting debugging. Kept in the Debug80 panel for this VS Code window session only; not written to debug80.json."
         >
           <input type="checkbox" id="stopOnEntry" />
           Stop on entry


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates user-facing copy for the shared **Stop on entry** control so it matches the implemented model: the checkbox is **panel/window-session state** and is **not** written to `debug80.json`.

## Changes

- **Tooltips** on the `stop-on-entry-label` in `webview/simple`, `webview/tec1`, and `webview/tec1g` HTML now state that the value is kept for the VS Code window session only and is not persisted to the project config file.
- **`ProjectStatusPayload.stopOnEntry` JSDoc** in `src/contracts/platform-view.ts` no longer describes config merge semantics that do not apply to the panel toggle.
- **`stop-on-entry-control.ts` file comment** no longer implies persistence via `setStopOnEntry`.
- **`tests/webview/session-status.test.ts`** expectation updated for the new tooltip string.

## Testing

- `npm run test:webview`

Closes #312
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54672c80-53a9-4c8f-8c17-2d2194fa7510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54672c80-53a9-4c8f-8c17-2d2194fa7510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

