### PR TITLE
docs: ADR for Project workspace-root control (#311)

### DIFF
--- a/docs/adr/0001-project-workspace-root-control.md
+++ b/docs/adr/0001-project-workspace-root-control.md
@@ -1,0 +1,41 @@
+# ADR 0001: Project (workspace root) control — button + Quick Pick
+
+## Status
+
+Accepted (2026-04-18)
+
+## Context
+
+The Debug80 platform panel header shows **Project** (active workspace root), **Target** (inline `<select>` from `debug80.json`), and **Platform**. **Target** and **Platform** are narrow, enumerable lists suited to a native dropdown in the webview.
+
+**Project** is different: it selects a **VS Code workspace folder** (multi-root workspace), not a field inside the current config file. The webview cannot list or switch arbitrary workspace roots without extension support; the extension must validate the choice against `vscode.workspace.workspaceFolders` and persist the selection (`WorkspaceSelectionController`, `debug80.selectedWorkspace`).
+
+Relevant lifecycle cases:
+
+| Situation | Behaviour today |
+|-----------|-----------------|
+| No workspace folders | Project button shows **Open Folder** and triggers create/open flow (`project-root-button.ts` empty state). |
+| Single root | Button shows that root’s name; click still routes through `selectProject` / `debug80.selectWorkspaceFolder` (no Quick Pick needed). |
+| Multiple roots | Click opens **Quick Pick** with name, path, and whether each root has a `debug80.json` (`WorkspaceSelectionController.selectWorkspaceFolder`). |
+| Workspace folders added/removed | `onDidChangeWorkspaceFolders` reapplies preferred selection; stale stored path falls back. |
+| Switch root while a Z80 session is running | `debug80.selectWorkspaceFolder` may stop and restart debugging when the resolved project config path changes (`commands.ts`). |
+
+An **inline `<select>` for roots** would duplicate the same list as the Quick Pick and require new webview markup, styling, keyboard behaviour, and message types (`selectProject` with explicit `rootPath` vs picker). It would be **more symmetric** with Target but **not** simpler for the extension.
+
+## Decision
+
+**Keep the Project control as a button** whose primary action is **choose workspace root via the VS Code Quick Pick** (or direct selection when only one root exists). **Do not** replace it with an inline dropdown as the default.
+
+Optional **follow-up** (separate scope): add an inline root `<select>` only if we later need faster switching without opening the Quick Pick, accepting the extra UI and test surface.
+
+## Consequences
+
+- **Pros:** Reuses VS Code’s native multi-item picker (search, keyboard, consistent with other extensions). Keeps webview header compact when there are many roots or long paths. Avoids duplicating root metadata (config presence) in two UIs.
+- **Cons:** Project and Target use different control patterns; users who expect two dropdowns may need a moment to learn that Project opens the editor picker.
+- **Documentation:** Product copy should describe “workspace root” / “folder” rather than implying the button cycles roots (it opens a picker or applies the single root).
+
+## References
+
+- Webview: `webview/common/project-root-button.ts`
+- Extension: `src/extension/workspace-selection.ts` (`selectWorkspaceFolder`, `rememberWorkspace`, `onDidChangeWorkspaceFolders`)
+- Command: `debug80.selectWorkspaceFolder` in `src/extension/commands.ts`

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -356,7 +356,7 @@ generate HTML, apply updates, handle messages, and build serialized update paylo
 
 Every platform panel includes a project header at the top with three controls:
 
-- **Project button** — shows the active workspace root name; clicking cycles or opens a picker.
+- **Project button** — shows the active workspace root name; with no folders it offers **Open Folder**; with multiple folders it opens the VS Code Quick Pick to choose the Debug80 workspace root (see `docs/adr/0001-project-workspace-root-control.md`).
 - **Target select** — dropdown of available launch targets from `debug80.json`.
 - **Platform select** — dropdown with options Simple / TEC-1 / TEC-1G.
   - Changing this dropdown immediately posts a `saveProjectConfig` message to the extension.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #311 by recording an explicit product decision: keep the **Project** control as a **button + VS Code Quick Pick** (not an inline `<select>` like **Target**), with rationale tied to workspace lifecycle and implementation.

## Changes

- New **`docs/adr/0001-project-workspace-root-control.md`** — context (no workspace / single root / multi-root / folder changes / switching while debugging), **decision**, tradeoffs, optional follow-up, code references.
- **`docs/technical.md`** §14.3 — replace inaccurate “cycles or opens a picker” wording with behaviour that matches `project-root-button.ts` + `WorkspaceSelectionController`.

## Scope

Documentation only; no panel behaviour changes.

Closes #311
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54672c80-53a9-4c8f-8c17-2d2194fa7510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54672c80-53a9-4c8f-8c17-2d2194fa7510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

