### PR TITLE
Fix project selector visibility when platform changes

### DIFF
--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -596,14 +596,24 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   }
 
   private getProjectStatusPayload(): ProjectStatusPayload {
-    const roots = (vscode.workspace.workspaceFolders ?? []).map((folder) => ({
+    const workspaceFolders = vscode.workspace.workspaceFolders ?? [];
+    const roots = workspaceFolders.map((folder) => ({
       name: folder.name,
       path: folder.uri.fsPath,
       hasProject: findProjectConfigPath(folder) !== undefined,
     }));
-    const folder = this.selectedWorkspace;
+    const folder =
+      this.selectedWorkspace ??
+      (workspaceFolders.length === 1 ? workspaceFolders[0] : undefined);
     if (folder === undefined) {
-      return { roots, targets: [], projectState: 'noWorkspace' };
+      return {
+        roots,
+        targets: [],
+        projectState: roots.length === 0 ? 'noWorkspace' : 'uninitialized',
+        hasProject: false,
+        platform: this.currentPlatform ?? 'simple',
+        stopOnEntry: this.stopOnEntry,
+      };
     }
 
     const projectConfigPath = findProjectConfigPath(folder);

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -303,6 +303,50 @@ describe('PlatformViewProvider', () => {
     }
   });
 
+  it('keeps workspace roots discoverable when no workspace is selected', () => {
+    findProjectConfigPath.mockImplementation(() => undefined);
+    try {
+      const provider = new PlatformViewProvider(extensionRoot, {
+        get: vi.fn(),
+        update: vi.fn(),
+      } as never);
+      const webviewView = createWebviewView();
+
+      provider.resolveWebviewView(
+        webviewView,
+        {} as vscode.WebviewViewResolveContext,
+        {
+          isCancellationRequested: false,
+          onCancellationRequested: vi.fn(),
+        } as vscode.CancellationToken
+      );
+
+      workspaceFolders = [
+        { name: 'alpha', uri: { fsPath: '/workspace/alpha' } },
+        { name: 'beta', uri: { fsPath: '/workspace/beta' } },
+      ];
+      provider.setSelectedWorkspace(undefined);
+      provider.setPlatform('simple', undefined, { reveal: false, tab: 'ui' });
+
+      const statusMessages = findProjectStatusMessages(getPostMessageCalls(webviewView));
+      expect(statusMessages.at(-1)).toMatchObject({
+        projectState: 'uninitialized',
+        hasProject: false,
+        platform: 'simple',
+        targets: [],
+      });
+      expect(statusMessages.at(-1)).not.toHaveProperty('rootPath');
+      expect(statusMessages.at(-1)?.roots).toEqual([
+        { name: 'alpha', path: '/workspace/alpha', hasProject: false },
+        { name: 'beta', path: '/workspace/beta', hasProject: false },
+      ]);
+    } finally {
+      findProjectConfigPath.mockImplementation(
+        (folder: { uri: { fsPath: string } }) => `${folder.uri.fsPath}/debug80.json`
+      );
+    }
+  });
+
   it('updates stop-on-entry state without restarting the session', async () => {
     const provider = new PlatformViewProvider(extensionRoot, {
       get: vi.fn(),

--- a/tests/webview/common/setup-card-state.test.ts
+++ b/tests/webview/common/setup-card-state.test.ts
@@ -3,17 +3,25 @@ import { resolveSetupCardState } from '../../../webview/common/setup-card-state'
 
 describe('setup card state resolver', () => {
   it('returns open-folder action for missing workspace root', () => {
-    const state = resolveSetupCardState(undefined, 'noWorkspace', 0);
+    const state = resolveSetupCardState(undefined, 'noWorkspace', 0, 0);
     expect(state).not.toBeNull();
     expect(state?.primaryAction).toBe('openWorkspaceFolder');
     expect(state?.primaryLabel).toBe('Open Folder');
+  });
+
+  it('returns select-project action when workspace roots exist but none is selected', () => {
+    const state = resolveSetupCardState(undefined, 'uninitialized', 0, 2);
+    expect(state).not.toBeNull();
+    expect(state?.primaryAction).toBe('selectProject');
+    expect(state?.primaryLabel).toBe('Select Project');
   });
 
   it('returns initialize-project action for uninitialized root', () => {
     const state = resolveSetupCardState(
       { name: 'demo', path: '/workspace/demo', hasProject: false },
       'uninitialized',
-      0
+      0,
+      1
     );
     expect(state).not.toBeNull();
     expect(state?.primaryAction).toBe('createProject');
@@ -26,14 +34,16 @@ describe('setup card state resolver', () => {
       resolveSetupCardState(
         { name: 'demo', path: '/workspace/demo', hasProject: true },
         'initialized',
-        0
+        0,
+        1
       )
     ).toBeNull();
     expect(
       resolveSetupCardState(
         { name: 'demo', path: '/workspace/demo', hasProject: true },
         'initialized',
-        2
+        2,
+        1
       )
     ).toBeNull();
   });

--- a/webview/common/setup-card-state.ts
+++ b/webview/common/setup-card-state.ts
@@ -6,7 +6,7 @@ export type SetupRootOption = {
 
 export type SetupProjectState = 'noWorkspace' | 'uninitialized' | 'initialized';
 
-export type SetupPrimaryAction = 'openWorkspaceFolder' | 'createProject';
+export type SetupPrimaryAction = 'openWorkspaceFolder' | 'selectProject' | 'createProject';
 
 export type SetupCardState = {
   text: string;
@@ -21,13 +21,21 @@ export type SetupCardState = {
 export function resolveSetupCardState(
   selectedRoot: SetupRootOption | undefined,
   projectState: SetupProjectState,
-  targetCount: number
+  targetCount: number,
+  rootCount = selectedRoot ? 1 : 0
 ): SetupCardState | null {
-  if (projectState === 'noWorkspace' || selectedRoot === undefined) {
+  if (rootCount === 0 && projectState === 'noWorkspace') {
     return {
       text: 'No workspace folder is open. Open a folder to start with Debug80.',
       primaryLabel: 'Open Folder',
       primaryAction: 'openWorkspaceFolder',
+    };
+  }
+  if (selectedRoot === undefined) {
+    return {
+      text: 'Workspace folders are available. Select a workspace root to create or find a Debug80 project.',
+      primaryLabel: 'Select Project',
+      primaryAction: 'selectProject',
     };
   }
   if (projectState === 'uninitialized') {

--- a/webview/simple/index.ts
+++ b/webview/simple/index.ts
@@ -39,7 +39,8 @@ const terminalClearEl = document.getElementById('terminalClear') as HTMLElement 
 let activeTab: 'ui' | 'memory' = 'ui';
 let currentRootPath = '';
 let currentRoots: Array<{ name: string; path: string; hasProject: boolean }> = [];
-let setupPrimaryActionType: 'openWorkspaceFolder' | 'createProject' = 'openWorkspaceFolder';
+let setupPrimaryActionType: 'openWorkspaceFolder' | 'selectProject' | 'createProject' =
+  'openWorkspaceFolder';
 let memoryRowSize = 16;
 let resizeTimer: number | null = null;
 
@@ -55,6 +56,10 @@ setupPrimaryAction?.addEventListener('click', () => {
   const selected = currentRoots.find((r) => r.path === currentRootPath) ?? currentRoots[0];
   if (setupPrimaryActionType === 'openWorkspaceFolder') {
     vscode.postMessage({ type: 'openWorkspaceFolder' });
+    return;
+  }
+  if (setupPrimaryActionType === 'selectProject') {
+    vscode.postMessage({ type: 'selectProject' });
     return;
   }
   if (selected !== undefined) {
@@ -156,7 +161,12 @@ function applyProjectStatus(payload: {
   if (!setupCard || !setupCardText || !setupPrimaryAction) {
     return;
   }
-  const setupState = resolveSetupCardState(selected, projectState, targetCount);
+  const setupState = resolveSetupCardState(
+    selected,
+    payload.projectState ?? 'noWorkspace',
+    targetCount,
+    currentRoots.length
+  );
   if (setupState === null) {
     setupCard.hidden = true;
     return;

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -82,7 +82,8 @@ let uiRevision = 0;
 let shiftLatched = false;
 let currentRootPath = '';
 let currentRoots: Array<{ name: string; path: string; hasProject: boolean }> = [];
-let setupPrimaryActionType: 'openWorkspaceFolder' | 'createProject' = 'openWorkspaceFolder';
+let setupPrimaryActionType: 'openWorkspaceFolder' | 'selectProject' | 'createProject' =
+  'openWorkspaceFolder';
 
 const audio = createAudioController(muteEl);
 
@@ -99,6 +100,10 @@ setupPrimaryAction?.addEventListener('click', () => {
   const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
   if (setupPrimaryActionType === 'openWorkspaceFolder') {
     vscode.postMessage({ type: 'openWorkspaceFolder' });
+    return;
+  }
+  if (setupPrimaryActionType === 'selectProject') {
+    vscode.postMessage({ type: 'selectProject' });
     return;
   }
   if (selected !== undefined) {
@@ -190,7 +195,12 @@ function applyProjectStatus(payload: {
   if (!setupCard || !setupCardText || !setupPrimaryAction) {
     return;
   }
-  const setupState = resolveSetupCardState(selected, projectState, targetCount);
+  const setupState = resolveSetupCardState(
+    selected,
+    payload.projectState ?? 'noWorkspace',
+    targetCount,
+    currentRoots.length
+  );
   if (setupState === null) {
     setupCard.hidden = true;
     return;

--- a/webview/tec1g/tec1g-project-status-ui.ts
+++ b/webview/tec1g/tec1g-project-status-ui.ts
@@ -84,7 +84,8 @@ export function createTec1gProjectStatusUi(
 
   let currentRootPath = '';
   let currentRoots: Array<{ name: string; path: string; hasProject: boolean }> = [];
-  let setupPrimaryActionType: 'openWorkspaceFolder' | 'createProject' = 'openWorkspaceFolder';
+  let setupPrimaryActionType: 'openWorkspaceFolder' | 'selectProject' | 'createProject' =
+    'openWorkspaceFolder';
 
   const projectRootController = createProjectRootButtonController(vscode, selectProjectButton);
 
@@ -92,6 +93,10 @@ export function createTec1gProjectStatusUi(
     const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
     if (setupPrimaryActionType === 'openWorkspaceFolder') {
       vscode.postMessage({ type: 'openWorkspaceFolder' });
+      return;
+    }
+    if (setupPrimaryActionType === 'selectProject') {
+      vscode.postMessage({ type: 'selectProject' });
       return;
     }
     if (selected !== undefined) {
@@ -134,7 +139,12 @@ export function createTec1gProjectStatusUi(
       return;
     }
     const projectState = resolveProjectViewState(payload);
-    const setupState = resolveSetupCardState(selected, projectState, targetCount);
+    const setupState = resolveSetupCardState(
+      selected,
+      projectState,
+      targetCount,
+      currentRoots.length
+    );
     if (setupState === null) {
       setupCard.hidden = true;
       return;


### PR DESCRIPTION
## Summary
- keep project discovery available when workspace roots exist but no root is selected
- add a selector-specific setup-card state instead of showing the true empty workspace message
- fix Simple and TEC-1 setup-card updates to use the incoming project state during platform changes

## Testing
- npx vitest run tests/extension/platform-view-provider.test.ts
- npx vitest run -c vitest.webview.config.ts tests/webview/common/setup-card-state.test.ts tests/webview/common/project-root-button.test.ts tests/webview/common/project-controls.test.ts tests/webview/common/project-state.test.ts
- npm test