### PR TITLE
Hide runtime UI for uninitialized projects

### DIFF
--- a/tests/webview/common/project-controls.test.ts
+++ b/tests/webview/common/project-controls.test.ts
@@ -7,6 +7,7 @@ function createElement(): HTMLElement {
 
 describe('initialized project controls', () => {
   it('shows only initialized controls after project setup', () => {
+    const appRoot = createElement();
     const targetControl = createElement();
     const platformControl = createElement();
     const stopOnEntryLabel = createElement();
@@ -17,10 +18,12 @@ describe('initialized project controls', () => {
 
     const initialized = applyInitializedProjectControls(
       { projectState: 'initialized', rootPath: '/workspace/demo', hasProject: true },
-      { targetControl, platformControl, stopOnEntryLabel, restartButton, tabs, panelUi, panelMemory }
+      { appRoot, targetControl, platformControl, stopOnEntryLabel, restartButton, tabs, panelUi, panelMemory }
     );
 
     expect(initialized).toBe(true);
+    expect(document.body.dataset.projectViewState).toBe('initialized');
+    expect(appRoot.dataset.projectViewState).toBe('initialized');
     expect(targetControl.hidden).toBe(false);
     expect(platformControl.hidden).toBe(true);
     expect(stopOnEntryLabel.hidden).toBe(false);
@@ -31,20 +34,56 @@ describe('initialized project controls', () => {
   });
 
   it('keeps platform visible until the project is initialized', () => {
+    const appRoot = createElement();
     const targetControl = createElement();
     const platformControl = createElement();
     const stopOnEntryLabel = createElement();
     const restartButton = createElement();
+    const tabs = createElement();
+    const panelUi = createElement();
+    const panelMemory = createElement();
 
     const initialized = applyInitializedProjectControls(
       { projectState: 'uninitialized', rootPath: '/workspace/demo', hasProject: false },
-      { targetControl, platformControl, stopOnEntryLabel, restartButton }
+      { appRoot, targetControl, platformControl, stopOnEntryLabel, restartButton, tabs, panelUi, panelMemory }
     );
 
     expect(initialized).toBe(false);
+    expect(document.body.dataset.projectViewState).toBe('uninitialized');
+    expect(appRoot.dataset.projectViewState).toBe('uninitialized');
     expect(targetControl.hidden).toBe(true);
     expect(platformControl.hidden).toBe(false);
     expect(stopOnEntryLabel.hidden).toBe(true);
     expect(restartButton.hidden).toBe(true);
+    expect(tabs.hidden).toBe(true);
+    expect(panelUi.hidden).toBe(true);
+    expect(panelMemory.hidden).toBe(true);
+  });
+
+  it('defaults to setup-only chrome before project state arrives', () => {
+    const appRoot = createElement();
+    const targetControl = createElement();
+    const platformControl = createElement();
+    const stopOnEntryLabel = createElement();
+    const restartButton = createElement();
+    const tabs = createElement();
+    const panelUi = createElement();
+    const panelMemory = createElement();
+
+    const initialized = applyInitializedProjectControls(
+      {},
+      { appRoot, targetControl, platformControl, stopOnEntryLabel, restartButton, tabs, panelUi, panelMemory }
+    );
+
+    expect(initialized).toBe(false);
+    expect(document.body.dataset.projectViewState).toBe('noWorkspace');
+    expect(appRoot.dataset.projectViewState).toBe('noWorkspace');
+    expect(targetControl.hidden).toBe(true);
+    expect(platformControl.hidden).toBe(false);
+    expect(stopOnEntryLabel.hidden).toBe(true);
+    expect(restartButton.hidden).toBe(true);
+    expect(tabs.hidden).toBe(true);
+    expect(panelUi.hidden).toBe(true);
+    expect(panelMemory.hidden).toBe(true);
   });
 });

--- a/webview/common/project-controls.ts
+++ b/webview/common/project-controls.ts
@@ -2,6 +2,7 @@ import type { ProjectStatusPayload } from '../../src/contracts/platform-view';
 import { resolveProjectViewState } from './project-state';
 
 export type SharedProjectControlElements = {
+  appRoot?: HTMLElement | null;
   targetControl?: HTMLElement | null;
   platformControl?: HTMLElement | null;
   stopOnEntryLabel?: HTMLElement | null;
@@ -19,7 +20,11 @@ export function applyInitializedProjectControls(
   },
   elements: SharedProjectControlElements
 ): boolean {
-  const initialized = resolveProjectViewState(payload) === 'initialized';
+  const projectViewState = resolveProjectViewState(payload);
+  const initialized = projectViewState === 'initialized';
+
+  document.body?.setAttribute('data-project-view-state', projectViewState);
+  elements.appRoot?.setAttribute('data-project-view-state', projectViewState);
 
   elements.targetControl?.toggleAttribute('hidden', !initialized);
   elements.platformControl?.toggleAttribute('hidden', initialized);

--- a/webview/simple/index.ts
+++ b/webview/simple/index.ts
@@ -16,6 +16,7 @@ const TERMINAL_MAX = 8000;
 
 const vscode = acquireVscodeApi();
 
+const appRoot = document.getElementById('app') as HTMLElement | null;
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
@@ -144,6 +145,7 @@ function applyProjectStatus(payload: {
     platformSelectEl.value = payload.platform;
   }
   const initialized = applyInitializedProjectControls(payload, {
+    appRoot,
     targetControl,
     platformControl,
     stopOnEntryLabel,
@@ -176,6 +178,8 @@ function applyProjectStatus(payload: {
   setupCardText.textContent = setupState.text;
   setupPrimaryAction.textContent = setupState.primaryLabel;
 }
+
+applyProjectStatus({});
 
 function setTab(tab: 'ui' | 'memory'): void {
   activeTab = tab;

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -19,6 +19,7 @@ const DEFAULT_TAB: PanelTab =
     ? 'memory'
     : 'ui';
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
+const appRoot = document.getElementById('app') as HTMLElement | null;
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
 const setupPrimaryAction = document.getElementById('setupPrimaryAction') as HTMLButtonElement | null;
@@ -178,6 +179,7 @@ function applyProjectStatus(payload: {
   });
   setTargetOptions(payload.targets ?? [], payload.targetName);
   const initialized = applyInitializedProjectControls(payload, {
+    appRoot,
     targetControl,
     platformControl,
     stopOnEntryLabel,

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -29,6 +29,7 @@ const DEFAULT_TAB: Tec1gPanelTab =
     ? 'memory'
     : 'ui';
 
+const appRoot = document.getElementById('app') as HTMLElement | null;
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
@@ -95,6 +96,16 @@ const projectStatusUi = createTec1gProjectStatusUi(vscode, {
 });
 
 projectStatusUi.applyProjectStatus({});
+applyInitializedProjectControls({}, {
+  appRoot,
+  targetControl,
+  platformControl,
+  stopOnEntryLabel,
+  restartButton: restartDebugButton,
+  tabs: tabsEl,
+  panelUi,
+  panelMemory,
+});
 
 const audio = createTec1gAudio({ muteEl, speakerEl, speakerLabel });
 audio.wireMuteClick();
@@ -164,6 +175,7 @@ window.addEventListener('message', (event: MessageEvent<IncomingMessage | undefi
       platformSelectEl.value = message.platform;
     }
     const initialized = applyInitializedProjectControls(message, {
+      appRoot,
       targetControl,
       platformControl,
       stopOnEntryLabel,


### PR DESCRIPTION
## Summary
- keep shared project chrome in explicit setup-only mode until a project is initialized
- apply the shared setup-only gate on initial boot for the Simple and TEC-1G webviews to prevent runtime UI flash/leakage
- add regression coverage for uninitialized and pre-status project states hiding target/session/runtime controls

## Testing
- npx vitest run tests/extension/platform-view-provider.test.ts
- npx vitest run tests/webview/common/project-controls.test.ts -c vitest.webview.config.ts
- npm run test:webview
- npm run typecheck
- npm run build:webview