### PR TITLE
Make platform selection uninitialized-only in the shared panel

### DIFF
--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -34,7 +34,6 @@ import {
   findProjectConfigPath,
   readProjectConfig,
   resolveProjectPlatform,
-  writeProjectConfig,
 } from './project-config';
 import { handlePlatformViewMessage } from './platform-view-messages';
 import {
@@ -527,7 +526,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   // Private — config
   // -------------------------------------------------------------------------
 
-  /** Writes updated platform to the project config file and triggers a restart. */
+  /** Applies the shared platform selector only for uninitialized workspaces. */
   private handleSaveProjectConfig(platform: string): void {
     const folder = this.selectedWorkspace ?? vscode.workspace.workspaceFolders?.[0];
     if (folder === undefined) {
@@ -545,23 +544,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       void vscode.window.showErrorMessage('Debug80: No project config found in workspace.');
       return;
     }
-    const existing = readProjectConfig(configPath) ?? {};
-    // Update projectPlatform (sidebar display) AND the platform field inside
-    // every target so the restarted debug session picks up the new platform.
-    const existingTargets = existing.targets ?? {};
-    const updatedTargets = Object.fromEntries(
-      Object.entries(existingTargets).map(([name, target]) => [
-        name,
-        { ...(target as Record<string, unknown>), platform },
-      ])
-    ) as typeof existingTargets;
-    const updated = { ...existing, projectPlatform: platform, targets: updatedTargets };
-    const ok = writeProjectConfig(configPath, updated);
-    if (!ok) {
-      void vscode.window.showErrorMessage('Debug80: Failed to save project config.');
-      return;
-    }
-    void vscode.commands.executeCommand('debug80.restartDebug');
+    this.postProjectStatus();
   }
 
   private normalizePlatformId(platform: string): PlatformId | undefined {

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -10,6 +10,7 @@ const {
   resolveProjectStatusSummary,
   findProjectConfigPath,
   listProjectTargetChoices,
+  writeProjectConfig,
 } = vi.hoisted(() => {
   const executeCommand = vi.fn(() => Promise.resolve(true));
   return {
@@ -26,6 +27,7 @@ const {
       { name: 'app', description: 'src/main.asm', detail: 'src/main.asm' },
       { name: 'serial', description: 'src/serial.asm', detail: 'src/serial.asm' },
     ]),
+    writeProjectConfig: vi.fn(() => true),
   };
 });
 
@@ -67,7 +69,7 @@ vi.mock('../../src/extension/project-config', () => ({
   readProjectConfig: vi.fn(() => ({ projectPlatform: 'tec1g', targets: {} })),
   resolveProjectPlatform: vi.fn(() => 'tec1g'),
   resolveStopOnEntryForTarget: vi.fn(() => false),
-  writeProjectConfig: vi.fn(() => true),
+  writeProjectConfig,
 }));
 
 vi.mock('../../src/extension/project-target-selection', () => ({
@@ -345,6 +347,45 @@ describe('PlatformViewProvider', () => {
         (folder: { uri: { fsPath: string } }) => `${folder.uri.fsPath}/debug80.json`
       );
     }
+  });
+
+  it('ignores shared platform change messages once the project is initialized', async () => {
+    const provider = new PlatformViewProvider(extensionRoot, {
+      get: vi.fn(),
+      update: vi.fn(),
+    } as never);
+    const webviewView = createWebviewView();
+
+    provider.resolveWebviewView(
+      webviewView,
+      {} as vscode.WebviewViewResolveContext,
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      } as vscode.CancellationToken
+    );
+
+    workspaceFolders = [{ name: 'demo', uri: { fsPath: '/workspace/demo' } }];
+    provider.setSelectedWorkspace({ name: 'demo', uri: { fsPath: '/workspace/demo' } } as never);
+    provider.setPlatform('tec1g', undefined, { reveal: false, tab: 'ui' });
+
+    const handler = (webviewView.webview.onDidReceiveMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[0] as ((msg: { type?: string; platform?: string }) => Promise<void>) | undefined;
+    expect(handler).toBeTypeOf('function');
+
+    executeCommand.mockClear();
+    writeProjectConfig.mockClear();
+    (webviewView.webview.postMessage as ReturnType<typeof vi.fn>).mockClear();
+    await handler?.({ type: 'saveProjectConfig', platform: 'simple' });
+
+    expect(writeProjectConfig).not.toHaveBeenCalled();
+    expect(executeCommand).not.toHaveBeenCalledWith('debug80.restartDebug');
+
+    const statusMessages = findProjectStatusMessages(getPostMessageCalls(webviewView));
+    expect(statusMessages.at(-1)).toMatchObject({
+      projectState: 'initialized',
+      platform: 'tec1g',
+    });
   });
 
   it('updates stop-on-entry state without restarting the session', async () => {

--- a/tests/webview/common/project-controls.test.ts
+++ b/tests/webview/common/project-controls.test.ts
@@ -10,6 +10,8 @@ describe('initialized project controls', () => {
     const appRoot = createElement();
     const targetControl = createElement();
     const platformControl = createElement();
+    const platformInfoControl = createElement();
+    const platformValue = createElement();
     const stopOnEntryLabel = createElement();
     const restartButton = createElement();
     const tabs = createElement();
@@ -17,8 +19,19 @@ describe('initialized project controls', () => {
     const panelMemory = createElement();
 
     const initialized = applyInitializedProjectControls(
-      { projectState: 'initialized', rootPath: '/workspace/demo', hasProject: true },
-      { appRoot, targetControl, platformControl, stopOnEntryLabel, restartButton, tabs, panelUi, panelMemory }
+      { projectState: 'initialized', rootPath: '/workspace/demo', hasProject: true, platform: 'tec1g' },
+      {
+        appRoot,
+        targetControl,
+        platformControl,
+        platformInfoControl,
+        platformValue,
+        stopOnEntryLabel,
+        restartButton,
+        tabs,
+        panelUi,
+        panelMemory,
+      }
     );
 
     expect(initialized).toBe(true);
@@ -26,6 +39,8 @@ describe('initialized project controls', () => {
     expect(appRoot.dataset.projectViewState).toBe('initialized');
     expect(targetControl.hidden).toBe(false);
     expect(platformControl.hidden).toBe(true);
+    expect(platformInfoControl.hidden).toBe(false);
+    expect(platformValue.textContent).toBe('TEC-1G');
     expect(stopOnEntryLabel.hidden).toBe(false);
     expect(restartButton.hidden).toBe(false);
     expect(tabs.hidden).toBe(false);
@@ -37,6 +52,8 @@ describe('initialized project controls', () => {
     const appRoot = createElement();
     const targetControl = createElement();
     const platformControl = createElement();
+    const platformInfoControl = createElement();
+    const platformValue = createElement();
     const stopOnEntryLabel = createElement();
     const restartButton = createElement();
     const tabs = createElement();
@@ -45,7 +62,18 @@ describe('initialized project controls', () => {
 
     const initialized = applyInitializedProjectControls(
       { projectState: 'uninitialized', rootPath: '/workspace/demo', hasProject: false },
-      { appRoot, targetControl, platformControl, stopOnEntryLabel, restartButton, tabs, panelUi, panelMemory }
+      {
+        appRoot,
+        targetControl,
+        platformControl,
+        platformInfoControl,
+        platformValue,
+        stopOnEntryLabel,
+        restartButton,
+        tabs,
+        panelUi,
+        panelMemory,
+      }
     );
 
     expect(initialized).toBe(false);
@@ -53,6 +81,8 @@ describe('initialized project controls', () => {
     expect(appRoot.dataset.projectViewState).toBe('uninitialized');
     expect(targetControl.hidden).toBe(true);
     expect(platformControl.hidden).toBe(false);
+    expect(platformInfoControl.hidden).toBe(true);
+    expect(platformValue.textContent).toBe('');
     expect(stopOnEntryLabel.hidden).toBe(true);
     expect(restartButton.hidden).toBe(true);
     expect(tabs.hidden).toBe(true);
@@ -64,6 +94,8 @@ describe('initialized project controls', () => {
     const appRoot = createElement();
     const targetControl = createElement();
     const platformControl = createElement();
+    const platformInfoControl = createElement();
+    const platformValue = createElement();
     const stopOnEntryLabel = createElement();
     const restartButton = createElement();
     const tabs = createElement();
@@ -72,18 +104,45 @@ describe('initialized project controls', () => {
 
     const initialized = applyInitializedProjectControls(
       {},
-      { appRoot, targetControl, platformControl, stopOnEntryLabel, restartButton, tabs, panelUi, panelMemory }
+      {
+        appRoot,
+        targetControl,
+        platformControl,
+        platformInfoControl,
+        platformValue,
+        stopOnEntryLabel,
+        restartButton,
+        tabs,
+        panelUi,
+        panelMemory,
+      }
     );
 
     expect(initialized).toBe(false);
     expect(document.body.dataset.projectViewState).toBe('noWorkspace');
     expect(appRoot.dataset.projectViewState).toBe('noWorkspace');
     expect(targetControl.hidden).toBe(true);
-    expect(platformControl.hidden).toBe(false);
+    expect(platformControl.hidden).toBe(true);
+    expect(platformInfoControl.hidden).toBe(true);
+    expect(platformValue.textContent).toBe('');
     expect(stopOnEntryLabel.hidden).toBe(true);
     expect(restartButton.hidden).toBe(true);
     expect(tabs.hidden).toBe(true);
     expect(panelUi.hidden).toBe(true);
     expect(panelMemory.hidden).toBe(true);
+  });
+
+  it('hides platform controls when no workspace root is selected', () => {
+    const platformControl = createElement();
+    const platformInfoControl = createElement();
+
+    const initialized = applyInitializedProjectControls(
+      { projectState: 'noWorkspace' },
+      { platformControl, platformInfoControl }
+    );
+
+    expect(initialized).toBe(false);
+    expect(platformControl.hidden).toBe(true);
+    expect(platformInfoControl.hidden).toBe(true);
   });
 });

--- a/webview/common/project-controls.ts
+++ b/webview/common/project-controls.ts
@@ -5,6 +5,8 @@ export type SharedProjectControlElements = {
   appRoot?: HTMLElement | null;
   targetControl?: HTMLElement | null;
   platformControl?: HTMLElement | null;
+  platformInfoControl?: HTMLElement | null;
+  platformValue?: HTMLElement | null;
   stopOnEntryLabel?: HTMLElement | null;
   restartButton?: HTMLElement | null;
   tabs?: HTMLElement | null;
@@ -12,22 +14,44 @@ export type SharedProjectControlElements = {
   panelMemory?: HTMLElement | null;
 };
 
+function formatPlatformLabel(platform?: string): string {
+  const normalized = platform?.trim().toLowerCase();
+  if (normalized === 'simple') {
+    return 'Simple';
+  }
+  if (normalized === 'tec1') {
+    return 'TEC-1';
+  }
+  if (normalized === 'tec1g') {
+    return 'TEC-1G';
+  }
+  return platform && platform.length > 0 ? platform : 'Unknown';
+}
+
 export function applyInitializedProjectControls(
   payload: {
     projectState?: ProjectStatusPayload['projectState'];
     rootPath?: ProjectStatusPayload['rootPath'];
     hasProject?: ProjectStatusPayload['hasProject'];
+    platform?: ProjectStatusPayload['platform'];
   },
   elements: SharedProjectControlElements
 ): boolean {
   const projectViewState = resolveProjectViewState(payload);
   const initialized = projectViewState === 'initialized';
+  const uninitialized = projectViewState === 'uninitialized';
 
   document.body?.setAttribute('data-project-view-state', projectViewState);
   elements.appRoot?.setAttribute('data-project-view-state', projectViewState);
 
   elements.targetControl?.toggleAttribute('hidden', !initialized);
-  elements.platformControl?.toggleAttribute('hidden', initialized);
+  elements.platformControl?.toggleAttribute('hidden', !uninitialized);
+  elements.platformInfoControl?.toggleAttribute('hidden', !initialized);
+  if (elements.platformValue) {
+    elements.platformValue.textContent = initialized
+      ? formatPlatformLabel(payload.platform)
+      : '';
+  }
   elements.stopOnEntryLabel?.toggleAttribute('hidden', !initialized);
   elements.restartButton?.toggleAttribute('hidden', !initialized);
   elements.tabs?.toggleAttribute('hidden', !initialized);

--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -108,6 +108,19 @@ body {
       padding: 4px 6px;
       font-size: 11px;
     }
+    .project-value {
+      flex: 1;
+      min-width: 0;
+      border: 1px solid #333;
+      border-radius: 6px;
+      background: #141414;
+      color: #cfcfcf;
+      padding: 4px 8px;
+      font-size: 11px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
     .layout {
       display: grid;
       gap: 16px;

--- a/webview/simple/index.html
+++ b/webview/simple/index.html
@@ -26,6 +26,10 @@
         <option value="tec1g">TEC-1G</option>
       </select>
     </div>
+    <div class="project-control" id="platformInfoControl" hidden>
+      <span class="project-label">Platform</span>
+      <span class="project-value" id="platformValue"></span>
+    </div>
   </div>
   <div class="setup-card" id="setupCard">
     <div class="setup-card-text" id="setupCardText">Select a workspace root to get started.</div>

--- a/webview/simple/index.ts
+++ b/webview/simple/index.ts
@@ -27,6 +27,8 @@ const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSele
 const platformSelectEl = document.getElementById('platformSelect') as HTMLSelectElement | null;
 const targetControl = homeTargetSelect?.closest('.project-control') as HTMLElement | null;
 const platformControl = platformSelectEl?.closest('.project-control') as HTMLElement | null;
+const platformInfoControl = document.getElementById('platformInfoControl') as HTMLElement | null;
+const platformValueEl = document.getElementById('platformValue') as HTMLElement | null;
 const tabsEl = document.querySelector('.tabs') as HTMLElement | null;
 const stopOnEntryLabel = stopOnEntryInput?.closest('.stop-on-entry-label') as HTMLElement | null;
 const panelUi = document.getElementById('panel-ui') as HTMLElement;
@@ -148,6 +150,8 @@ function applyProjectStatus(payload: {
     appRoot,
     targetControl,
     platformControl,
+    platformInfoControl,
+    platformValue: platformValueEl,
     stopOnEntryLabel,
     restartButton: restartDebugButton,
     tabs: tabsEl,

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -26,6 +26,10 @@
           <option value="tec1g">TEC-1G</option>
         </select>
       </div>
+      <div class="project-control" id="platformInfoControl" hidden>
+        <span class="project-label">Platform</span>
+        <span class="project-value" id="platformValue"></span>
+      </div>
     </div>
     <div class="setup-card" id="setupCard">
       <div class="setup-card-text" id="setupCardText">Select a workspace root to get started.</div>

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -38,6 +38,8 @@ const panelUi = document.getElementById('panel-ui') as HTMLElement;
 const panelMemory = document.getElementById('panel-memory') as HTMLElement;
 const platformSelectEl = document.getElementById('platformSelect') as HTMLSelectElement | null;
 const platformControl = platformSelectEl?.closest('.project-control') as HTMLElement | null;
+const platformInfoControl = document.getElementById('platformInfoControl') as HTMLElement | null;
+const platformValueEl = document.getElementById('platformValue') as HTMLElement | null;
 const registerStrip = document.getElementById('registerStrip') as HTMLElement;
 const memoryPanel = document.getElementById('memoryPanel') as HTMLElement;
 const tabsEl = document.querySelector('.tabs') as HTMLElement | null;
@@ -167,6 +169,7 @@ function applyProjectStatus(payload: {
   targets?: ProjectStatusPayload['targets'];
   targetName?: ProjectStatusPayload['targetName'];
   projectState?: ProjectStatusPayload['projectState'];
+  platform?: ProjectStatusPayload['platform'];
   hasProject?: ProjectStatusPayload['hasProject'];
   stopOnEntry?: ProjectStatusPayload['stopOnEntry'];
 }): void {
@@ -178,10 +181,15 @@ function applyProjectStatus(payload: {
     targetCount: payload.targets?.length ?? 0,
   });
   setTargetOptions(payload.targets ?? [], payload.targetName);
+  if (platformSelectEl && payload.platform !== undefined) {
+    platformSelectEl.value = payload.platform;
+  }
   const initialized = applyInitializedProjectControls(payload, {
     appRoot,
     targetControl,
     platformControl,
+    platformInfoControl,
+    platformValue: platformValueEl,
     stopOnEntryLabel,
     restartButton: restartDebugButton,
     tabs: tabsEl,

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -26,6 +26,10 @@
           <option value="tec1g">TEC-1G</option>
         </select>
       </div>
+      <div class="project-control" id="platformInfoControl" hidden>
+        <span class="project-label">Platform</span>
+        <span class="project-value" id="platformValue"></span>
+      </div>
     </div>
     <div class="setup-card" id="setupCard">
       <div class="setup-card-text" id="setupCardText">Select a workspace root to get started.</div>

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -53,6 +53,8 @@ const panelMemory = document.getElementById('panel-memory') as HTMLElement;
 const platformSelectEl = document.getElementById('platformSelect') as HTMLSelectElement | null;
 const targetControl = homeTargetSelect?.closest('.project-control') as HTMLElement | null;
 const platformControl = platformSelectEl?.closest('.project-control') as HTMLElement | null;
+const platformInfoControl = document.getElementById('platformInfoControl') as HTMLElement | null;
+const platformValueEl = document.getElementById('platformValue') as HTMLElement | null;
 const tabsEl = document.querySelector('.tabs') as HTMLElement | null;
 const stopOnEntryLabel = stopOnEntryInput?.closest('.stop-on-entry-label') as HTMLElement | null;
 const registerStrip = document.getElementById('registerStrip') as HTMLElement;
@@ -178,6 +180,8 @@ window.addEventListener('message', (event: MessageEvent<IncomingMessage | undefi
       appRoot,
       targetControl,
       platformControl,
+      platformInfoControl,
+      platformValue: platformValueEl,
       stopOnEntryLabel,
       restartButton: restartDebugButton,
       tabs: tabsEl,


### PR DESCRIPTION
## Summary
- limit the shared platform selector to uninitialized projects and hide it when no workspace is selected
- show the resolved platform as read-only project information after initialization instead of an active selector
- ignore shared-panel platform-change messages once a project is initialized, with regression coverage for both provider and webview control behavior

## Testing
- npx vitest run tests/extension/platform-view-provider.test.ts
- npm run test:webview -- tests/webview/common/project-controls.test.ts
- npm run typecheck
- npm run build:webview

Closes #317