### PR TITLE
Fix duplicate platform controls in Debug80 panel

### DIFF
--- a/tests/webview/common/project-controls.test.ts
+++ b/tests/webview/common/project-controls.test.ts
@@ -145,4 +145,54 @@ describe('initialized project controls', () => {
     expect(platformControl.hidden).toBe(true);
     expect(platformInfoControl.hidden).toBe(true);
   });
+
+  it('forces platform controls back to a single visible branch on first render', () => {
+    const platformControl = createElement();
+    const platformInfoControl = createElement();
+
+    platformControl.hidden = false;
+    platformInfoControl.hidden = false;
+
+    const initialized = applyInitializedProjectControls(
+      {},
+      { platformControl, platformInfoControl }
+    );
+
+    expect(initialized).toBe(false);
+    expect(platformControl.hidden).toBe(true);
+    expect(platformInfoControl.hidden).toBe(true);
+  });
+
+  it('switches cleanly between uninitialized and initialized platform states', () => {
+    const platformControl = createElement();
+    const platformInfoControl = createElement();
+    const platformValue = createElement();
+
+    applyInitializedProjectControls(
+      { projectState: 'uninitialized', rootPath: '/workspace/demo', hasProject: false, platform: 'tec1' },
+      { platformControl, platformInfoControl, platformValue }
+    );
+
+    expect(platformControl.hidden).toBe(false);
+    expect(platformInfoControl.hidden).toBe(true);
+    expect(platformValue.textContent).toBe('');
+
+    applyInitializedProjectControls(
+      { projectState: 'initialized', rootPath: '/workspace/demo', hasProject: true, platform: 'tec1g' },
+      { platformControl, platformInfoControl, platformValue }
+    );
+
+    expect(platformControl.hidden).toBe(true);
+    expect(platformInfoControl.hidden).toBe(false);
+    expect(platformValue.textContent).toBe('TEC-1G');
+
+    applyInitializedProjectControls(
+      { projectState: 'uninitialized', rootPath: '/workspace/demo', hasProject: false, platform: 'simple' },
+      { platformControl, platformInfoControl, platformValue }
+    );
+
+    expect(platformControl.hidden).toBe(false);
+    expect(platformInfoControl.hidden).toBe(true);
+    expect(platformValue.textContent).toBe('');
+  });
 });

--- a/webview/common/project-controls.ts
+++ b/webview/common/project-controls.ts
@@ -45,8 +45,14 @@ export function applyInitializedProjectControls(
   elements.appRoot?.setAttribute('data-project-view-state', projectViewState);
 
   elements.targetControl?.toggleAttribute('hidden', !initialized);
-  elements.platformControl?.toggleAttribute('hidden', !uninitialized);
-  elements.platformInfoControl?.toggleAttribute('hidden', !initialized);
+  // Force the platform controls through a single exclusive path on every update.
+  elements.platformControl?.setAttribute('hidden', '');
+  elements.platformInfoControl?.setAttribute('hidden', '');
+  if (uninitialized) {
+    elements.platformControl?.removeAttribute('hidden');
+  } else if (initialized) {
+    elements.platformInfoControl?.removeAttribute('hidden');
+  }
   if (elements.platformValue) {
     elements.platformValue.textContent = initialized
       ? formatPlatformLabel(payload.platform)

--- a/webview/simple/index.html
+++ b/webview/simple/index.html
@@ -18,7 +18,7 @@
       <span class="project-label">Target</span>
       <select class="project-select" id="homeTargetSelect"></select>
     </div>
-    <div class="project-control">
+    <div class="project-control" hidden>
       <span class="project-label">Platform</span>
       <select class="project-select" id="platformSelect">
         <option value="simple">Simple</option>

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -18,7 +18,7 @@
         <span class="project-label">Target</span>
         <select class="project-select" id="homeTargetSelect"></select>
       </div>
-      <div class="project-control">
+      <div class="project-control" hidden>
         <span class="project-label">Platform</span>
         <select class="project-select" id="platformSelect">
           <option value="simple">Simple</option>

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -18,7 +18,7 @@
         <span class="project-label">Target</span>
         <select class="project-select" id="homeTargetSelect"></select>
       </div>
-      <div class="project-control">
+      <div class="project-control" hidden>
         <span class="project-label">Platform</span>
         <select class="project-select" id="platformSelect">
           <option value="simple">Simple</option>

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -102,6 +102,8 @@ applyInitializedProjectControls({}, {
   appRoot,
   targetControl,
   platformControl,
+  platformInfoControl,
+  platformValue: platformValueEl,
   stopOnEntryLabel,
   restartButton: restartDebugButton,
   tabs: tabsEl,


### PR DESCRIPTION
Closes #330

## Summary
- hide the editable platform control by default in all platform templates until project state is known
- make shared project-control rendering enforce a single visible platform branch on every update
- add regression coverage for first render, no-workspace, initialized, uninitialized, and init/uninit transitions

## Verification
- ./node_modules/.bin/vitest run -c vitest.webview.config.ts tests/webview/common/project-controls.test.ts
- ./node_modules/.bin/vitest run -c vitest.webview.config.ts