### PR TITLE
Fix uninitialized project chrome state

### DIFF
--- a/tests/webview/common/project-controls.test.ts
+++ b/tests/webview/common/project-controls.test.ts
@@ -9,7 +9,10 @@ describe('initialized project controls', () => {
   it('shows only initialized controls after project setup', () => {
     const appRoot = createElement();
     const targetControl = createElement();
+    const targetSelect = document.createElement('select');
+    targetSelect.value = 'app';
     const platformControl = createElement();
+    const platformSelect = document.createElement('select');
     const platformInfoControl = createElement();
     const platformValue = createElement();
     const stopOnEntryLabel = createElement();
@@ -23,7 +26,9 @@ describe('initialized project controls', () => {
       {
         appRoot,
         targetControl,
+        targetSelect,
         platformControl,
+        platformSelect,
         platformInfoControl,
         platformValue,
         stopOnEntryLabel,
@@ -38,7 +43,9 @@ describe('initialized project controls', () => {
     expect(document.body.dataset.projectViewState).toBe('initialized');
     expect(appRoot.dataset.projectViewState).toBe('initialized');
     expect(targetControl.hidden).toBe(false);
+    expect(targetSelect.disabled).toBe(false);
     expect(platformControl.hidden).toBe(true);
+    expect(platformSelect.disabled).toBe(true);
     expect(platformInfoControl.hidden).toBe(false);
     expect(platformValue.textContent).toBe('TEC-1G');
     expect(stopOnEntryLabel.hidden).toBe(false);
@@ -51,7 +58,10 @@ describe('initialized project controls', () => {
   it('keeps platform visible until the project is initialized', () => {
     const appRoot = createElement();
     const targetControl = createElement();
+    const targetSelect = document.createElement('select');
+    targetSelect.value = 'app';
     const platformControl = createElement();
+    const platformSelect = document.createElement('select');
     const platformInfoControl = createElement();
     const platformValue = createElement();
     const stopOnEntryLabel = createElement();
@@ -65,7 +75,9 @@ describe('initialized project controls', () => {
       {
         appRoot,
         targetControl,
+        targetSelect,
         platformControl,
+        platformSelect,
         platformInfoControl,
         platformValue,
         stopOnEntryLabel,
@@ -80,7 +92,10 @@ describe('initialized project controls', () => {
     expect(document.body.dataset.projectViewState).toBe('uninitialized');
     expect(appRoot.dataset.projectViewState).toBe('uninitialized');
     expect(targetControl.hidden).toBe(true);
+    expect(targetSelect.disabled).toBe(true);
+    expect(targetSelect.value).toBe('');
     expect(platformControl.hidden).toBe(false);
+    expect(platformSelect.disabled).toBe(false);
     expect(platformInfoControl.hidden).toBe(true);
     expect(platformValue.textContent).toBe('');
     expect(stopOnEntryLabel.hidden).toBe(true);
@@ -93,7 +108,10 @@ describe('initialized project controls', () => {
   it('defaults to setup-only chrome before project state arrives', () => {
     const appRoot = createElement();
     const targetControl = createElement();
+    const targetSelect = document.createElement('select');
+    targetSelect.value = 'stale-target';
     const platformControl = createElement();
+    const platformSelect = document.createElement('select');
     const platformInfoControl = createElement();
     const platformValue = createElement();
     const stopOnEntryLabel = createElement();
@@ -107,7 +125,9 @@ describe('initialized project controls', () => {
       {
         appRoot,
         targetControl,
+        targetSelect,
         platformControl,
+        platformSelect,
         platformInfoControl,
         platformValue,
         stopOnEntryLabel,
@@ -122,7 +142,10 @@ describe('initialized project controls', () => {
     expect(document.body.dataset.projectViewState).toBe('noWorkspace');
     expect(appRoot.dataset.projectViewState).toBe('noWorkspace');
     expect(targetControl.hidden).toBe(true);
+    expect(targetSelect.disabled).toBe(true);
+    expect(targetSelect.value).toBe('');
     expect(platformControl.hidden).toBe(true);
+    expect(platformSelect.disabled).toBe(true);
     expect(platformInfoControl.hidden).toBe(true);
     expect(platformValue.textContent).toBe('');
     expect(stopOnEntryLabel.hidden).toBe(true);
@@ -134,15 +157,17 @@ describe('initialized project controls', () => {
 
   it('hides platform controls when no workspace root is selected', () => {
     const platformControl = createElement();
+    const platformSelect = document.createElement('select');
     const platformInfoControl = createElement();
 
     const initialized = applyInitializedProjectControls(
       { projectState: 'noWorkspace' },
-      { platformControl, platformInfoControl }
+      { platformControl, platformSelect, platformInfoControl }
     );
 
     expect(initialized).toBe(false);
     expect(platformControl.hidden).toBe(true);
+    expect(platformSelect.disabled).toBe(true);
     expect(platformInfoControl.hidden).toBe(true);
   });
 
@@ -194,5 +219,72 @@ describe('initialized project controls', () => {
     expect(platformControl.hidden).toBe(false);
     expect(platformInfoControl.hidden).toBe(true);
     expect(platformValue.textContent).toBe('');
+  });
+
+  it('clears stale runtime controls when switching from initialized to uninitialized', () => {
+    const appRoot = createElement();
+    const targetControl = createElement();
+    const targetSelect = document.createElement('select');
+    targetSelect.value = 'matrix';
+    const platformControl = createElement();
+    const platformSelect = document.createElement('select');
+    const platformInfoControl = createElement();
+    const platformValue = createElement();
+    const stopOnEntryLabel = createElement();
+    const restartButton = createElement();
+    const tabs = createElement();
+    const panelUi = createElement();
+    const panelMemory = createElement();
+
+    applyInitializedProjectControls(
+      { projectState: 'initialized', rootPath: '/workspace/demo', hasProject: true, platform: 'tec1g' },
+      {
+        appRoot,
+        targetControl,
+        targetSelect,
+        platformControl,
+        platformSelect,
+        platformInfoControl,
+        platformValue,
+        stopOnEntryLabel,
+        restartButton,
+        tabs,
+        panelUi,
+        panelMemory,
+      }
+    );
+
+    const initialized = applyInitializedProjectControls(
+      { projectState: 'uninitialized', rootPath: '/workspace/demo', hasProject: false, platform: 'tec1g' },
+      {
+        appRoot,
+        targetControl,
+        targetSelect,
+        platformControl,
+        platformSelect,
+        platformInfoControl,
+        platformValue,
+        stopOnEntryLabel,
+        restartButton,
+        tabs,
+        panelUi,
+        panelMemory,
+      }
+    );
+
+    expect(initialized).toBe(false);
+    expect(document.body.dataset.projectViewState).toBe('uninitialized');
+    expect(targetControl.hidden).toBe(true);
+    expect(targetSelect.disabled).toBe(true);
+    expect(targetSelect.value).toBe('');
+    expect(platformControl.hidden).toBe(false);
+    expect(platformSelect.disabled).toBe(false);
+    expect(platformInfoControl.hidden).toBe(true);
+    expect(platformValue.textContent).toBe('');
+    expect(stopOnEntryLabel.hidden).toBe(true);
+    expect(restartButton.hidden).toBe(true);
+    expect(tabs.hidden).toBe(true);
+    expect(panelUi.hidden).toBe(true);
+    expect(panelMemory.hidden).toBe(true);
   });
 });

--- a/webview/common/project-controls.ts
+++ b/webview/common/project-controls.ts
@@ -4,7 +4,9 @@ import { resolveProjectViewState } from './project-state';
 export type SharedProjectControlElements = {
   appRoot?: HTMLElement | null;
   targetControl?: HTMLElement | null;
+  targetSelect?: HTMLSelectElement | null;
   platformControl?: HTMLElement | null;
+  platformSelect?: HTMLSelectElement | null;
   platformInfoControl?: HTMLElement | null;
   platformValue?: HTMLElement | null;
   stopOnEntryLabel?: HTMLElement | null;
@@ -44,25 +46,53 @@ export function applyInitializedProjectControls(
   document.body?.setAttribute('data-project-view-state', projectViewState);
   elements.appRoot?.setAttribute('data-project-view-state', projectViewState);
 
-  elements.targetControl?.toggleAttribute('hidden', !initialized);
+  if (elements.targetControl) {
+    elements.targetControl.hidden = !initialized;
+  }
+  if (elements.targetSelect) {
+    elements.targetSelect.disabled = !initialized;
+    if (!initialized) {
+      elements.targetSelect.value = '';
+    }
+  }
+  if (elements.platformControl) {
+    elements.platformControl.hidden = !uninitialized;
+  }
+  if (elements.platformSelect) {
+    elements.platformSelect.disabled = !uninitialized;
+  }
   // Force the platform controls through a single exclusive path on every update.
-  elements.platformControl?.setAttribute('hidden', '');
-  elements.platformInfoControl?.setAttribute('hidden', '');
-  if (uninitialized) {
-    elements.platformControl?.removeAttribute('hidden');
-  } else if (initialized) {
-    elements.platformInfoControl?.removeAttribute('hidden');
+  if (elements.platformControl) {
+    elements.platformControl.hidden = true;
+  }
+  if (elements.platformInfoControl) {
+    elements.platformInfoControl.hidden = true;
+  }
+  if (uninitialized && elements.platformControl) {
+    elements.platformControl.hidden = false;
+  } else if (initialized && elements.platformInfoControl) {
+    elements.platformInfoControl.hidden = false;
   }
   if (elements.platformValue) {
     elements.platformValue.textContent = initialized
       ? formatPlatformLabel(payload.platform)
       : '';
   }
-  elements.stopOnEntryLabel?.toggleAttribute('hidden', !initialized);
-  elements.restartButton?.toggleAttribute('hidden', !initialized);
-  elements.tabs?.toggleAttribute('hidden', !initialized);
-  elements.panelUi?.toggleAttribute('hidden', !initialized);
-  elements.panelMemory?.toggleAttribute('hidden', !initialized);
+  if (elements.stopOnEntryLabel) {
+    elements.stopOnEntryLabel.hidden = !initialized;
+  }
+  if (elements.restartButton) {
+    elements.restartButton.hidden = !initialized;
+  }
+  if (elements.tabs) {
+    elements.tabs.hidden = !initialized;
+  }
+  if (elements.panelUi) {
+    elements.panelUi.hidden = !initialized;
+  }
+  if (elements.panelMemory) {
+    elements.panelMemory.hidden = !initialized;
+  }
 
   return initialized;
 }

--- a/webview/simple/index.ts
+++ b/webview/simple/index.ts
@@ -135,6 +135,8 @@ function applyProjectStatus(payload: {
   hasProject?: ProjectStatusPayload['hasProject'];
   stopOnEntry?: ProjectStatusPayload['stopOnEntry'];
 }): void {
+  const projectState = payload.projectState ?? 'noWorkspace';
+  const initializedProject = projectState === 'initialized';
   currentRootPath = payload.rootPath ?? '';
   currentRoots = payload.roots ?? [];
   projectRootController.applyProjectStatus({
@@ -142,14 +144,16 @@ function applyProjectStatus(payload: {
     roots: payload.roots ?? [],
     targetCount: payload.targets?.length ?? 0,
   });
-  setTargetOptions(payload.targets ?? [], payload.targetName);
+  setTargetOptions(initializedProject ? (payload.targets ?? []) : [], payload.targetName);
   if (platformSelectEl && payload.platform !== undefined) {
     platformSelectEl.value = payload.platform;
   }
   const initialized = applyInitializedProjectControls(payload, {
     appRoot,
     targetControl,
+    targetSelect: homeTargetSelect,
     platformControl,
+    platformSelect: platformSelectEl,
     platformInfoControl,
     platformValue: platformValueEl,
     stopOnEntryLabel,
@@ -169,7 +173,7 @@ function applyProjectStatus(payload: {
   }
   const setupState = resolveSetupCardState(
     selected,
-    payload.projectState ?? 'noWorkspace',
+    projectState,
     targetCount,
     currentRoots.length
   );

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -173,6 +173,8 @@ function applyProjectStatus(payload: {
   hasProject?: ProjectStatusPayload['hasProject'];
   stopOnEntry?: ProjectStatusPayload['stopOnEntry'];
 }): void {
+  const projectState = payload.projectState ?? 'noWorkspace';
+  const initializedProject = projectState === 'initialized';
   currentRootPath = payload.rootPath ?? '';
   currentRoots = payload.roots ?? [];
   projectRootController.applyProjectStatus({
@@ -180,14 +182,16 @@ function applyProjectStatus(payload: {
     roots: payload.roots ?? [],
     targetCount: payload.targets?.length ?? 0,
   });
-  setTargetOptions(payload.targets ?? [], payload.targetName);
+  setTargetOptions(initializedProject ? (payload.targets ?? []) : [], payload.targetName);
   if (platformSelectEl && payload.platform !== undefined) {
     platformSelectEl.value = payload.platform;
   }
   const initialized = applyInitializedProjectControls(payload, {
     appRoot,
     targetControl,
+    targetSelect: homeTargetSelect,
     platformControl,
+    platformSelect: platformSelectEl,
     platformInfoControl,
     platformValue: platformValueEl,
     stopOnEntryLabel,
@@ -207,7 +211,7 @@ function applyProjectStatus(payload: {
   }
   const setupState = resolveSetupCardState(
     selected,
-    payload.projectState ?? 'noWorkspace',
+    projectState,
     targetCount,
     currentRoots.length
   );

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -101,7 +101,11 @@ projectStatusUi.applyProjectStatus({});
 applyInitializedProjectControls({}, {
   appRoot,
   targetControl,
+  targetSelect: homeTargetSelect,
   platformControl,
+  platformInfoControl,
+  platformValue: platformValueEl,
+  platformSelect: platformSelectEl,
   platformInfoControl,
   platformValue: platformValueEl,
   stopOnEntryLabel,
@@ -181,7 +185,9 @@ window.addEventListener('message', (event: MessageEvent<IncomingMessage | undefi
     const initialized = applyInitializedProjectControls(message, {
       appRoot,
       targetControl,
+      targetSelect: homeTargetSelect,
       platformControl,
+      platformSelect: platformSelectEl,
       platformInfoControl,
       platformValue: platformValueEl,
       stopOnEntryLabel,

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -106,8 +106,6 @@ applyInitializedProjectControls({}, {
   platformInfoControl,
   platformValue: platformValueEl,
   platformSelect: platformSelectEl,
-  platformInfoControl,
-  platformValue: platformValueEl,
   stopOnEntryLabel,
   restartButton: restartDebugButton,
   tabs: tabsEl,

--- a/webview/tec1g/tec1g-project-status-ui.ts
+++ b/webview/tec1g/tec1g-project-status-ui.ts
@@ -123,6 +123,8 @@ export function createTec1gProjectStatusUi(
     targetName?: ProjectStatusPayload['targetName'];
     projectState?: ProjectStatusPayload['projectState'];
   }): void {
+    const projectState = resolveProjectViewState(payload);
+    const initializedProject = projectState === 'initialized';
     currentRootPath = payload.rootPath ?? '';
     currentRoots = payload.roots ?? [];
     projectRootController.applyProjectStatus({
@@ -131,14 +133,17 @@ export function createTec1gProjectStatusUi(
       targetCount: payload.targets?.length ?? 0,
     });
     if (homeTargetSelect) {
-      setTargetOptions(homeTargetSelect, payload.targets ?? [], payload.targetName);
+      setTargetOptions(
+        homeTargetSelect,
+        initializedProject ? (payload.targets ?? []) : [],
+        payload.targetName
+      );
     }
     const selected = currentRoots.find((root) => root.path === currentRootPath) ?? currentRoots[0];
     const targetCount = payload.targets?.length ?? 0;
     if (!setupCard || !setupCardText || !setupPrimaryAction) {
       return;
     }
-    const projectState = resolveProjectViewState(payload);
     const setupState = resolveSetupCardState(
       selected,
       projectState,


### PR DESCRIPTION
Closes #331.

## What changed
- actively clear and disable runtime-only controls when the selected project is not initialized
- gate target option population so uninitialized/no-workspace states never keep stale target choices around
- cover initialized -> uninitialized transitions in the shared webview control tests

## Validation
- `./node_modules/.bin/vitest run tests/extension/platform-view-provider.test.ts`
- `./node_modules/.bin/vitest run -c vitest.webview.config.ts tests/webview/common/project-controls.test.ts`
- `./node_modules/.bin/eslint webview/common/project-controls.ts webview/tec1g/index.ts webview/tec1/index.ts webview/simple/index.ts webview/tec1g/tec1g-project-status-ui.ts tests/webview/common/project-controls.test.ts`
