### PR TITLE
Simplify Debug80 panel lifecycle states

### DIFF
--- a/tests/webview/common/project-controls.test.ts
+++ b/tests/webview/common/project-controls.test.ts
@@ -8,6 +8,7 @@ function createElement(): HTMLElement {
 describe('initialized project controls', () => {
   it('shows only initialized controls after project setup', () => {
     const appRoot = createElement();
+    const projectHeader = createElement();
     const targetControl = createElement();
     const targetSelect = document.createElement('select');
     targetSelect.value = 'app';
@@ -25,6 +26,7 @@ describe('initialized project controls', () => {
       { projectState: 'initialized', rootPath: '/workspace/demo', hasProject: true, platform: 'tec1g' },
       {
         appRoot,
+        projectHeader,
         targetControl,
         targetSelect,
         platformControl,
@@ -42,6 +44,7 @@ describe('initialized project controls', () => {
     expect(initialized).toBe(true);
     expect(document.body.dataset.projectViewState).toBe('initialized');
     expect(appRoot.dataset.projectViewState).toBe('initialized');
+    expect(projectHeader.hidden).toBe(false);
     expect(targetControl.hidden).toBe(false);
     expect(targetSelect.disabled).toBe(false);
     expect(platformControl.hidden).toBe(true);
@@ -57,6 +60,7 @@ describe('initialized project controls', () => {
 
   it('keeps platform visible until the project is initialized', () => {
     const appRoot = createElement();
+    const projectHeader = createElement();
     const targetControl = createElement();
     const targetSelect = document.createElement('select');
     targetSelect.value = 'app';
@@ -74,6 +78,7 @@ describe('initialized project controls', () => {
       { projectState: 'uninitialized', rootPath: '/workspace/demo', hasProject: false },
       {
         appRoot,
+        projectHeader,
         targetControl,
         targetSelect,
         platformControl,
@@ -91,6 +96,7 @@ describe('initialized project controls', () => {
     expect(initialized).toBe(false);
     expect(document.body.dataset.projectViewState).toBe('uninitialized');
     expect(appRoot.dataset.projectViewState).toBe('uninitialized');
+    expect(projectHeader.hidden).toBe(false);
     expect(targetControl.hidden).toBe(true);
     expect(targetSelect.disabled).toBe(true);
     expect(targetSelect.value).toBe('');
@@ -107,6 +113,7 @@ describe('initialized project controls', () => {
 
   it('defaults to setup-only chrome before project state arrives', () => {
     const appRoot = createElement();
+    const projectHeader = createElement();
     const targetControl = createElement();
     const targetSelect = document.createElement('select');
     targetSelect.value = 'stale-target';
@@ -124,6 +131,7 @@ describe('initialized project controls', () => {
       {},
       {
         appRoot,
+        projectHeader,
         targetControl,
         targetSelect,
         platformControl,
@@ -141,6 +149,7 @@ describe('initialized project controls', () => {
     expect(initialized).toBe(false);
     expect(document.body.dataset.projectViewState).toBe('noWorkspace');
     expect(appRoot.dataset.projectViewState).toBe('noWorkspace');
+    expect(projectHeader.hidden).toBe(true);
     expect(targetControl.hidden).toBe(true);
     expect(targetSelect.disabled).toBe(true);
     expect(targetSelect.value).toBe('');
@@ -156,22 +165,25 @@ describe('initialized project controls', () => {
   });
 
   it('hides platform controls when no workspace root is selected', () => {
+    const projectHeader = createElement();
     const platformControl = createElement();
     const platformSelect = document.createElement('select');
     const platformInfoControl = createElement();
 
     const initialized = applyInitializedProjectControls(
       { projectState: 'noWorkspace' },
-      { platformControl, platformSelect, platformInfoControl }
+      { projectHeader, platformControl, platformSelect, platformInfoControl }
     );
 
     expect(initialized).toBe(false);
+    expect(projectHeader.hidden).toBe(true);
     expect(platformControl.hidden).toBe(true);
     expect(platformSelect.disabled).toBe(true);
     expect(platformInfoControl.hidden).toBe(true);
   });
 
   it('forces platform controls back to a single visible branch on first render', () => {
+    const projectHeader = createElement();
     const platformControl = createElement();
     const platformInfoControl = createElement();
 
@@ -180,42 +192,47 @@ describe('initialized project controls', () => {
 
     const initialized = applyInitializedProjectControls(
       {},
-      { platformControl, platformInfoControl }
+      { projectHeader, platformControl, platformInfoControl }
     );
 
     expect(initialized).toBe(false);
+    expect(projectHeader.hidden).toBe(true);
     expect(platformControl.hidden).toBe(true);
     expect(platformInfoControl.hidden).toBe(true);
   });
 
   it('switches cleanly between uninitialized and initialized platform states', () => {
+    const projectHeader = createElement();
     const platformControl = createElement();
     const platformInfoControl = createElement();
     const platformValue = createElement();
 
     applyInitializedProjectControls(
       { projectState: 'uninitialized', rootPath: '/workspace/demo', hasProject: false, platform: 'tec1' },
-      { platformControl, platformInfoControl, platformValue }
+      { projectHeader, platformControl, platformInfoControl, platformValue }
     );
 
+    expect(projectHeader.hidden).toBe(false);
     expect(platformControl.hidden).toBe(false);
     expect(platformInfoControl.hidden).toBe(true);
     expect(platformValue.textContent).toBe('');
 
     applyInitializedProjectControls(
       { projectState: 'initialized', rootPath: '/workspace/demo', hasProject: true, platform: 'tec1g' },
-      { platformControl, platformInfoControl, platformValue }
+      { projectHeader, platformControl, platformInfoControl, platformValue }
     );
 
+    expect(projectHeader.hidden).toBe(false);
     expect(platformControl.hidden).toBe(true);
     expect(platformInfoControl.hidden).toBe(false);
     expect(platformValue.textContent).toBe('TEC-1G');
 
     applyInitializedProjectControls(
       { projectState: 'uninitialized', rootPath: '/workspace/demo', hasProject: false, platform: 'simple' },
-      { platformControl, platformInfoControl, platformValue }
+      { projectHeader, platformControl, platformInfoControl, platformValue }
     );
 
+    expect(projectHeader.hidden).toBe(false);
     expect(platformControl.hidden).toBe(false);
     expect(platformInfoControl.hidden).toBe(true);
     expect(platformValue.textContent).toBe('');
@@ -223,6 +240,7 @@ describe('initialized project controls', () => {
 
   it('clears stale runtime controls when switching from initialized to uninitialized', () => {
     const appRoot = createElement();
+    const projectHeader = createElement();
     const targetControl = createElement();
     const targetSelect = document.createElement('select');
     targetSelect.value = 'matrix';
@@ -240,6 +258,7 @@ describe('initialized project controls', () => {
       { projectState: 'initialized', rootPath: '/workspace/demo', hasProject: true, platform: 'tec1g' },
       {
         appRoot,
+        projectHeader,
         targetControl,
         targetSelect,
         platformControl,
@@ -258,6 +277,7 @@ describe('initialized project controls', () => {
       { projectState: 'uninitialized', rootPath: '/workspace/demo', hasProject: false, platform: 'tec1g' },
       {
         appRoot,
+        projectHeader,
         targetControl,
         targetSelect,
         platformControl,
@@ -274,6 +294,7 @@ describe('initialized project controls', () => {
 
     expect(initialized).toBe(false);
     expect(document.body.dataset.projectViewState).toBe('uninitialized');
+    expect(projectHeader.hidden).toBe(false);
     expect(targetControl.hidden).toBe(true);
     expect(targetSelect.disabled).toBe(true);
     expect(targetSelect.value).toBe('');
@@ -281,6 +302,72 @@ describe('initialized project controls', () => {
     expect(platformSelect.disabled).toBe(false);
     expect(platformInfoControl.hidden).toBe(true);
     expect(platformValue.textContent).toBe('');
+    expect(stopOnEntryLabel.hidden).toBe(true);
+    expect(restartButton.hidden).toBe(true);
+    expect(tabs.hidden).toBe(true);
+    expect(panelUi.hidden).toBe(true);
+    expect(panelMemory.hidden).toBe(true);
+  });
+
+  it('collapses to empty-state only when switching back to no workspace', () => {
+    const appRoot = createElement();
+    const projectHeader = createElement();
+    const targetControl = createElement();
+    const targetSelect = document.createElement('select');
+    const platformControl = createElement();
+    const platformSelect = document.createElement('select');
+    const platformInfoControl = createElement();
+    const platformValue = createElement();
+    const stopOnEntryLabel = createElement();
+    const restartButton = createElement();
+    const tabs = createElement();
+    const panelUi = createElement();
+    const panelMemory = createElement();
+
+    applyInitializedProjectControls(
+      { projectState: 'initialized', rootPath: '/workspace/demo', hasProject: true, platform: 'tec1g' },
+      {
+        appRoot,
+        projectHeader,
+        targetControl,
+        targetSelect,
+        platformControl,
+        platformSelect,
+        platformInfoControl,
+        platformValue,
+        stopOnEntryLabel,
+        restartButton,
+        tabs,
+        panelUi,
+        panelMemory,
+      }
+    );
+
+    const initialized = applyInitializedProjectControls(
+      { projectState: 'noWorkspace' },
+      {
+        appRoot,
+        projectHeader,
+        targetControl,
+        targetSelect,
+        platformControl,
+        platformSelect,
+        platformInfoControl,
+        platformValue,
+        stopOnEntryLabel,
+        restartButton,
+        tabs,
+        panelUi,
+        panelMemory,
+      }
+    );
+
+    expect(initialized).toBe(false);
+    expect(document.body.dataset.projectViewState).toBe('noWorkspace');
+    expect(projectHeader.hidden).toBe(true);
+    expect(targetControl.hidden).toBe(true);
+    expect(platformControl.hidden).toBe(true);
+    expect(platformInfoControl.hidden).toBe(true);
     expect(stopOnEntryLabel.hidden).toBe(true);
     expect(restartButton.hidden).toBe(true);
     expect(tabs.hidden).toBe(true);

--- a/tests/webview/common/setup-card-state.test.ts
+++ b/tests/webview/common/setup-card-state.test.ts
@@ -7,6 +7,7 @@ describe('setup card state resolver', () => {
     expect(state).not.toBeNull();
     expect(state?.primaryAction).toBe('openWorkspaceFolder');
     expect(state?.primaryLabel).toBe('Open Folder');
+    expect(state?.text).toBe('Add projects or folders to the workspace to start with Debug80.');
   });
 
   it('returns select-project action when workspace roots exist but none is selected', () => {

--- a/webview/common/project-controls.ts
+++ b/webview/common/project-controls.ts
@@ -3,6 +3,7 @@ import { resolveProjectViewState } from './project-state';
 
 export type SharedProjectControlElements = {
   appRoot?: HTMLElement | null;
+  projectHeader?: HTMLElement | null;
   targetControl?: HTMLElement | null;
   targetSelect?: HTMLSelectElement | null;
   platformControl?: HTMLElement | null;
@@ -40,11 +41,17 @@ export function applyInitializedProjectControls(
   elements: SharedProjectControlElements
 ): boolean {
   const projectViewState = resolveProjectViewState(payload);
+  const noWorkspace = projectViewState === 'noWorkspace';
   const initialized = projectViewState === 'initialized';
   const uninitialized = projectViewState === 'uninitialized';
 
   document.body?.setAttribute('data-project-view-state', projectViewState);
   elements.appRoot?.setAttribute('data-project-view-state', projectViewState);
+  if (elements.projectHeader) {
+    // Keep the "no workspace" panel to a single empty-state card. Header controls only
+    // appear once there is a workspace root to select or an actual project to run.
+    elements.projectHeader.hidden = noWorkspace;
+  }
 
   if (elements.targetControl) {
     elements.targetControl.hidden = !initialized;

--- a/webview/common/setup-card-state.ts
+++ b/webview/common/setup-card-state.ts
@@ -26,7 +26,7 @@ export function resolveSetupCardState(
 ): SetupCardState | null {
   if (rootCount === 0 && projectState === 'noWorkspace') {
     return {
-      text: 'No workspace folder is open. Open a folder to start with Debug80.',
+      text: 'Add projects or folders to the workspace to start with Debug80.',
       primaryLabel: 'Open Folder',
       primaryAction: 'openWorkspaceFolder',
     };

--- a/webview/simple/index.ts
+++ b/webview/simple/index.ts
@@ -5,6 +5,7 @@
 import { appendSerialText } from '../common/serial';
 import { MemoryPanel } from '../common/memory-panel';
 import { applyInitializedProjectControls } from '../common/project-controls';
+import { resolveProjectViewState } from '../common/project-state';
 import { createSessionStatusController } from '../common/session-status';
 import { wireStopOnEntryControl } from '../common/stop-on-entry-control';
 import { createProjectRootButtonController } from '../common/project-root-button';
@@ -17,6 +18,7 @@ const TERMINAL_MAX = 8000;
 const vscode = acquireVscodeApi();
 
 const appRoot = document.getElementById('app') as HTMLElement | null;
+const projectHeader = document.getElementById('projectHeader') as HTMLElement | null;
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
@@ -135,7 +137,7 @@ function applyProjectStatus(payload: {
   hasProject?: ProjectStatusPayload['hasProject'];
   stopOnEntry?: ProjectStatusPayload['stopOnEntry'];
 }): void {
-  const projectState = payload.projectState ?? 'noWorkspace';
+  const projectState = resolveProjectViewState(payload);
   const initializedProject = projectState === 'initialized';
   currentRootPath = payload.rootPath ?? '';
   currentRoots = payload.roots ?? [];
@@ -150,6 +152,7 @@ function applyProjectStatus(payload: {
   }
   const initialized = applyInitializedProjectControls(payload, {
     appRoot,
+    projectHeader,
     targetControl,
     targetSelect: homeTargetSelect,
     platformControl,

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -1,5 +1,6 @@
 import { createDigit } from '../common/digits';
 import { applyInitializedProjectControls } from '../common/project-controls';
+import { resolveProjectViewState } from '../common/project-state';
 import { MemoryPanel } from '../common/memory-panel';
 import { createSessionStatusController } from '../common/session-status';
 import { wireStopOnEntryControl } from '../common/stop-on-entry-control';
@@ -20,6 +21,7 @@ const DEFAULT_TAB: PanelTab =
     : 'ui';
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
 const appRoot = document.getElementById('app') as HTMLElement | null;
+const projectHeader = document.getElementById('projectHeader') as HTMLElement | null;
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
 const setupPrimaryAction = document.getElementById('setupPrimaryAction') as HTMLButtonElement | null;
@@ -173,7 +175,7 @@ function applyProjectStatus(payload: {
   hasProject?: ProjectStatusPayload['hasProject'];
   stopOnEntry?: ProjectStatusPayload['stopOnEntry'];
 }): void {
-  const projectState = payload.projectState ?? 'noWorkspace';
+  const projectState = resolveProjectViewState(payload);
   const initializedProject = projectState === 'initialized';
   currentRootPath = payload.rootPath ?? '';
   currentRoots = payload.roots ?? [];
@@ -188,6 +190,7 @@ function applyProjectStatus(payload: {
   }
   const initialized = applyInitializedProjectControls(payload, {
     appRoot,
+    projectHeader,
     targetControl,
     targetSelect: homeTargetSelect,
     platformControl,

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -30,6 +30,7 @@ const DEFAULT_TAB: Tec1gPanelTab =
     : 'ui';
 
 const appRoot = document.getElementById('app') as HTMLElement | null;
+const projectHeader = document.getElementById('projectHeader') as HTMLElement | null;
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
@@ -100,6 +101,7 @@ const projectStatusUi = createTec1gProjectStatusUi(vscode, {
 projectStatusUi.applyProjectStatus({});
 applyInitializedProjectControls({}, {
   appRoot,
+  projectHeader,
   targetControl,
   targetSelect: homeTargetSelect,
   platformControl,
@@ -182,6 +184,7 @@ window.addEventListener('message', (event: MessageEvent<IncomingMessage | undefi
     }
     const initialized = applyInitializedProjectControls(message, {
       appRoot,
+      projectHeader,
       targetControl,
       targetSelect: homeTargetSelect,
       platformControl,


### PR DESCRIPTION
Closes #332

## Summary
- make the panel header disappear entirely in the no-workspace state so the empty-state card is the only visible chrome
- normalize all platform entrypoints onto the shared project view-state resolver so setup-card and control visibility cannot disagree during transitions
- extend the lifecycle regression tests to cover the three-state contract and stale-control cleanup when switching states

## Verification
- ./node_modules/.bin/vitest run -c vitest.webview.config.ts tests/webview/common/project-controls.test.ts tests/webview/common/setup-card-state.test.ts
- ./node_modules/.bin/vitest run -c vitest.webview.config.ts
- ./node_modules/.bin/eslint webview/common/project-controls.ts webview/common/setup-card-state.ts webview/simple/index.ts webview/tec1/index.ts webview/tec1g/index.ts tests/webview/common/project-controls.test.ts tests/webview/common/setup-card-state.test.ts