### PR TITLE
Fix platform UI state bugs: saveProjectConfig guard + duplicate Platform display

### DIFF
--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -23,6 +23,9 @@ body {
       min-width: 0;
       flex: 1;
     }
+    .project-control[hidden] {
+      display: none;
+    }
     .project-control.actions {
       flex: 0 0 auto;
       align-items: stretch;

--- a/webview/simple/index.ts
+++ b/webview/simple/index.ts
@@ -43,6 +43,7 @@ const terminalClearEl = document.getElementById('terminalClear') as HTMLElement 
 
 let activeTab: 'ui' | 'memory' = 'ui';
 let currentRootPath = '';
+let projectIsInitialized = false;
 let currentRoots: Array<{ name: string; path: string; hasProject: boolean }> = [];
 let setupPrimaryActionType: 'openWorkspaceFolder' | 'selectProject' | 'createProject' =
   'openWorkspaceFolder';
@@ -54,7 +55,9 @@ const stopOnEntryControl = wireStopOnEntryControl(vscode, stopOnEntryInput);
 const projectRootController = createProjectRootButtonController(vscode, selectProjectButton);
 
 platformSelectEl?.addEventListener('change', () => {
-  vscode.postMessage({ type: 'saveProjectConfig', platform: platformSelectEl.value });
+  if (projectIsInitialized) {
+    vscode.postMessage({ type: 'saveProjectConfig', platform: platformSelectEl.value });
+  }
 });
 
 setupPrimaryAction?.addEventListener('click', () => {
@@ -165,6 +168,7 @@ function applyProjectStatus(payload: {
     panelUi,
     panelMemory,
   });
+  projectIsInitialized = initialized;
   stopOnEntryControl.applyProjectStatus({
     hasProject: initialized,
     stopOnEntry: payload.stopOnEntry,

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -84,6 +84,7 @@ const hexOrder = [
 
 let speedMode = 'fast';
 let uiRevision = 0;
+let projectIsInitialized = false;
 let shiftLatched = false;
 let currentRootPath = '';
 let currentRoots: Array<{ name: string; path: string; hasProject: boolean }> = [];
@@ -93,7 +94,9 @@ let setupPrimaryActionType: 'openWorkspaceFolder' | 'selectProject' | 'createPro
 const audio = createAudioController(muteEl);
 
 platformSelectEl?.addEventListener('change', () => {
-  vscode.postMessage({ type: 'saveProjectConfig', platform: platformSelectEl.value });
+  if (projectIsInitialized) {
+    vscode.postMessage({ type: 'saveProjectConfig', platform: platformSelectEl.value });
+  }
 });
 const lcdRenderer = createLcdRenderer();
 const matrixRenderer = createMatrixRenderer();
@@ -203,6 +206,7 @@ function applyProjectStatus(payload: {
     panelUi,
     panelMemory,
   });
+  projectIsInitialized = initialized;
   stopOnEntryControl.applyProjectStatus({
     hasProject: initialized,
     stopOnEntry: payload.stopOnEntry,

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -99,7 +99,7 @@ const projectStatusUi = createTec1gProjectStatusUi(vscode, {
 });
 
 projectStatusUi.applyProjectStatus({});
-applyInitializedProjectControls({}, {
+projectIsInitialized = applyInitializedProjectControls({}, {
   appRoot,
   projectHeader,
   targetControl,
@@ -119,10 +119,13 @@ const audio = createTec1gAudio({ muteEl, speakerEl, speakerLabel });
 audio.wireMuteClick();
 
 platformSelectEl?.addEventListener('change', () => {
-  vscode.postMessage({ type: 'saveProjectConfig', platform: platformSelectEl.value });
+  if (projectIsInitialized) {
+    vscode.postMessage({ type: 'saveProjectConfig', platform: platformSelectEl.value });
+  }
 });
 
 let speedMode: Tec1gSpeedMode = 'fast';
+let projectIsInitialized = false;
 function applySpeed(mode: Tec1gSpeedMode): void {
   speedMode = mode;
   speedEl.textContent = mode.toUpperCase();
@@ -197,6 +200,7 @@ window.addEventListener('message', (event: MessageEvent<IncomingMessage | undefi
       panelUi,
       panelMemory,
     });
+    projectIsInitialized = initialized;
     stopOnEntryControl.applyProjectStatus({
       hasProject: initialized,
       stopOnEntry: message.stopOnEntry,


### PR DESCRIPTION
## Summary

- **Guard `saveProjectConfig` when uninitialized**: The `platformSelectEl` change handler in all three platform panels (`tec1`, `tec1g`, `simple`) was firing `saveProjectConfig` unconditionally. When uninitialized, there is no config file to save to, so the extension would call `renderCurrentView(true)` and switch webview bundles — confusing the project/platform state machine. The fix tracks `projectIsInitialized` in each panel (updated on every `projectStatus` message) and skips the postMessage when `false`.
- **Fix duplicate Platform row**: `.project-control` has `display: flex` in the stylesheet, which overrides the UA `[hidden]` → `display: none` rule. The codebase already applied this fix for `.project-action-button[hidden]` and `.setup-card[hidden]`; added `.project-control[hidden]` to the same pattern so both the platform select row and platform info row respect `hidden` correctly.

## Test plan

- [ ] Open extension with no workspace: only setup card visible, no emulator UI
- [ ] Open workspace with no debug80.json (uninitialized): platform select visible, changing it does NOT trigger a webview reload or error toast
- [ ] Initialize project via panel: single Platform row visible (read-only text, not select)
- [ ] Switch between projects (TEC-1G → TEC-1): no unexpected state jumps or "Open Folder" regression
- [ ] Verify initialized project shows target select, stop-on-entry, restart, and panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)