### PR TITLE
Hide platform controls entirely when project is initialized

### DIFF
--- a/webview/common/project-controls.ts
+++ b/webview/common/project-controls.ts
@@ -17,19 +17,6 @@ export type SharedProjectControlElements = {
   panelMemory?: HTMLElement | null;
 };
 
-function formatPlatformLabel(platform?: string): string {
-  const normalized = platform?.trim().toLowerCase();
-  if (normalized === 'simple') {
-    return 'Simple';
-  }
-  if (normalized === 'tec1') {
-    return 'TEC-1';
-  }
-  if (normalized === 'tec1g') {
-    return 'TEC-1G';
-  }
-  return platform && platform.length > 0 ? platform : 'Unknown';
-}
 
 export function applyInitializedProjectControls(
   payload: {
@@ -62,28 +49,19 @@ export function applyInitializedProjectControls(
       elements.targetSelect.value = '';
     }
   }
+  // Platform selector: visible only when uninitialized (choosing platform before first init).
+  // platformInfoControl (read-only label) is never shown — platform is implicit once initialized.
   if (elements.platformControl) {
     elements.platformControl.hidden = !uninitialized;
   }
   if (elements.platformSelect) {
     elements.platformSelect.disabled = !uninitialized;
   }
-  // Force the platform controls through a single exclusive path on every update.
-  if (elements.platformControl) {
-    elements.platformControl.hidden = true;
-  }
   if (elements.platformInfoControl) {
     elements.platformInfoControl.hidden = true;
   }
-  if (uninitialized && elements.platformControl) {
-    elements.platformControl.hidden = false;
-  } else if (initialized && elements.platformInfoControl) {
-    elements.platformInfoControl.hidden = false;
-  }
   if (elements.platformValue) {
-    elements.platformValue.textContent = initialized
-      ? formatPlatformLabel(payload.platform)
-      : '';
+    elements.platformValue.textContent = '';
   }
   if (elements.stopOnEntryLabel) {
     elements.stopOnEntryLabel.hidden = !initialized;


### PR DESCRIPTION
## Summary

- Platform selection is only needed before first initialization (choosing which platform to scaffold). Once a project exists the platform is fixed by `debug80.json` and can't be changed from the panel.
- Both `platformControl` (the select row) and `platformInfoControl` (the read-only label row) are now hidden when `initialized`. Previously `platformInfoControl` was shown as a read-only display; that row is removed entirely.
- Removes the now-unused `formatPlatformLabel` helper.

## Test plan

- [ ] No workspace / uninitialized: platform selector row visible, changeable
- [ ] Initialized project: no Platform row of any kind in the header
- [ ] Switching projects: Platform row stays hidden throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)