### PR TITLE
Move Stop on Entry checkbox into project header row

### DIFF
--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -344,6 +344,9 @@ body {
       flex-shrink: 0;
       margin-left: auto;
     }
+    .stop-on-entry-label[hidden] {
+      display: none;
+    }
     .stop-on-entry-label {
       display: flex;
       align-items: center;

--- a/webview/simple/index.html
+++ b/webview/simple/index.html
@@ -30,6 +30,14 @@
       <span class="project-label">Platform</span>
       <span class="project-value" id="platformValue"></span>
     </div>
+    <label
+      class="stop-on-entry-label"
+      hidden
+      title="Pause at the program entry point when starting or restarting debugging. Kept in the Debug80 panel for this VS Code window session only; not written to debug80.json."
+    >
+      <input type="checkbox" id="stopOnEntry" />
+      Stop on entry
+    </label>
   </div>
   <div class="setup-card" id="setupCard">
     <div class="setup-card-text" id="setupCardText">Select a workspace root to get started.</div>
@@ -43,13 +51,6 @@
       <button class="tab" data-tab="memory">CPU</button>
     </div>
     <div class="tabs-status-slot">
-      <label
-        class="stop-on-entry-label"
-        title="Pause at the program entry point when starting or restarting debugging. Kept in the Debug80 panel for this VS Code window session only; not written to debug80.json."
-      >
-        <input type="checkbox" id="stopOnEntry" />
-        Stop on entry
-      </label>
       <button
         class="session-status"
         id="restartDebug"

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -30,6 +30,14 @@
         <span class="project-label">Platform</span>
         <span class="project-value" id="platformValue"></span>
       </div>
+      <label
+        class="stop-on-entry-label"
+        hidden
+        title="Pause at the program entry point when starting or restarting debugging. Kept in the Debug80 panel for this VS Code window session only; not written to debug80.json."
+      >
+        <input type="checkbox" id="stopOnEntry" />
+        Stop on entry
+      </label>
     </div>
     <div class="setup-card" id="setupCard">
       <div class="setup-card-text" id="setupCardText">Select a workspace root to get started.</div>
@@ -43,13 +51,6 @@
         <button class="tab" data-tab="memory">CPU</button>
       </div>
       <div class="tabs-status-slot">
-        <label
-          class="stop-on-entry-label"
-          title="Pause at the program entry point when starting or restarting debugging. Kept in the Debug80 panel for this VS Code window session only; not written to debug80.json."
-        >
-          <input type="checkbox" id="stopOnEntry" />
-          Stop on entry
-        </label>
         <button
           class="session-status"
           id="restartDebug"

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -30,6 +30,14 @@
         <span class="project-label">Platform</span>
         <span class="project-value" id="platformValue"></span>
       </div>
+      <label
+        class="stop-on-entry-label"
+        hidden
+        title="Pause at the program entry point when starting or restarting debugging. Kept in the Debug80 panel for this VS Code window session only; not written to debug80.json."
+      >
+        <input type="checkbox" id="stopOnEntry" />
+        Stop on entry
+      </label>
     </div>
     <div class="setup-card" id="setupCard">
       <div class="setup-card-text" id="setupCardText">Select a workspace root to get started.</div>
@@ -43,13 +51,6 @@
         <button class="tab" data-tab="memory">CPU</button>
       </div>
       <div class="tabs-status-slot">
-        <label
-          class="stop-on-entry-label"
-          title="Pause at the program entry point when starting or restarting debugging. Kept in the Debug80 panel for this VS Code window session only; not written to debug80.json."
-        >
-          <input type="checkbox" id="stopOnEntry" />
-          Stop on entry
-        </label>
         <button
           class="session-status"
           id="restartDebug"


### PR DESCRIPTION
## Summary

- Relocates the `stop-on-entry` label from the tabs status slot (next to the Restart button) into the project header, where it sits alongside the Project and Target selectors.
- It starts with `hidden` on the element and only appears for initialized projects — the existing `applyInitializedProjectControls` visibility logic is untouched.
- Adds `.stop-on-entry-label[hidden] { display: none }` to `common/styles.css` so the `hidden` attribute is respected against the element's `display: flex` (same pattern used for `.project-control[hidden]`, `.project-action-button[hidden]`, and `.setup-card[hidden]`).
- The Restart button stays in the tabs status slot.
- Change applied identically to all three platform panels: `tec1`, `tec1g`, `simple`.

## Test plan

- [ ] Uninitialized project: Stop on entry is not visible in the header
- [ ] Initialized project: Stop on entry appears in the header row alongside Project / Target
- [ ] Restart button remains in the tabs bar
- [ ] Checkbox still functions correctly (sets stop-on-entry for next session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)