### PR TITLE
Add persistent + button to project header for adding workspace folders

### DIFF
--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -56,6 +56,22 @@ body {
       cursor: default;
       color: #7a7a7a;
     }
+    .add-workspace-button {
+      flex: 0 0 auto;
+      border: 1px solid #444;
+      border-radius: 4px;
+      background: transparent;
+      color: #9a9a9a;
+      padding: 1px 7px;
+      font-size: 16px;
+      line-height: 1.2;
+      cursor: pointer;
+    }
+    .add-workspace-button:hover {
+      background: #2a2a2a;
+      color: #f0f0f0;
+      border-color: #666;
+    }
     .project-action-button {
       flex: 0 0 auto;
       min-width: 0;

--- a/webview/simple/index.html
+++ b/webview/simple/index.html
@@ -13,6 +13,7 @@
     <div class="project-control">
       <span class="project-label">Project</span>
       <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
+      <button class="add-workspace-button" id="addWorkspaceFolder" type="button" title="Add folder to workspace">+</button>
     </div>
     <div class="project-control">
       <span class="project-label">Target</span>

--- a/webview/simple/index.ts
+++ b/webview/simple/index.ts
@@ -20,6 +20,7 @@ const vscode = acquireVscodeApi();
 const appRoot = document.getElementById('app') as HTMLElement | null;
 const projectHeader = document.getElementById('projectHeader') as HTMLElement | null;
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
+const addWorkspaceFolderButton = document.getElementById('addWorkspaceFolder') as HTMLButtonElement | null;
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
 const setupPrimaryAction = document.getElementById('setupPrimaryAction') as HTMLButtonElement | null;
@@ -53,6 +54,10 @@ let resizeTimer: number | null = null;
 const sessionStatusController = createSessionStatusController(vscode, restartDebugButton);
 const stopOnEntryControl = wireStopOnEntryControl(vscode, stopOnEntryInput);
 const projectRootController = createProjectRootButtonController(vscode, selectProjectButton);
+
+addWorkspaceFolderButton?.addEventListener('click', () => {
+  vscode.postMessage({ type: 'openWorkspaceFolder' });
+});
 
 platformSelectEl?.addEventListener('change', () => {
   if (projectIsInitialized) {

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -13,6 +13,7 @@
       <div class="project-control">
         <span class="project-label">Project</span>
         <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
+        <button class="add-workspace-button" id="addWorkspaceFolder" type="button" title="Add folder to workspace">+</button>
       </div>
       <div class="project-control">
         <span class="project-label">Target</span>

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -20,6 +20,7 @@ const DEFAULT_TAB: PanelTab =
     ? 'memory'
     : 'ui';
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
+const addWorkspaceFolderButton = document.getElementById('addWorkspaceFolder') as HTMLButtonElement | null;
 const appRoot = document.getElementById('app') as HTMLElement | null;
 const projectHeader = document.getElementById('projectHeader') as HTMLElement | null;
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
@@ -92,6 +93,10 @@ let setupPrimaryActionType: 'openWorkspaceFolder' | 'selectProject' | 'createPro
   'openWorkspaceFolder';
 
 const audio = createAudioController(muteEl);
+
+addWorkspaceFolderButton?.addEventListener('click', () => {
+  vscode.postMessage({ type: 'openWorkspaceFolder' });
+});
 
 platformSelectEl?.addEventListener('change', () => {
   if (projectIsInitialized) {

--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -13,6 +13,7 @@
       <div class="project-control">
         <span class="project-label">Project</span>
         <button class="project-root-button" id="selectProject" type="button">No workspace roots available</button>
+        <button class="add-workspace-button" id="addWorkspaceFolder" type="button" title="Add folder to workspace">+</button>
       </div>
       <div class="project-control">
         <span class="project-label">Target</span>

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -32,6 +32,7 @@ const DEFAULT_TAB: Tec1gPanelTab =
 const appRoot = document.getElementById('app') as HTMLElement | null;
 const projectHeader = document.getElementById('projectHeader') as HTMLElement | null;
 const selectProjectButton = document.getElementById('selectProject') as HTMLButtonElement | null;
+const addWorkspaceFolderButton = document.getElementById('addWorkspaceFolder') as HTMLButtonElement | null;
 const setupCard = document.getElementById('setupCard') as HTMLElement | null;
 const setupCardText = document.getElementById('setupCardText') as HTMLElement | null;
 const setupPrimaryAction = document.getElementById('setupPrimaryAction') as HTMLButtonElement | null;
@@ -117,6 +118,10 @@ projectIsInitialized = applyInitializedProjectControls({}, {
 
 const audio = createTec1gAudio({ muteEl, speakerEl, speakerLabel });
 audio.wireMuteClick();
+
+addWorkspaceFolderButton?.addEventListener('click', () => {
+  vscode.postMessage({ type: 'openWorkspaceFolder' });
+});
 
 platformSelectEl?.addEventListener('change', () => {
   if (projectIsInitialized) {


### PR DESCRIPTION
## Summary

- Adds a small `+` button to the right of the Project selector in the project header on all three platform panels (`tec1`, `tec1g`, `simple`).
- Clicking it fires `{ type: 'openWorkspaceFolder' }` — the same message the setup card's "Open Folder" button uses — so the extension opens the native folder picker and adds the chosen folder to the workspace.
- The button is visible whenever the project header is visible (i.e. once there is at least one workspace folder). When there are no folders the setup card still owns that first-time flow.
- No extension-side changes needed; the `openWorkspaceFolder` handler already exists.
- Styled as a compact, low-contrast `+` button that brightens on hover, consistent with the existing header aesthetics.

## Test plan

- [ ] No workspace folders: setup card shows, `+` button not visible (header hidden)
- [ ] One or more workspace folders present: `+` button visible next to Project selector in all states (uninitialized and initialized)
- [ ] Clicking `+` opens the native folder picker; selecting a folder adds it to the workspace and the Project selector updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)