### PR TITLE
Materialize bundled ROM assets at project init time

### DIFF
--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -27,6 +27,7 @@ import {
   type ScaffoldPlatform,
   type StarterLanguage,
 } from './project-kits';
+import { materializeBundledRom } from './bundle-materialize';
 
 type ScaffoldPlan = {
   kit: ProjectKit;
@@ -260,6 +261,18 @@ export async function scaffoldProject(
         }
       }
       fs.writeFileSync(configPath, `${JSON.stringify(defaultConfig, null, 2)}\n`);
+      if (plan.kit.bundledProfile !== undefined && extensionUri !== undefined) {
+        const romResult = materializeBundledRom(
+          extensionUri,
+          workspaceRoot,
+          plan.kit.bundledProfile.bundleRelPath
+        );
+        if (!romResult.ok) {
+          void vscode.window.showWarningMessage(
+            `Debug80: Project created but bundled ROM assets could not be installed: ${romResult.reason}`
+          );
+        }
+      }
       void vscode.window.showInformationMessage(
         `Debug80: Created ${plan.kit.label} project in debug80.json targeting ${plan.sourceFile}.`
       );


### PR DESCRIPTION
## Summary

Moves ROM asset copying from first-launch to project initialization, so a newly created project is fully ready to debug immediately.

**Before:** `Initialize Project` wrote `debug80.json` and `src/main.asm` but not the ROM/listing files. On first `Start Debugging`, `ensureBundledAssetsPresent` (PR #341) would silently copy them — but this felt unexpected and the workspace explorer showed no `roms/` folder until then.

**After:** `scaffoldProject` calls `materializeBundledRom` immediately after writing `debug80.json`. The `roms/` folder appears in the workspace explorer as part of project creation, and debugging works on the very first launch with no intermediate step.

The lazy fallback in `startCurrentProjectDebugging` (PR #341) is kept as a safety net for:
- Projects created before this change
- Any case where `roms/` was manually deleted

A warning toast is shown if init-time materialization fails, but the project config is still written so the runtime fallback can handle it.

## Test plan

- [ ] Initialize a new TEC-1G project via the panel — `roms/tec1g/mon3/` folder appears in workspace immediately
- [ ] Initialize a new TEC-1 project — `roms/tec1/mon1b/` appears immediately
- [ ] Initialize a Simple project — no `roms/` folder (ROM-less, expected)
- [ ] Start debugging the new project immediately — works on first launch without any extra step

🤖 Generated with [Claude Code](https://claude.com/claude-code)