### PR TITLE
feat: add E2E-1 adapter integration suite with shared harness

### DIFF
--- a/tests/e2e/adapter/adapter.e2e.test.ts
+++ b/tests/e2e/adapter/adapter.e2e.test.ts
@@ -1,62 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { PassThrough } from 'stream';
-import path from 'path';
-import { Z80DebugSession } from '../../../src/debug/adapter';
-import { DapClient } from './dap-client';
 import { workspace } from './vscode-mock';
+import {
+  createHarness,
+  initialize,
+  launchWithDiagnostics,
+  fixtureRoot,
+  projectConfig,
+  sourcePath,
+  THREAD_ID,
+  type SessionHarness,
+} from './harness';
 
-const fixtureRoot = path.resolve(__dirname, '../fixtures/simple');
-const projectConfig = path.join(fixtureRoot, '.vscode', 'debug80.json');
-const sourcePath = path.join(fixtureRoot, 'src', 'simple.asm');
-
-const THREAD_ID = 1;
-
-type SessionHarness = {
-  session: Z80DebugSession;
-  client: DapClient;
-  input: PassThrough;
-  output: PassThrough;
-};
-
-function createHarness(): SessionHarness {
-  const input = new PassThrough();
-  const output = new PassThrough();
-  const session = new Z80DebugSession();
-  session.setRunAsServer(true);
-  session.start(input, output);
-  const client = new DapClient(input, output);
-  return { session, client, input, output };
-}
-
-async function initialize(client: DapClient): Promise<void> {
-  await client.sendRequest('initialize', {
-    adapterID: 'z80',
-    pathFormat: 'path',
-    linesStartAt1: true,
-    columnsStartAt1: true,
-  });
-  await client.waitForEvent('initialized');
-}
-
-async function launchWithDiagnostics(
-  client: DapClient,
-  args: Record<string, unknown>
-): Promise<void> {
-  try {
-    await client.sendRequest('launch', args);
-  } catch (err) {
-    let output = '';
-    try {
-      const event = await client.waitForEvent<{ body?: { output?: string } }>('output', undefined, 1000);
-      output = event.body?.output?.trim() ?? '';
-    } catch {
-      // ignore missing output
-    }
-    const message = err instanceof Error ? err.message : String(err);
-    const detail = output.length > 0 ? `${message}\n${output}` : message;
-    throw new Error(detail);
-  }
-}
 describe('Debug80 adapter e2e (in-process)', () => {
   let harness: SessionHarness | undefined;
 

--- a/tests/e2e/adapter/harness.ts
+++ b/tests/e2e/adapter/harness.ts
@@ -1,0 +1,57 @@
+import { PassThrough } from 'stream';
+import path from 'path';
+import { Z80DebugSession } from '../../../src/debug/adapter';
+import { DapClient } from './dap-client';
+
+export const fixtureRoot = path.resolve(__dirname, '../fixtures/simple');
+export const projectConfig = path.join(fixtureRoot, '.vscode', 'debug80.json');
+export const sourcePath = path.join(fixtureRoot, 'src', 'simple.asm');
+
+export const THREAD_ID = 1;
+
+export type SessionHarness = {
+  session: Z80DebugSession;
+  client: DapClient;
+  input: PassThrough;
+  output: PassThrough;
+};
+
+export function createHarness(): SessionHarness {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const session = new Z80DebugSession();
+  session.setRunAsServer(true);
+  session.start(input, output);
+  const client = new DapClient(input, output);
+  return { session, client, input, output };
+}
+
+export async function initialize(client: DapClient): Promise<void> {
+  await client.sendRequest('initialize', {
+    adapterID: 'z80',
+    pathFormat: 'path',
+    linesStartAt1: true,
+    columnsStartAt1: true,
+  });
+  await client.waitForEvent('initialized');
+}
+
+export async function launchWithDiagnostics(
+  client: DapClient,
+  args: Record<string, unknown>
+): Promise<void> {
+  try {
+    await client.sendRequest('launch', args);
+  } catch (err) {
+    let output = '';
+    try {
+      const event = await client.waitForEvent<{ body?: { output?: string } }>('output', undefined, 1000);
+      output = event.body?.output?.trim() ?? '';
+    } catch {
+      // ignore missing output
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    const detail = output.length > 0 ? `${message}\n${output}` : message;
+    throw new Error(detail);
+  }
+}

--- a/tests/e2e/adapter/step.test.ts
+++ b/tests/e2e/adapter/step.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { workspace } from './vscode-mock';
+import {
+  createHarness,
+  initialize,
+  launchWithDiagnostics,
+  fixtureRoot,
+  projectConfig,
+  THREAD_ID,
+  type SessionHarness,
+} from './harness';
+
+describe('step and register read', () => {
+  let harness: SessionHarness | undefined;
+
+  beforeEach(() => {
+    workspace.workspaceFolders = [{ uri: { fsPath: fixtureRoot } }];
+    harness = createHarness();
+  });
+
+  afterEach(() => {
+    harness?.client.dispose();
+    harness?.input.end();
+    harness?.output.end();
+    harness = undefined;
+  });
+
+  it('stepIn advances PC from NOP to IN instruction', async () => {
+    const { client } = harness!;
+    await initialize(client);
+    await launchWithDiagnostics(client, {
+      projectConfig,
+      target: 'app',
+      stopOnEntry: true,
+      openRomSourcesOnLaunch: false,
+      openMainSourceOnLaunch: false,
+    });
+    await client.sendRequest('setBreakpoints', { source: { path: '' }, breakpoints: [] });
+    await client.sendRequest('configurationDone');
+    await client.waitForEvent('stopped'); // entry stop
+
+    // Step over the NOP at 0x0000
+    await client.sendRequest('next', { threadId: THREAD_ID });
+    const stepped = await client.waitForEvent<{ body?: { reason?: string } }>('stopped');
+    expect(stepped.body?.reason).toBe('step');
+
+    // PC should now be at 0x0001 — verify via stack trace (line 3 of simple.asm)
+    const stack = await client.sendRequest<{
+      body?: { stackFrames?: Array<{ id: number; line: number }> };
+    }>('stackTrace', { threadId: THREAD_ID, startFrame: 0, levels: 1 });
+    expect(stack.body?.stackFrames?.[0]?.line).toBe(3);
+
+    // Verify PC register reads back correctly
+    const frameId = stack.body?.stackFrames?.[0]?.id ?? 0;
+    const scopes = await client.sendRequest<{
+      body?: { scopes?: Array<{ name: string; variablesReference: number }> };
+    }>('scopes', { frameId });
+    const regScope = scopes.body?.scopes?.find((s) => /register/i.test(s.name));
+    if (regScope) {
+      const vars = await client.sendRequest<{
+        body?: { variables?: Array<{ name: string; value: string }> };
+      }>('variables', { variablesReference: regScope.variablesReference });
+      const pc = vars.body?.variables?.find((v) => v.name.toUpperCase() === 'PC');
+      expect(pc?.value).toMatch(/0001/i);
+    }
+
+    await client.sendRequest('disconnect');
+  });
+});

--- a/tests/e2e/adapter/terminate.test.ts
+++ b/tests/e2e/adapter/terminate.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { workspace } from './vscode-mock';
+import {
+  createHarness,
+  initialize,
+  launchWithDiagnostics,
+  fixtureRoot,
+  projectConfig,
+  type SessionHarness,
+} from './harness';
+
+describe('session termination', () => {
+  let harness: SessionHarness | undefined;
+
+  beforeEach(() => {
+    workspace.workspaceFolders = [{ uri: { fsPath: fixtureRoot } }];
+    harness = createHarness();
+  });
+
+  afterEach(() => {
+    harness?.client.dispose();
+    harness?.input.end();
+    harness?.output.end();
+    harness = undefined;
+  });
+
+  it('disconnects cleanly when stopped at entry', async () => {
+    const { client } = harness!;
+    await initialize(client);
+    await launchWithDiagnostics(client, {
+      projectConfig,
+      target: 'app',
+      stopOnEntry: true,
+      openRomSourcesOnLaunch: false,
+      openMainSourceOnLaunch: false,
+    });
+    await client.sendRequest('setBreakpoints', { source: { path: '' }, breakpoints: [] });
+    await client.sendRequest('configurationDone');
+    await client.waitForEvent('stopped'); // entry stop
+
+    // Should not throw
+    await expect(client.sendRequest('disconnect')).resolves.not.toThrow();
+  });
+
+  it('disconnects cleanly when program is running', async () => {
+    const { client } = harness!;
+    await initialize(client);
+    await launchWithDiagnostics(client, {
+      projectConfig,
+      target: 'app',
+      stopOnEntry: false,
+      openRomSourcesOnLaunch: false,
+      openMainSourceOnLaunch: false,
+    });
+    await client.sendRequest('setBreakpoints', { source: { path: '' }, breakpoints: [] });
+    await client.sendRequest('configurationDone');
+
+    // Disconnect immediately while running — should not throw or time out
+    await expect(client.sendRequest('disconnect')).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts shared test setup (`SessionHarness`, `createHarness`, `initialize`, `launchWithDiagnostics`, constants) from `adapter.e2e.test.ts` into a new `tests/e2e/adapter/harness.ts` module
- Adds `step.test.ts`: verifies that `next` (step over) from the NOP at 0x0000 advances PC to 0x0001 and the stack frame maps to line 3 of `simple.asm`, with PC register value confirmed via the variables API
- Adds `terminate.test.ts`: verifies clean disconnect both when stopped at entry and when the program is running

## Test plan

- [x] All 5 E2E adapter tests pass (`npm run test:e2e:adapter`)
- [x] Existing 2 tests in `adapter.e2e.test.ts` still pass unchanged
- [x] `step.test.ts` — 1 test passes
- [x] `terminate.test.ts` — 2 tests pass

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)