### PR TITLE
feat: focus-gated keyboard input for TEC-1G and TEC-1 keypads

### DIFF
--- a/tests/e2e/adapter/step.test.ts
+++ b/tests/e2e/adapter/step.test.ts
@@ -44,7 +44,9 @@ describe('step and register read', () => {
     const stepped = await client.waitForEvent<{ body?: { reason?: string } }>('stopped');
     expect(stepped.body?.reason).toBe('step');
 
-    // PC should now be at 0x0001 — verify via stack trace (line 3 of simple.asm)
+    // PC should now be at 0x0001 — verify via stack trace.
+    // Line 3 = the IN instruction in tests/e2e/fixtures/simple/src/simple.asm.
+    // If the fixture changes, update this assertion.
     const stack = await client.sendRequest<{
       body?: { stackFrames?: Array<{ id: number; line: number }> };
     }>('stackTrace', { threadId: THREAD_ID, startFrame: 0, levels: 1 });
@@ -56,13 +58,12 @@ describe('step and register read', () => {
       body?: { scopes?: Array<{ name: string; variablesReference: number }> };
     }>('scopes', { frameId });
     const regScope = scopes.body?.scopes?.find((s) => /register/i.test(s.name));
-    if (regScope) {
-      const vars = await client.sendRequest<{
-        body?: { variables?: Array<{ name: string; value: string }> };
-      }>('variables', { variablesReference: regScope.variablesReference });
-      const pc = vars.body?.variables?.find((v) => v.name.toUpperCase() === 'PC');
-      expect(pc?.value).toMatch(/0001/i);
-    }
+    expect(regScope).toBeDefined();
+    const vars = await client.sendRequest<{
+      body?: { variables?: Array<{ name: string; value: string }> };
+    }>('variables', { variablesReference: regScope!.variablesReference });
+    const pc = vars.body?.variables?.find((v) => v.name.toUpperCase() === 'PC');
+    expect(pc?.value).toMatch(/0001/i);
 
     await client.sendRequest('disconnect');
   });

--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -180,6 +180,7 @@ body {
       display: inline-flex;
       align-items: center;
       gap: 8px;
+      min-width: 48px; /* Keeps speaker width constant */
     }
     .speaker.on {
       background: #ffb000;

--- a/webview/tec1/index.html
+++ b/webview/tec1/index.html
@@ -70,12 +70,12 @@
         <div class="left-col">
           <div class="display" id="display"></div>
           <div class="status">
+            <div class="key speed" id="speed">SLOW</div>
+            <div class="key mute" id="mute">MUTED</div>
             <div class="speaker" id="speaker">
               <span>SPEAKER</span>
               <span id="speakerHz"></span>
             </div>
-            <div class="key speed" id="speed">SLOW</div>
-            <div class="key mute" id="mute">MUTED</div>
           </div>
           <div class="keypad" id="keypad"></div>
         </div>

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -31,6 +31,7 @@ const homeTargetSelect = document.getElementById('homeTargetSelect') as HTMLSele
 const targetControl = homeTargetSelect?.closest('.project-control') as HTMLElement | null;
 const displayEl = document.getElementById('display') as HTMLElement;
 const keypadEl = document.getElementById('keypad') as HTMLElement;
+keypadEl.tabIndex = 0;
 const speakerEl = document.getElementById('speaker') as HTMLElement;
 const speakerHzEl = document.getElementById('speakerHz') as HTMLElement;
 const speedEl = document.getElementById('speed') as HTMLElement;
@@ -179,6 +180,9 @@ function addButton(label: string, action: () => void, className?: string): HTMLE
   button.className = className ? 'key ' + className : 'key';
   button.textContent = label;
   button.addEventListener('click', action);
+  button.addEventListener('mousedown', (e) => {
+    e.preventDefault(); // retain keypad focus when clicking keys
+  });
   keypadEl.appendChild(button);
   return button;
 }
@@ -348,19 +352,13 @@ lcdRenderer.draw();
 matrixRenderer.build();
 matrixRenderer.draw();
 panelLayout.setTab(DEFAULT_TAB, false);
+keypadEl.focus();
 sessionStatusController.setStatus('not running');
 window.addEventListener('resize', () => panelLayout.scheduleMemoryResize());
 panelLayout.updateMemoryLayout(false);
 
-window.addEventListener('keydown', event => {
+keypadEl.addEventListener('keydown', (event) => {
   if (event.repeat) return;
-  const target = event.target;
-  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
-    return;
-  }
-  if (target && target.isContentEditable) {
-    return;
-  }
   const key = event.key.toUpperCase();
   if (keyMap[key] !== undefined) {
     sendKey(keyMap[key]);

--- a/webview/tec1/styles.css
+++ b/webview/tec1/styles.css
@@ -9,3 +9,7 @@
       gap: 8px;
       align-items: center;
     }
+    .keypad:focus-visible {
+      outline: 2px solid var(--vscode-focusBorder);
+      outline-offset: 2px;
+    }

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -273,7 +273,9 @@ window.addEventListener('keydown', (event) => {
   }
 });
 
-// Keypad key routing is gated on keypad focus
+// Keypad key routing is gated on keypad focus.
+// stopPropagation() prevents the window-level matrix handler from also seeing
+// a consumed key — the two key sets may overlap.
 keypadEl.addEventListener('keydown', (event) => {
   if (event.repeat) {
     return;
@@ -282,20 +284,25 @@ keypadEl.addEventListener('keydown', (event) => {
   if (TEC1G_KEY_MAP[key] !== undefined) {
     keypad.sendKey(TEC1G_KEY_MAP[key]);
     event.preventDefault();
+    event.stopPropagation();
     return;
   }
   if (event.key === 'Enter') {
     keypad.sendKey(0x12);
     event.preventDefault();
+    event.stopPropagation();
   } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
     keypad.sendKey(0x11);
     event.preventDefault();
+    event.stopPropagation();
   } else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
     keypad.sendKey(0x10);
     event.preventDefault();
+    event.stopPropagation();
   } else if (event.key === 'Tab') {
     keypad.sendKey(0x13);
     event.preventDefault();
+    event.stopPropagation();
   }
 });
 window.addEventListener('keyup', (event) => {

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -255,6 +255,7 @@ visibilityController.wire();
 lcdRenderer.draw();
 glcdRenderer.draw();
 tabMemory.setTab(DEFAULT_TAB, false);
+keypad.focusKeypad();
 sessionStatusController.setStatus('not running');
 window.addEventListener('resize', () => {
   tabMemory.scheduleMemoryResize();
@@ -262,19 +263,19 @@ window.addEventListener('resize', () => {
 tabMemory.updateMemoryLayout(false);
 wireTec1gSerialUi(vscode);
 
+// Matrix keyboard stays at window level — it has its own mode system
 window.addEventListener('keydown', (event) => {
   if (event.repeat) {
     return;
   }
   if (matrixUi.handleKeyEvent(event, true)) {
     event.preventDefault();
-    return;
   }
-  const target = event.target;
-  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
-    return;
-  }
-  if (target && target.isContentEditable) {
+});
+
+// Keypad key routing is gated on keypad focus
+keypadEl.addEventListener('keydown', (event) => {
+  if (event.repeat) {
     return;
   }
   const key = event.key.toUpperCase();

--- a/webview/tec1g/styles.css
+++ b/webview/tec1g/styles.css
@@ -56,6 +56,10 @@
       padding: 10px;
       border-radius: 6px;
     }
+    .keypad:focus-visible {
+      outline: 2px solid var(--vscode-focusBorder);
+      outline-offset: 2px;
+    }
     .keycap {
       width: 42px;
       height: 42px;

--- a/webview/tec1g/tec1g-keypad.ts
+++ b/webview/tec1g/tec1g-keypad.ts
@@ -20,6 +20,7 @@ export type Tec1gKeypad = {
   getSysCtrlValue: () => number;
   updateSysCtrl: () => void;
   updateStatusLeds: () => void;
+  focusKeypad: () => void;
 };
 
 /**
@@ -35,6 +36,7 @@ export function createTec1gKeypad(
     statusCaps: HTMLElement | null;
   }
 ): Tec1gKeypad {
+  keypadEl.tabIndex = 0;
   let sysCtrlSegs: HTMLElement[] = [];
   let sysCtrlValue = 0;
   let shiftLatched = false;
@@ -78,6 +80,9 @@ export function createTec1gKeypad(
       button.style.gridRow = String(row);
     }
     button.addEventListener('click', action);
+    button.addEventListener('mousedown', (e) => {
+      e.preventDefault(); // retain keypad focus when clicking keys
+    });
     keypadEl.appendChild(button);
     return button;
   }
@@ -191,6 +196,7 @@ export function createTec1gKeypad(
     getSysCtrlValue: () => sysCtrlValue,
     updateSysCtrl,
     updateStatusLeds,
+    focusKeypad: () => keypadEl.focus(),
   };
 }
 


### PR DESCRIPTION
## Summary

- `keypadEl` gains `tabIndex=0` — it enters the tab order and can receive focus
- Each keycap uses `mousedown` + `preventDefault` to keep focus on the keypad when clicking keys (click event still fires normally)
- Keyboard routing moved from `window.keydown` → `keypadEl.keydown`, so keys only reach the emulator when the keypad is focused
- TEC-1G: `matrixUi.handleKeyEvent` stays on a separate `window.keydown` listener (its own mode system is independent)
- Both keypads auto-focus on load for seamless out-of-the-box use
- CSS `:focus-visible` ring using `--vscode-focusBorder` on both platforms
- **Harmonization bonus**: TEC-1 classic status bar element order aligned with TEC-1G (SLOW/MUTED before SPEAKER); speaker `min-width` fix prevents reflow

Closes #333

## Test plan

- [ ] Open TEC-1G panel — keypad should have focus ring immediately; hex/control keys and arrow keys route to emulator
- [ ] Click on memory panel address input — typing should NOT go to keypad; click keypad to restore focus
- [ ] Open TEC-1 classic panel — same behaviour; keyboard works without clicking first
- [ ] Tab key sends AD (0x13) on both platforms when keypad is focused
- [ ] FN/SHIFT latch works correctly with keyboard input
- [ ] Matrix keyboard (TEC-1G) still works regardless of keypad focus state

🤖 Generated with [Claude Code](https://claude.com/claude-code)