### PR TITLE
feat: Space/R/Shift shortcuts and click-to-focus for keypads

### DIFF
--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -181,7 +181,8 @@ function addButton(label: string, action: () => void, className?: string): HTMLE
   button.textContent = label;
   button.addEventListener('click', action);
   button.addEventListener('mousedown', (e) => {
-    e.preventDefault(); // retain keypad focus when clicking keys
+    e.preventDefault(); // prevent default focus change
+    keypadEl.focus();   // claim keypad focus when any key is clicked
   });
   keypadEl.appendChild(button);
   return button;
@@ -359,6 +360,22 @@ panelLayout.updateMemoryLayout(false);
 
 keypadEl.addEventListener('keydown', (event) => {
   if (event.repeat) return;
+  if (event.key === ' ') {
+    sendKey(keyMap['AD']); // 0x13
+    event.preventDefault();
+    return;
+  }
+  if (event.key === 'r' || event.key === 'R') {
+    setShiftLatched(false);
+    vscode.postMessage({ type: 'reset' });
+    event.preventDefault();
+    return;
+  }
+  if (event.key === 'Shift') {
+    setShiftLatched(true);
+    event.preventDefault();
+    return;
+  }
   const key = event.key.toUpperCase();
   if (keyMap[key] !== undefined) {
     sendKey(keyMap[key]);
@@ -377,6 +394,11 @@ keypadEl.addEventListener('keydown', (event) => {
   } else if (event.key === 'Tab') {
     sendKey(0x13);
     event.preventDefault();
+  }
+});
+keypadEl.addEventListener('keyup', (event) => {
+  if (event.key === 'Shift' && shiftLatched) {
+    setShiftLatched(false);
   }
 });
 

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -280,6 +280,25 @@ keypadEl.addEventListener('keydown', (event) => {
   if (event.repeat) {
     return;
   }
+  if (event.key === ' ') {
+    keypad.sendKey(TEC1G_KEY_MAP['AD']);
+    event.preventDefault();
+    event.stopPropagation();
+    return;
+  }
+  if (event.key === 'r' || event.key === 'R') {
+    keypad.setShiftLatched(false);
+    vscode.postMessage({ type: 'reset' });
+    event.preventDefault();
+    event.stopPropagation();
+    return;
+  }
+  if (event.key === 'Shift') {
+    keypad.setShiftLatched(true);
+    event.preventDefault();
+    event.stopPropagation();
+    return;
+  }
   const key = event.key.toUpperCase();
   if (TEC1G_KEY_MAP[key] !== undefined) {
     keypad.sendKey(TEC1G_KEY_MAP[key]);
@@ -303,6 +322,11 @@ keypadEl.addEventListener('keydown', (event) => {
     keypad.sendKey(0x13);
     event.preventDefault();
     event.stopPropagation();
+  }
+});
+keypadEl.addEventListener('keyup', (event) => {
+  if (event.key === 'Shift' && keypad.getShiftLatched()) {
+    keypad.setShiftLatched(false);
   }
 });
 window.addEventListener('keyup', (event) => {

--- a/webview/tec1g/tec1g-keypad.ts
+++ b/webview/tec1g/tec1g-keypad.ts
@@ -81,7 +81,8 @@ export function createTec1gKeypad(
     }
     button.addEventListener('click', action);
     button.addEventListener('mousedown', (e) => {
-      e.preventDefault(); // retain keypad focus when clicking keys
+      e.preventDefault(); // prevent default focus change
+      keypadEl.focus();   // claim keypad focus when any key is clicked
     });
     keypadEl.appendChild(button);
     return button;


### PR DESCRIPTION
## Summary

Follow-up to #364 — adds the missing keyboard shortcuts and fixes click-to-focus.

- **Space → AD** on both TEC-1G and TEC-1 classic
- **R → Reset** on both platforms (clears FN latch first so reset is always clean)
- **Shift as momentary FN modifier** — hold Shift to activate the FN latch; releasing Shift without pressing another key clears the latch automatically (Shift+hex key = function key, same as clicking FN then the key with the mouse)
- **Click any key to claim focus** — `mousedown` on each keycap now calls `keypadEl.focus()` so clicking a key works even if the keypad wasn't previously focused (previously only `preventDefault` was called)

## FN / Shift behaviour

FN is a one-shot latch on both platforms:
- **Mouse**: click FN (it highlights), then click the target key — FN unlatches automatically
- **Keyboard**: hold Shift, press the target key — Shift keyup clears the latch if unused

## Test plan

- [ ] Space sends AD on TEC-1G and TEC-1
- [ ] R resets the CPU on both platforms; FN latch is cleared first
- [ ] Hold Shift + press a hex key → key is sent in function mode (FN latch unlatches after)
- [ ] Hold Shift, release without pressing a key → FN latch clears cleanly
- [ ] Click a key when the keypad has no focus → key is sent AND keypad gains focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)