### PR TITLE
fix: clicking keypad background claims focus

### DIFF
--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -32,6 +32,10 @@ const targetControl = homeTargetSelect?.closest('.project-control') as HTMLEleme
 const displayEl = document.getElementById('display') as HTMLElement;
 const keypadEl = document.getElementById('keypad') as HTMLElement;
 keypadEl.tabIndex = 0;
+keypadEl.addEventListener('mousedown', (e) => {
+  e.preventDefault();
+  keypadEl.focus();
+});
 const speakerEl = document.getElementById('speaker') as HTMLElement;
 const speakerHzEl = document.getElementById('speakerHz') as HTMLElement;
 const speedEl = document.getElementById('speed') as HTMLElement;

--- a/webview/tec1g/tec1g-keypad.ts
+++ b/webview/tec1g/tec1g-keypad.ts
@@ -37,6 +37,10 @@ export function createTec1gKeypad(
   }
 ): Tec1gKeypad {
   keypadEl.tabIndex = 0;
+  keypadEl.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    keypadEl.focus();
+  });
   let sysCtrlSegs: HTMLElement[] = [];
   let sysCtrlValue = 0;
   let shiftLatched = false;


### PR DESCRIPTION
Clicking the black background/padding of the keypad area now gives focus to the keypad on both TEC-1G and TEC-1 classic. Root cause: `keypadEl` had `tabIndex=0` but no `mousedown` handler on the container itself — clicks on non-key areas sent focus to body. Fix: attach `mousedown` → `preventDefault` + `focus()` directly to `keypadEl`.