### PR TITLE
fix: rebind Reset from R to Escape

### DIFF
--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -377,7 +377,7 @@ keypadEl.addEventListener('keydown', (event) => {
     event.preventDefault();
     return;
   }
-  if (event.key === 'r' || event.key === 'R') {
+  if (event.key === 'Escape') {
     setShiftLatched(false);
     vscode.postMessage({ type: 'reset' });
     event.preventDefault();

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -294,7 +294,7 @@ keypadEl.addEventListener('keydown', (event) => {
     event.stopPropagation();
     return;
   }
-  if (event.key === 'r' || event.key === 'R') {
+  if (event.key === 'Escape') {
     keypad.setShiftLatched(false);
     vscode.postMessage({ type: 'reset' });
     event.preventDefault();


### PR DESCRIPTION
Changes the keyboard Reset binding from R to Escape on both TEC-1G and TEC-1 classic.