### PR TITLE
refactor: restructure TEC-1G panel layout

### DIFF
--- a/webview/tec1g/index.html
+++ b/webview/tec1g/index.html
@@ -67,12 +67,12 @@
     </div>
     <div class="panel panel-ui" id="panel-ui">
       <div class="ui-controls" id="uiControls">
-        <label><input type="checkbox" data-section="lcd" checked /> LCD</label>
         <label><input type="checkbox" data-section="display" checked /> 7-SEG</label>
+        <label><input type="checkbox" data-section="lcd" checked /> LCD</label>
         <label><input type="checkbox" data-section="keypad" checked /> KEYPAD</label>
         <label><input type="checkbox" data-section="glcd" checked /> GLCD</label>
-        <label><input type="checkbox" data-section="serial" /> SERIAL</label>
         <label><input type="checkbox" data-section="matrix" /> 8X8</label>
+        <label><input type="checkbox" data-section="serial" /> SERIAL</label>
         <label><input type="checkbox" data-section="matrixKeyboard" /> KEYBD</label>
       </div>
       <div class="layout">
@@ -83,53 +83,38 @@
           </div>
           <div class="display-block ui-section" data-section="display">
             <div class="display" id="display"></div>
-            <div class="status">
-              <div class="key speed" id="speed">SLOW</div>
-              <div class="key mute" id="mute">MUTED</div>
-              <div class="speaker" id="speaker">
-                <span id="speakerLabel">SPEAKER</span>
+          </div>
+          <div class="keypad ui-section" id="keypad" data-section="keypad"></div>
+        </div>
+        <div class="right-col">
+          <div class="status">
+            <div class="key speed" id="speed">SLOW</div>
+            <div class="key mute" id="mute">MUTED</div>
+            <div class="speaker" id="speaker">
+              <span id="speakerLabel">SPEAKER</span>
+            </div>
+            <div class="status-leds" id="statusLeds">
+              <div class="status-led">
+                <span class="status-led-light" id="statusShadow"></span>
+                <span class="status-led-label">SHADOW</span>
               </div>
-              <div class="status-leds" id="statusLeds">
-                <div class="status-led">
-                  <span class="status-led-light" id="statusShadow"></span>
-                  <span class="status-led-label">SHADOW</span>
-                </div>
-                <div class="status-led">
-                  <span class="status-led-light" id="statusProtect"></span>
-                  <span class="status-led-label">PROTECT</span>
-                </div>
-                <div class="status-led">
-                  <span class="status-led-light" id="statusExpand"></span>
-                  <span class="status-led-label">EXPAND</span>
-                </div>
-                <div class="status-led">
-                  <span class="status-led-light" id="statusCaps"></span>
-                  <span class="status-led-label">CAPS</span>
-                </div>
+              <div class="status-led">
+                <span class="status-led-light" id="statusProtect"></span>
+                <span class="status-led-label">PROTECT</span>
+              </div>
+              <div class="status-led">
+                <span class="status-led-light" id="statusExpand"></span>
+                <span class="status-led-label">EXPAND</span>
+              </div>
+              <div class="status-led">
+                <span class="status-led-light" id="statusCaps"></span>
+                <span class="status-led-label">CAPS</span>
               </div>
             </div>
           </div>
-        </div>
-        <div class="right-col">
           <div class="glcd ui-section" data-section="glcd">
             <div class="glcd-title">GLCD (128x64)</div>
             <canvas class="glcd-canvas" id="glcdCanvas" width="320" height="160"></canvas>
-          </div>
-          <div class="keypad ui-section" id="keypad" data-section="keypad"></div>
-          <div class="matrix-keyboard ui-section" data-section="matrixKeyboard">
-            <div class="matrix-keyboard-title">MATRIX KEYBOARD</div>
-            <div class="matrix-keyboard-controls">
-              <div class="key" id="matrixModeToggle">MATRIX MODE</div>
-              <div class="matrix-keyboard-indicator" id="matrixModeStatus">OFF</div>
-              <div class="matrix-keyboard-indicator" id="matrixCapsStatus">CAPS</div>
-            </div>
-            <div class="matrix-keyboard-mods">
-              <div class="key" id="matrixShift">SHIFT</div>
-              <div class="key" id="matrixCtrl">CTRL</div>
-              <div class="key" id="matrixAlt">ALT</div>
-            </div>
-            <div class="matrix-keyboard-hint">Type or click keys to send input.</div>
-            <div class="matrix-keyboard-grid" id="matrixKeyboardGrid"></div>
           </div>
           <div class="matrix ui-section" data-section="matrix">
             <div class="matrix-title">8x8 LED MATRIX</div>
@@ -151,6 +136,21 @@
           <input id="serialInput" type="text" placeholder="Type and press Enter (CR)..." />
           <div class="key" id="serialSend">SEND</div>
         </div>
+      </div>
+      <div class="matrix-keyboard ui-section" data-section="matrixKeyboard">
+        <div class="matrix-keyboard-title">MATRIX KEYBOARD</div>
+        <div class="matrix-keyboard-controls">
+          <div class="key" id="matrixModeToggle">MATRIX MODE</div>
+          <div class="matrix-keyboard-indicator" id="matrixModeStatus">OFF</div>
+          <div class="matrix-keyboard-indicator" id="matrixCapsStatus">CAPS</div>
+        </div>
+        <div class="matrix-keyboard-mods">
+          <div class="key" id="matrixShift">SHIFT</div>
+          <div class="key" id="matrixCtrl">CTRL</div>
+          <div class="key" id="matrixAlt">ALT</div>
+        </div>
+        <div class="matrix-keyboard-hint">Type or click keys to send input.</div>
+        <div class="matrix-keyboard-grid" id="matrixKeyboardGrid"></div>
       </div>
     </div>
     <div class="panel panel-memory" id="panel-memory">

--- a/webview/tec1g/styles.css
+++ b/webview/tec1g/styles.css
@@ -2,16 +2,18 @@
       justify-items: start;
       justify-content: start;
     }
-    @container (min-width: 480px) {
+    @container (min-width: 620px) {
       .layout {
-        grid-template-columns: auto 300px;
+        grid-template-columns: auto 320px;
         width: fit-content;
         max-width: 100%;
       }
     }
     .right-col {
       align-items: stretch;
-      --keypad-width: 282px;
+    }
+    .right-col .status {
+      margin-bottom: 12px;
     }
     .status {
       flex-wrap: wrap;
@@ -51,7 +53,7 @@
       grid-template-rows: repeat(4, 42px);
       gap: 2px;
       align-items: center;
-      width: var(--keypad-width);
+      width: 282px;
       background: #1c1c1c;
       padding: 10px;
       border-radius: 6px;
@@ -154,7 +156,7 @@
       border-radius: 8px;
       padding: 10px 12px;
       border: 1px solid #243528;
-      width: var(--keypad-width);
+      width: 100%;
     }
     .glcd-title {
       font-size: 11px;


### PR DESCRIPTION
Reorganises the TEC-1G webview into a coherent two-column layout. Left col = front panel (LCD, 7-seg, keypad). Right col = status + extensions (GLCD, 8x8). Full width below = serial + matrix keyboard. No logic changes — element IDs all unchanged.