### PR TITLE
fix: TEC-1G matrix off-dots visible as unlit LEDs

### DIFF
--- a/webview/tec1g/styles.css
+++ b/webview/tec1g/styles.css
@@ -207,11 +207,11 @@
       width: 16px;
       height: 16px;
       border-radius: 999px;
-      background: radial-gradient(circle at 35% 35%, #2a1810 0%, #140c08 55%, #080403 100%);
+      background: radial-gradient(circle at 35% 35%, #3d2018 0%, #221008 55%, #100604 100%);
       box-shadow:
-        inset 0 1px 2px rgba(255, 255, 255, 0.04),
+        inset 0 1px 2px rgba(255, 255, 255, 0.08),
         inset 0 -1px 2px rgba(0, 0, 0, 0.65);
-      opacity: calc(0.03 + (var(--matrix-level) * 0.97));
+      opacity: calc(0.35 + (var(--matrix-level) * 0.65));
       transition: opacity 40ms linear, box-shadow 40ms linear, background 40ms linear, filter 40ms linear;
     }
     .matrix-dot.on {


### PR DESCRIPTION
Opacity floor was 3% making dots invisible when off. Raised to 35%, brightened off-state background gradient, and increased inner highlight for spherical depth.