### PR TITLE
fix: increase 8x8 LED matrix dot size by ~a third

### DIFF
--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -272,17 +272,17 @@ body {
     }
     .matrix-grid {
       display: grid;
-      grid-template-columns: repeat(8, 18px);
-      grid-template-rows: repeat(8, 18px);
-      gap: 6px;
+      grid-template-columns: repeat(8, 24px);
+      grid-template-rows: repeat(8, 24px);
+      gap: 8px;
       background: #120707;
-      padding: 8px;
+      padding: 10px;
       border-radius: 6px;
       border: 1px solid #2f1111;
     }
     .matrix-dot {
-      width: 18px;
-      height: 18px;
+      width: 24px;
+      height: 24px;
       border-radius: 50%;
       background: radial-gradient(circle at 30% 30%, #6b1515, #3a0a0a 70%);
       box-shadow: inset 0 0 3px rgba(0, 0, 0, 0.6);

--- a/webview/tec1g/styles.css
+++ b/webview/tec1g/styles.css
@@ -191,10 +191,10 @@
     }
     .matrix-grid {
       display: grid;
-      grid-template-columns: repeat(8, 16px);
-      gap: 6px;
+      grid-template-columns: repeat(8, 22px);
+      gap: 8px;
       width: fit-content;
-      padding: 8px;
+      padding: 10px;
       border-radius: 8px;
       background: #000000;
       border: 1px solid #1a1a1a;
@@ -204,8 +204,8 @@
       --matrix-r: 0;
       --matrix-g: 0;
       --matrix-b: 0;
-      width: 16px;
-      height: 16px;
+      width: 22px;
+      height: 22px;
       border-radius: 999px;
       background: radial-gradient(circle at 35% 35%, #3d2018 0%, #221008 55%, #100604 100%);
       box-shadow:
@@ -235,7 +235,7 @@
         ) 100%
       );
       box-shadow:
-        0 0 calc(3px + (var(--matrix-level) * 14px))
+        0 0 calc(4px + (var(--matrix-level) * 18px))
           rgba(
             calc(100 + 155 * var(--matrix-r)),
             calc(100 + 155 * var(--matrix-g)),


### PR DESCRIPTION
TEC-1 classic: 18→24px dots. TEC-1G: 16→22px dots. Gaps and padding scaled proportionally. TEC-1G glow radius scaled up to match.