### PR TITLE
fix: unify matrix dot size across both platforms (24px)

### DIFF
--- a/webview/tec1g/styles.css
+++ b/webview/tec1g/styles.css
@@ -191,7 +191,7 @@
     }
     .matrix-grid {
       display: grid;
-      grid-template-columns: repeat(8, 22px);
+      grid-template-columns: repeat(8, 24px);
       gap: 8px;
       width: fit-content;
       padding: 10px;
@@ -204,8 +204,8 @@
       --matrix-r: 0;
       --matrix-g: 0;
       --matrix-b: 0;
-      width: 22px;
-      height: 22px;
+      width: 24px;
+      height: 24px;
       border-radius: 999px;
       background: radial-gradient(circle at 35% 35%, #3d2018 0%, #221008 55%, #100604 100%);
       box-shadow:


### PR DESCRIPTION
TEC-1G was 22px, TEC-1 classic was 24px. Align TEC-1G to 24px for consistency.