### PR TITLE
refactor: single source of truth for matrix dimensions

### DIFF
--- a/webview/common/styles.css
+++ b/webview/common/styles.css
@@ -275,9 +275,10 @@ body {
       grid-template-columns: repeat(8, 24px);
       grid-template-rows: repeat(8, 24px);
       gap: 8px;
-      background: #120707;
+      width: fit-content;
       padding: 10px;
-      border-radius: 6px;
+      border-radius: 8px;
+      background: #120707;
       border: 1px solid #2f1111;
     }
     .matrix-dot {

--- a/webview/tec1g/styles.css
+++ b/webview/tec1g/styles.css
@@ -190,23 +190,14 @@
       text-transform: uppercase;
     }
     .matrix-grid {
-      display: grid;
-      grid-template-columns: repeat(8, 24px);
-      gap: 8px;
-      width: fit-content;
-      padding: 10px;
-      border-radius: 8px;
       background: #000000;
-      border: 1px solid #1a1a1a;
+      border-color: #1a1a1a;
     }
     .matrix-dot {
       --matrix-level: 0;
       --matrix-r: 0;
       --matrix-g: 0;
       --matrix-b: 0;
-      width: 24px;
-      height: 24px;
-      border-radius: 999px;
       background: radial-gradient(circle at 35% 35%, #3d2018 0%, #221008 55%, #100604 100%);
       box-shadow:
         inset 0 1px 2px rgba(255, 255, 255, 0.08),


### PR DESCRIPTION
All size/layout properties live in common only. TEC-1G override keeps only what's genuinely different: grid colours and the RGB dot system.