### PR TITLE
fix(glcd/debug): GLCD clear, source stepping, and block-repeat step

### DIFF
--- a/src/debug/mapping/mapping-service.ts
+++ b/src/debug/mapping/mapping-service.ts
@@ -14,6 +14,7 @@ import { resolveAssemblerBackend } from '../launch/assembler-backend';
 import { resolveListingSourcePath } from './path-resolver';
 import {
   applyLayer2,
+  propagateMisassignedIncludeSegments,
   remapAsm80MisassignedIncludeAnchors,
   syncSegmentLocationsFromAnchors,
 } from '../../mapping/layer2';
@@ -169,11 +170,18 @@ export function buildMappingFromListing(options: {
   }
 
   // Native `.d8.json` maps skip the listing→Layer2 path; asm80 still attributes many
-  // labels to an include parent (e.g. packages.z80 vs glcd_library.z80). Remap and sync.
-  const remappedIncludeAnchors = remapAsm80MisassignedIncludeAnchors(mapping.anchors, (file) =>
+  // labels to an include parent (e.g. packages.z80 vs glcd_library.z80). Remap, propagate
+  // segment files across the whole included routine, then sync anchor lines onto segment starts.
+  const includeAnchorRemaps = remapAsm80MisassignedIncludeAnchors(mapping.anchors, (file) =>
     service.resolveMappedPath(file)
   );
-  syncSegmentLocationsFromAnchors(mapping, remappedIncludeAnchors);
+  propagateMisassignedIncludeSegments(mapping, includeAnchorRemaps, (file) =>
+    service.resolveMappedPath(file)
+  );
+  syncSegmentLocationsFromAnchors(
+    mapping,
+    new Set(includeAnchorRemaps.map((r) => r.address))
+  );
 
   setSegmentWarningHandler((msg) => service.logger.warn(`Debug80: ${msg}`));
 

--- a/src/mapping/layer2.ts
+++ b/src/mapping/layer2.ts
@@ -44,13 +44,20 @@ const SOURCE_EXTENSIONS = /\.(z80|asm)$/i;
  * Also run when loading a native `.d8.json` (ZAX etc.): those maps embed the same
  * asm80 paths and never went through {@link applyLayer2} from a listing rebuild.
  */
+export type IncludeAnchorRemap = {
+  address: number;
+  oldFile: string;
+  newFile: string;
+};
+
 export function remapAsm80MisassignedIncludeAnchors(
   anchors: SourceMapAnchor[],
   resolvePath: (file: string) => string | undefined
-): Set<number> {
-  const remappedAddresses = new Set<number>();
+): IncludeAnchorRemap[] {
+  const remaps: IncludeAnchorRemap[] = [];
   for (const anchor of anchors) {
-    const resolved = resolvePath(anchor.file);
+    const oldFile = anchor.file;
+    const resolved = resolvePath(oldFile);
     if (resolved === undefined || resolved.length === 0) {
       continue;
     }
@@ -70,7 +77,7 @@ export function remapAsm80MisassignedIncludeAnchors(
     } catch {
       continue;
     }
-    const base = path.basename(anchor.file);
+    const base = path.basename(oldFile);
     const matches: string[] = [];
     for (const name of names) {
       if (name === base) {
@@ -95,11 +102,11 @@ export function remapAsm80MisassignedIncludeAnchors(
       const only = matches[0];
       if (only !== undefined) {
         anchor.file = only;
-        remappedAddresses.add(anchor.address);
+        remaps.push({ address: anchor.address, oldFile, newFile: only });
       }
     }
   }
-  return remappedAddresses;
+  return remaps;
 }
 
 function lineDefinesLabel(symbol: string, rawLine: string): boolean {
@@ -142,6 +149,86 @@ export function syncSegmentLocationsFromAnchors(
 }
 
 /**
+ * First address after {@link remapAsm80MisassignedIncludeAnchors} region: next symbol that still
+ * maps to the parent file and whose label actually appears on that line in the parent source.
+ */
+function findIncludeRegionEnd(
+  remap: IncludeAnchorRemap,
+  mapping: MappingParseResult,
+  resolvePath: (file: string) => string | undefined
+): number {
+  const parentPath = resolvePath(remap.oldFile);
+  let parentLines: string[] | null = null;
+  if (parentPath !== undefined) {
+    try {
+      parentLines = fs.readFileSync(parentPath, 'utf-8').split(/\r?\n/);
+    } catch {
+      parentLines = null;
+    }
+  }
+
+  const sorted = [...mapping.anchors].sort((a, b) => a.address - b.address);
+  for (const next of sorted) {
+    if (next.address <= remap.address) {
+      continue;
+    }
+    if (next.file !== remap.oldFile) {
+      continue;
+    }
+    if (parentLines === null) {
+      continue;
+    }
+    const li = next.line - 1;
+    if (li >= 0 && li < parentLines.length && lineDefinesLabel(next.symbol, parentLines[li] ?? '')) {
+      return next.address;
+    }
+  }
+  return 0x10000;
+}
+
+/**
+ * asm80/D8 often tag every byte in an included routine with the parent file. After anchors are
+ * remapped to the real include (e.g. glcd_library.z80), copy that file onto all segments in the
+ * address range until the next genuine parent-file symbol so step-in/stack mapping follows GLCD
+ * source, not only the entry label.
+ */
+export function propagateMisassignedIncludeSegments(
+  mapping: MappingParseResult,
+  remaps: IncludeAnchorRemap[],
+  resolvePath: (file: string) => string | undefined
+): void {
+  if (remaps.length === 0) {
+    return;
+  }
+  const sortedRemaps = [...remaps].sort((a, b) => a.address - b.address);
+  const endByRemapAddress = new Map<number, number>();
+  for (const r of sortedRemaps) {
+    endByRemapAddress.set(r.address, findIncludeRegionEnd(r, mapping, resolvePath));
+  }
+
+  for (const seg of mapping.segments) {
+    if (seg.loc.file === null) {
+      continue;
+    }
+    let best: IncludeAnchorRemap | undefined;
+    let bestAddr = -1;
+    for (const r of sortedRemaps) {
+      if (r.oldFile !== seg.loc.file) {
+        continue;
+      }
+      const end = endByRemapAddress.get(r.address) ?? 0x10000;
+      if (seg.start >= r.address && seg.start < end && r.address >= bestAddr) {
+        best = r;
+        bestAddr = r.address;
+      }
+    }
+    if (best !== undefined) {
+      seg.loc.file = best.newFile;
+    }
+  }
+}
+
+/**
  * Applies Layer 2 refinement to improve source mapping accuracy.
  *
  * Layer 2 processing:
@@ -167,7 +254,8 @@ export function syncSegmentLocationsFromAnchors(
  * ```
  */
 export function applyLayer2(mapping: MappingParseResult, options: Layer2Options): Layer2Result {
-  remapAsm80MisassignedIncludeAnchors(mapping.anchors, options.resolvePath);
+  const includeRemaps = remapAsm80MisassignedIncludeAnchors(mapping.anchors, options.resolvePath);
+  propagateMisassignedIncludeSegments(mapping, includeRemaps, options.resolvePath);
 
   const files = collectSourceFiles(mapping);
   const { fileData, missingSources } = loadSourceFiles(files, options.resolvePath);

--- a/src/platforms/tec1g/glcd.ts
+++ b/src/platforms/tec1g/glcd.ts
@@ -179,7 +179,8 @@ export function createGlcdController(
   const setColumn = (value: number): void => {
     const bankSelected = (value & TEC1G_GLCD_COL_BANK_BIT) !== 0;
     state.glcdRowBase = bankSelected ? TEC1G_GLCD_ROW_BASE : 0;
-    state.glcdCol = value & TEC1G_GLCD_COL_MASK;
+    // Store the full 4-bit X address (0-15) so auto-increment can cross into the lower bank.
+    state.glcdCol = value & (TEC1G_GLCD_COL_BANK_BIT | TEC1G_GLCD_COL_MASK);
     state.glcdExpectColumn = false;
     state.glcdGdramPhase = 0;
     state.glcdReadPrimed = false;
@@ -295,7 +296,9 @@ export function createGlcdController(
       setBusy(GLCD_BUSY_US);
       return;
     }
-    const row = (state.glcdRowBase + state.glcdRowAddr) & TEC1G_GLCD_ROW_MASK;
+    // Derive the active bank from the full X address (bit 3 = lower chip).
+    const colBank = (state.glcdCol & TEC1G_GLCD_COL_BANK_BIT) !== 0 ? TEC1G_GLCD_ROW_BASE : 0;
+    const row = (colBank + state.glcdRowAddr) & TEC1G_GLCD_ROW_MASK;
     const col = state.glcdCol & TEC1G_GLCD_COL_MASK;
     const index = row * TEC1G_GLCD_ROW_STRIDE + col * TEC1G_GLCD_COL_STRIDE + state.glcdGdramPhase;
     if (index >= 0 && index < state.glcd.length) {
@@ -307,7 +310,12 @@ export function createGlcdController(
       state.glcdGdramPhase = 1;
     } else {
       state.glcdGdramPhase = 0;
-      state.glcdCol = (state.glcdCol + 1) & TEC1G_GLCD_COL_MASK;
+      // X auto-increments after each 16-bit word; per ST7920 datasheet it stays at the
+      // boundary if out of range. Max valid X is 0x0F (lower bank, col 7).
+      const maxCol = TEC1G_GLCD_COL_BANK_BIT | TEC1G_GLCD_COL_MASK;
+      if (state.glcdCol < maxCol) {
+        state.glcdCol += 1;
+      }
     }
   };
 
@@ -315,7 +323,8 @@ export function createGlcdController(
     if (!state.glcdGraphics) {
       return readDdram();
     }
-    const row = (state.glcdRowBase + state.glcdRowAddr) & TEC1G_GLCD_ROW_MASK;
+    const colBank = (state.glcdCol & TEC1G_GLCD_COL_BANK_BIT) !== 0 ? TEC1G_GLCD_ROW_BASE : 0;
+    const row = (colBank + state.glcdRowAddr) & TEC1G_GLCD_ROW_MASK;
     const col = state.glcdCol & TEC1G_GLCD_COL_MASK;
     const index = row * TEC1G_GLCD_ROW_STRIDE + col * TEC1G_GLCD_COL_STRIDE + state.glcdGdramPhase;
     const value = index >= 0 && index < state.glcd.length ? (state.glcd[index] ?? 0) : 0;
@@ -329,10 +338,14 @@ export function createGlcdController(
       state.glcdGdramPhase = 1;
     } else {
       state.glcdGdramPhase = 0;
-      state.glcdCol = (state.glcdCol + 1) & TEC1G_GLCD_COL_MASK;
+      const maxCol = TEC1G_GLCD_COL_BANK_BIT | TEC1G_GLCD_COL_MASK;
+      if (state.glcdCol < maxCol) {
+        state.glcdCol += 1;
+      }
     }
+    const nextColBank = (state.glcdCol & TEC1G_GLCD_COL_BANK_BIT) !== 0 ? TEC1G_GLCD_ROW_BASE : 0;
     const nextIndex =
-      ((state.glcdRowBase + state.glcdRowAddr) & TEC1G_GLCD_ROW_MASK) *
+      ((nextColBank + state.glcdRowAddr) & TEC1G_GLCD_ROW_MASK) *
         TEC1G_GLCD_ROW_STRIDE +
       (state.glcdCol & TEC1G_GLCD_COL_MASK) * TEC1G_GLCD_COL_STRIDE +
       state.glcdGdramPhase;

--- a/src/z80/runtime.ts
+++ b/src/z80/runtime.ts
@@ -239,6 +239,40 @@ function classifyStepOver(cpu: Cpu, memRead: (addr: number) => number): StepInfo
   return null;
 }
 
+/**
+ * ED-prefixed instructions that rewind PC to re-execute until a condition is met
+ * (LDIR, CPIR, INIR, OTIR, LDDR, CPDR, INDR, OTDR). The CPU executes one transfer per
+ * internal "iteration", but a single logical instruction should complete in one debugger step.
+ */
+const ED_BLOCK_REPEAT_SECOND = new Set<number>([
+  0xb0, 0xb1, 0xb2, 0xb3, 0xb8, 0xb9, 0xba, 0xbb,
+]);
+
+const OP_DJNZ = 0x10;
+
+/** Max inner iterations when finishing a block instruction (guards pathological loops). */
+const MAX_BLOCK_REPEAT_ITERATIONS = 0x110000;
+
+function shouldContinueRepeatingInstruction(
+  instructionStartPc: number,
+  currentPc: number,
+  memRead: (addr: number) => number
+): boolean {
+  const start = instructionStartPc & 0xffff;
+  if ((currentPc & 0xffff) !== start) {
+    return false;
+  }
+  const op0 = memRead(start) & 0xff;
+  if (op0 === OP_PREFIX_ED) {
+    const op1 = memRead((start + 1) & 0xffff) & 0xff;
+    return ED_BLOCK_REPEAT_SECOND.has(op1);
+  }
+  if (op0 === OP_DJNZ) {
+    return true;
+  }
+  return false;
+}
+
 function stepRuntime(this: Z80RuntimeImpl, options?: { trace?: StepInfo }): RunResult {
   const cpu = this.cpu;
   const hardware = this.hardware;
@@ -262,39 +296,55 @@ function stepRuntime(this: Z80RuntimeImpl, options?: { trace?: StepInfo }): RunR
     }
   }
 
-  const cycles = execute(cpu, {
+  const instructionStartPc = cpu.pc & 0xffff;
+  let totalCycles = 0;
+  let iterations = 0;
+
+  const execCallbacks = {
     mem_read: memRead,
     mem_write: memWrite,
-    io_read: (port: number) => hardware.ioRead(port & 0xffff),
-    io_write: (port: number, value: number) => {
+    io_read: (port: number): number => hardware.ioRead(port & 0xffff),
+    io_write: (port: number, value: number): void => {
       hardware.ioWrite(port & 0xffff, value & 0xff);
     },
-  });
+  };
 
-  const tickResult = (hardware.ioTick ? (hardware.ioTick() as TickResult | void) : undefined) as
-    | TickResult
-    | undefined;
-  if (tickResult?.interrupt !== undefined) {
-    const irq = tickResult.interrupt;
-    triggerInterrupt(cpu, {
-      mem_read: memRead,
-      mem_write: memWrite,
-      io_read: (port: number) => hardware.ioRead(port & 0xffff),
-      io_write: (port: number, value: number) => {
-        hardware.ioWrite(port & 0xffff, value & 0xff);
-      },
-    }, irq.nonMaskable === true, irq.data ?? 0);
-  }
-  if (tickResult !== undefined && tickResult.stop === true) {
-    return { halted: false, pc: cpu.pc, reason: 'breakpoint', cycles };
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const cycles = execute(cpu, execCallbacks);
+    totalCycles += cycles;
+    iterations += 1;
+
+    const tickResult = (hardware.ioTick ? (hardware.ioTick() as TickResult | void) : undefined) as
+      | TickResult
+      | undefined;
+    if (tickResult?.interrupt !== undefined) {
+      const irq = tickResult.interrupt;
+      triggerInterrupt(cpu, {
+        mem_read: memRead,
+        mem_write: memWrite,
+        io_read: (port: number) => hardware.ioRead(port & 0xffff),
+        io_write: (port: number, value: number) => {
+          hardware.ioWrite(port & 0xffff, value & 0xff);
+        },
+      }, irq.nonMaskable === true, irq.data ?? 0);
+    }
+    if (tickResult !== undefined && tickResult.stop === true) {
+      return { halted: false, pc: cpu.pc, reason: 'breakpoint', cycles: totalCycles };
+    }
+
+    if (cpu.pc >= hardware.memory.length || cpu.halted) {
+      cpu.halted = true;
+      return { halted: true, pc: cpu.pc, reason: 'halt', cycles: totalCycles };
+    }
+
+    const repeat = shouldContinueRepeatingInstruction(instructionStartPc, cpu.pc, memRead);
+    if (!repeat || iterations >= MAX_BLOCK_REPEAT_ITERATIONS) {
+      break;
+    }
   }
 
-  if (cpu.pc >= hardware.memory.length || cpu.halted) {
-    cpu.halted = true;
-    return { halted: true, pc: cpu.pc, reason: 'halt', cycles };
-  }
-
-  return { halted: false, pc: cpu.pc, reason: 'breakpoint', cycles };
+  return { halted: false, pc: cpu.pc, reason: 'breakpoint', cycles: totalCycles };
 }
 
 function runUntilStopRuntime(this: Z80RuntimeImpl, breakpoints: Set<number>): RunResult {

--- a/src/z80/runtime.ts
+++ b/src/z80/runtime.ts
@@ -240,37 +240,28 @@ function classifyStepOver(cpu: Cpu, memRead: (addr: number) => number): StepInfo
 }
 
 /**
- * ED-prefixed instructions that rewind PC to re-execute until a condition is met
- * (LDIR, CPIR, INIR, OTIR, LDDR, CPDR, INDR, OTDR). The CPU executes one transfer per
- * internal "iteration", but a single logical instruction should complete in one debugger step.
+ * ED-prefixed block-repeat opcodes: LDIR, CPIR, INIR, OTIR, LDDR, CPDR, INDR, OTDR.
+ * These rewind PC to themselves on every iteration, so one call to step() would appear
+ * stuck on the same source line until the counter exhausts. Completing them in one
+ * logical step matches user expectations for bulk operations.
  */
 const ED_BLOCK_REPEAT_SECOND = new Set<number>([
   0xb0, 0xb1, 0xb2, 0xb3, 0xb8, 0xb9, 0xba, 0xbb,
 ]);
 
-const OP_DJNZ = 0x10;
-
 /** Max inner iterations when finishing a block instruction (guards pathological loops). */
 const MAX_BLOCK_REPEAT_ITERATIONS = 0x110000;
 
-function shouldContinueRepeatingInstruction(
-  instructionStartPc: number,
-  currentPc: number,
+function isBlockRepeatInstruction(
+  pc: number,
   memRead: (addr: number) => number
 ): boolean {
-  const start = instructionStartPc & 0xffff;
-  if ((currentPc & 0xffff) !== start) {
+  const start = pc & 0xffff;
+  if ((memRead(start) & 0xff) !== OP_PREFIX_ED) {
     return false;
   }
-  const op0 = memRead(start) & 0xff;
-  if (op0 === OP_PREFIX_ED) {
-    const op1 = memRead((start + 1) & 0xffff) & 0xff;
-    return ED_BLOCK_REPEAT_SECOND.has(op1);
-  }
-  if (op0 === OP_DJNZ) {
-    return true;
-  }
-  return false;
+  const op1 = memRead((start + 1) & 0xffff) & 0xff;
+  return ED_BLOCK_REPEAT_SECOND.has(op1);
 }
 
 function stepRuntime(this: Z80RuntimeImpl, options?: { trace?: StepInfo }): RunResult {
@@ -338,7 +329,8 @@ function stepRuntime(this: Z80RuntimeImpl, options?: { trace?: StepInfo }): RunR
       return { halted: true, pc: cpu.pc, reason: 'halt', cycles: totalCycles };
     }
 
-    const repeat = shouldContinueRepeatingInstruction(instructionStartPc, cpu.pc, memRead);
+    const pcStayed = (cpu.pc & 0xffff) === instructionStartPc;
+    const repeat = pcStayed && isBlockRepeatInstruction(instructionStartPc, memRead);
     if (!repeat || iterations >= MAX_BLOCK_REPEAT_ITERATIONS) {
       break;
     }

--- a/tests/mapping/mapping-layer2.test.ts
+++ b/tests/mapping/mapping-layer2.test.ts
@@ -1,10 +1,15 @@
 import assert from 'node:assert/strict';
 import { describe, expect, it } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import type { MappingParseResult } from '../../src/mapping/parser';
 import { parseMapping } from '../../src/mapping/parser';
-import { applyLayer2 } from '../../src/mapping/layer2';
+import {
+  applyLayer2,
+  propagateMisassignedIncludeSegments,
+  remapAsm80MisassignedIncludeAnchors,
+} from '../../src/mapping/layer2';
 
 const fixtureDir = path.join(process.cwd(), 'tests', 'fixtures');
 const includeAnchorRemapDir = path.join(fixtureDir, 'include-anchor-remap');
@@ -189,6 +194,56 @@ describe('mapping-layer2', () => {
     applyLayer2(mapping, { resolvePath: resolveIncludeAnchorRemap });
     expect(mapping.anchors[0]?.file).toBe('glcd_library.z80');
     expect(mapping.anchors[0]?.line).toBe(5);
+  });
+
+  it('propagates remapped include file to every segment until the next real parent symbol', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-inc-'));
+    const pkgPath = path.join(tmp, 'packages.z80');
+    const glcdPath = path.join(tmp, 'glcd_library.z80');
+    fs.writeFileSync(
+      pkgPath,
+      ['; shim', '\t.include "glcd_library.z80"', 'REALMAIN:', '\tnop', ''].join('\n'),
+      'utf-8'
+    );
+    fs.copyFileSync(path.join(includeAnchorRemapDir, 'glcd_library.z80'), glcdPath);
+    const resolveTmp = (file: string): string | undefined => {
+      if (file === 'packages.z80') {
+        return pkgPath;
+      }
+      if (file === 'glcd_library.z80') {
+        return glcdPath;
+      }
+      return undefined;
+    };
+
+    const mapping: MappingParseResult = {
+      segments: [
+        {
+          start: 0xd802,
+          end: 0xd803,
+          loc: { file: 'packages.z80', line: 6 },
+          lst: { line: 2, text: 'nop' },
+          confidence: 'HIGH',
+        },
+        {
+          start: 0xd900,
+          end: 0xd901,
+          loc: { file: 'packages.z80', line: 3 },
+          lst: { line: 3, text: 'nop' },
+          confidence: 'HIGH',
+        },
+      ],
+      anchors: [
+        { symbol: 'INITLCD', address: 0xd800, file: 'packages.z80', line: 5 },
+        { symbol: 'REALMAIN', address: 0xd900, file: 'packages.z80', line: 3 },
+      ],
+    };
+    const remaps = remapAsm80MisassignedIncludeAnchors(mapping.anchors, resolveTmp);
+    assert.equal(remaps.length, 1);
+    propagateMisassignedIncludeSegments(mapping, remaps, resolveTmp);
+    expect(mapping.segments[0]?.loc.file).toBe('glcd_library.z80');
+    expect(mapping.segments[1]?.loc.file).toBe('packages.z80');
+    fs.rmSync(tmp, { recursive: true, force: true });
   });
 
   it('handles single-quoted strings with semicolons', () => {

--- a/tests/platforms/tec1g/glcd.test.ts
+++ b/tests/platforms/tec1g/glcd.test.ts
@@ -137,6 +137,46 @@ describe('TEC-1G GLCD instruction handling', () => {
     expect(rt.state.display.glcdCtrl.glcdScroll).toBe(10);
   });
 
+  it('GDRAM X auto-increment crosses into the lower bank (clearGrLCD pattern)', () => {
+    // This tests the ST7920 behaviour that clearGrLCD relies on:
+    //   clearGrLCD sets X=0 (0x80) and writes B=0x10 iterations × 2 bytes = 16 words per row.
+    //   Words 1-8 land at X=0-7 (upper bank, rows 0-31).
+    //   Words 9-16 land at X=8-15 (lower bank, rows 32-63).
+    // Without the fix the column counter wraps at 7 and the lower bank is never written.
+    const rt = makeRuntime();
+
+    // Fill the whole GDRAM with a sentinel so we can detect which bytes were written.
+    rt.state.display.glcdCtrl.glcd.fill(0xff);
+
+    // Enter extended graphics mode.
+    rt.ioHandlers.write(0x07, 0x36); // RE=1, G=1
+
+    // Set row 0 (Y=0), column 0 (X=0, no bank bit).
+    rt.ioHandlers.write(0x07, 0x80); // vertical Y=0
+    rt.ioHandlers.write(0x07, 0x80); // horizontal X=0, bank=0
+
+    // Write 32 bytes (16 words) of zeros — the clearGrLCD CLR_Y inner loop.
+    for (let i = 0; i < 32; i++) {
+      rt.ioHandlers.write(0x87, 0x00);
+    }
+
+    const glcd = rt.state.display.glcdCtrl.glcd;
+
+    // Upper bank (bank=0, glcdRowBase=0): row 0, cols 0-7 → bytes 0-15
+    for (let b = 0; b < 16; b++) {
+      expect(glcd[b]).toBe(0x00);
+    }
+
+    // Lower bank (bank=1, glcdRowBase=32): row 32+0=32, cols 0-7 → bytes 32*16 to 32*16+15 = 512-527
+    for (let b = 0; b < 16; b++) {
+      expect(glcd[512 + b]).toBe(0x00);
+    }
+
+    // The rest of the GDRAM should still be 0xff (not touched).
+    expect(glcd[16]).toBe(0xff);
+    expect(glcd[528]).toBe(0xff);
+  });
+
   it('shifts text after a complete DDRAM write when entry shift is enabled', () => {
     const rt = makeRuntime();
 

--- a/tests/z80/z80.test.ts
+++ b/tests/z80/z80.test.ts
@@ -83,4 +83,25 @@ describe('Z80 utilities', () => {
     assert.equal(result.reason, 'halt');
     assert.equal(runtime.getRegisters().a, 0x02);
   });
+
+  it('completes LDIR in one step (PC does not stick on the block instruction)', () => {
+    // LD HL,1000h; LD DE,1001h; LD BC,2; LD A,55h; LD (HL),A; LDIR; HALT
+    const hex = ':0F0000002100101101100102003E5577EDB0767E\n:00000001FF';
+    const program = parseIntelHex(hex);
+    const runtime = createZ80Runtime(program);
+    const mem = runtime.hardware.memory;
+
+    for (let i = 0; i < 6; i += 1) {
+      const r = runtime.step();
+      assert.equal(r.halted, false);
+    }
+    assert.equal(runtime.getPC() & 0xffff, 0x000e);
+    const last = runtime.step();
+    assert.equal(last.halted, true);
+    const regs = runtime.getRegisters();
+    assert.equal(regs.b | regs.c, 0);
+    assert.equal(mem[0x1000], 0x55);
+    assert.equal(mem[0x1001], 0x55);
+    assert.equal(mem[0x1002], 0x55);
+  });
 });


### PR DESCRIPTION
## Summary

- **ST7920 `clearGrLCD` only cleared the top half of the display** — the column auto-increment was masked to `0x07`, so it wrapped back to 0 instead of advancing to column 8 (lower chip). `clearGrLCD` deliberately writes 16 words per row to sweep both chips via auto-increment; `plotToLCD` uses only 8 words and switches banks explicitly. Storing the full 4-bit X address in `glcdCol` and capping at `0x0F` fixes both the write and read paths.

- **Step-in to GLCD routines showed `packages.z80` instead of `glcd_library.z80`** — anchor remapping corrected entry-label symbols but left every instruction segment in the include still tagged with the parent file. `propagateMisassignedIncludeSegments` retags all segments from the remap address up to the next genuine parent-file symbol. Applied in the listing path (`applyLayer2`) and the native D8 map path (`buildMappingFromListing`).

- **ED block-repeat opcodes (LDIR, LDDR, CPIR, CPDR, INIR, INDR, OTIR, OTDR) appeared stuck in the debugger** — they rewind PC to themselves each iteration, so a single `execute()` per `step()` looked like a stuck source line. `stepRuntime` now inner-loops `execute()` until PC leaves the instruction, summing cycle counts. A cap (`0x110000` iterations) guards pathological cases. **DJNZ is not** included: it is a branch, not a guaranteed-terminating bulk op; a future F10 “step over DJNZ” should use a temporary breakpoint at the fall-through address (like step-over a call), not an inner `execute` loop.