### PR TITLE
feat(extension): merge Debug80 .gitignore block on project scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ To make a folder debuggable quickly in VS Code:
 2) Type “Debug80: Create Project (config + launch)” and press Enter.
 
 This command scaffolds a built-in profile kit:
-- Creates `.vscode/debug80.json` with a default target (tries `src/main.asm`, or the first `.asm` it finds).
-- Creates `.vscode/launch.json` with a Debug80 launch configuration.
+- Creates `debug80.json` (or you may place it at `.vscode/debug80.json`) with a default target (tries `src/main.asm`, or the first `.asm` it finds).
+- Creates `.vscode/launch.json` with a Debug80 launch configuration when you choose a launch-enabled scaffold.
+- Merges a small **Debug80** block into `.gitignore` if missing: `.debug80/` cache, the default `outputDir`, `.vscode/launch.json` (local-only; the extension also contributes a default launch), and common OS junk. It does not ignore the whole `.vscode/` folder, because project config can live at `.vscode/debug80.json`.
 - Built-in kits cover Simple/default, TEC-1/MON-1B, TEC-1/Classic 2K, and TEC-1G/MON-3.
 - It does not generate `.vscode/settings.json`; the extension already contributes the relevant file associations.
 
@@ -156,8 +157,8 @@ To target a different platform (e.g., `tec1`):
 
 ## Z80 workflow
 
-1) Run “Debug80: Create Project (config + launch)” to scaffold `.vscode/debug80.json` (defaults to `targets.app` with `src/main.asm`) and `.vscode/launch.json`. The profile picker lets you choose the built-in kit before scaffolding.
-2) Start debugging with the generated debug80 launch; the adapter reads `.vscode/debug80.json`, runs `asm80` automatically using the target’s `sourceFile`/`asm`, and writes HEX/LST into `outputDir` (install `asm80` locally first). Set `assemble: false` to use pre-built artifacts instead.
+1) Run “Debug80: Create Project (config + launch)” to scaffold `debug80.json` (defaults to `targets.app` with `src/main.asm`) and, if requested, `.vscode/launch.json`. The profile picker lets you choose the built-in kit before scaffolding.
+2) Start debugging with the generated debug80 launch; the adapter reads `debug80.json` (or `.vscode/debug80.json` if you use that layout), runs `asm80` automatically using the target’s `sourceFile`/`asm`, and writes HEX/LST into `outputDir` (install `asm80` locally first). Set `assemble: false` to use pre-built artifacts instead.
 3) Set breakpoints in `.asm` files (preferred). Listing breakpoints in `.lst` still work as a fallback.
 4) Start debugging (F5). `stopOnEntry` halts on entry; Step/Continue as usual. Registers show in the Variables view.
 

--- a/src/extension/project-gitignore.ts
+++ b/src/extension/project-gitignore.ts
@@ -1,0 +1,51 @@
+/**
+ * Merges Debug80-recommended .gitignore rules into a project workspace. Kept free of
+ * vscode dependencies so it can be unit tested without a VS Code host.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const DEBUG80_GITIGNORE_BEGIN = '### Debug80 (do not remove this line) ###';
+const DEBUG80_GITIGNORE_END = '### end Debug80 ###';
+
+/**
+ * Merges a small ignore block: extension cache, default build dir, local-only launch,
+ * common junk. Idempotent. Does not ignore all of `.vscode/` (a config may
+ * live at `.vscode/debug80.json`).
+ */
+export function ensureDebug80Gitignore(workspaceRoot: string, defaultOutputDir: string): void {
+  const relOut = (defaultOutputDir || 'build').replace(/^\.\/+/, '').replace(/\/$/, '') || 'build';
+  const block = [
+    '',
+    DEBUG80_GITIGNORE_BEGIN,
+    '# Extension cache and session data',
+    '.debug80/',
+    `# Assembled output (scaffold default is "${relOut}/"; match your debug80.json outputDir)`,
+    `${relOut}/`,
+    'out/',
+    'dist/',
+    '# Optional local launch; the extension also contributes "Debug80: Current Project"',
+    '.vscode/launch.json',
+    '# OS / editor',
+    '.DS_Store',
+    'Thumbs.db',
+    DEBUG80_GITIGNORE_END,
+    '',
+  ].join('\n');
+
+  const gitignorePath = path.join(workspaceRoot, '.gitignore');
+  try {
+    if (fs.existsSync(gitignorePath)) {
+      const existing = fs.readFileSync(gitignorePath, 'utf8');
+      if (existing.includes(DEBUG80_GITIGNORE_BEGIN)) {
+        return;
+      }
+      fs.appendFileSync(gitignorePath, block, 'utf8');
+      return;
+    }
+    fs.writeFileSync(gitignorePath, block.replace(/^\n/, ''), 'utf8');
+  } catch {
+    // Best-effort; do not fail scaffold if the workspace is read-only, etc.
+  }
+}

--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -28,6 +28,7 @@ import {
   type StarterLanguage,
 } from './project-kits';
 import { materializeBundledRom } from './bundle-materialize';
+import { ensureDebug80Gitignore } from './project-gitignore';
 
 type ScaffoldPlan = {
   kit: ProjectKit;
@@ -317,6 +318,11 @@ export async function scaffoldProject(
         'Debug80: .vscode/launch.json already exists; not overwriting.'
       );
     }
+  }
+
+  if (created) {
+    const outputDirForGitignore = plan?.outputDir ?? inferred.outputDir;
+    ensureDebug80Gitignore(workspaceRoot, outputDirForGitignore);
   }
 
   return created;

--- a/tests/extension/project-scaffolding-gitignore.test.ts
+++ b/tests/extension/project-scaffolding-gitignore.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ensureDebug80Gitignore } from '../../src/extension/project-gitignore';
+
+describe('ensureDebug80Gitignore', () => {
+  it('merges a Debug80 block into .gitignore without duplicating on second run', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-gi-'));
+    try {
+      expect(fs.existsSync(path.join(root, '.gitignore'))).toBe(false);
+      ensureDebug80Gitignore(root, 'build');
+      const g1 = fs.readFileSync(path.join(root, '.gitignore'), 'utf8');
+      expect(g1).toContain('.debug80/');
+      expect(g1).toContain('build/');
+      ensureDebug80Gitignore(root, 'build');
+      const g2 = fs.readFileSync(path.join(root, '.gitignore'), 'utf8');
+      expect(g2.split('### Debug80').length - 1).toBe(1);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('appends a Debug80 block when .gitignore already has user content', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-gi-'));
+    try {
+      fs.writeFileSync(path.join(root, '.gitignore'), 'node_modules/\n', 'utf8');
+      ensureDebug80Gitignore(root, 'out');
+      const g = fs.readFileSync(path.join(root, '.gitignore'), 'utf8');
+      expect(g.startsWith('node_modules/')).toBe(true);
+      expect(g).toContain('out/');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -14,6 +14,9 @@ const { showQuickPick, showInputBox, showInformationMessage, showErrorMessage } 
 
 function defaultExistsSync(candidate: string): boolean {
   const normalized = candidate.replace(/\\/g, '/');
+  if (normalized.endsWith('/.gitignore')) {
+    return false;
+  }
   return (
     !normalized.endsWith('/debug80.json') &&
     !normalized.endsWith('/.vscode/debug80.json') &&
@@ -361,6 +364,9 @@ describe('project-scaffolding helpers', () => {
     try {
       existsSync.mockImplementation((candidate: string) => {
         const normalized = candidate.replace(/\\/g, '/');
+        if (normalized.endsWith('/.gitignore')) {
+          return false;
+        }
         return (
           !normalized.endsWith('/debug80.json') &&
           !normalized.endsWith('/.debug80.json') &&
@@ -428,6 +434,9 @@ describe('project-scaffolding helpers', () => {
     try {
       existsSync.mockImplementation((candidate: string) => {
         const normalized = candidate.replace(/\\/g, '/');
+        if (normalized.endsWith('/.gitignore')) {
+          return false;
+        }
         return (
           !normalized.endsWith('/debug80.json') &&
           !normalized.endsWith('/.debug80.json') &&


### PR DESCRIPTION
## Summary
When **Debug80: Create Project** creates `debug80.json` and optionally `.vscode/launch.json`, the extension now merges a small, idempotent **Debug80** block into `.gitignore` (if the block is not already present).

## Rules included
- `.debug80/` (extension cache)
- Default `outputDir` (e.g. `build/`), plus `out/` and `dist/`
- `.vscode/launch.json` (local-only; extension still contributes a default launch)
- `.DS_Store`, `Thumbs.db`

Does **not** ignore all of `.vscode/` so `.vscode/debug80.json` can still be committed if used.

## Files
- `src/extension/project-gitignore.ts` — implementation (no `vscode` import, unit-testable)
- `src/extension/project-scaffolding.ts` — calls `ensureDebug80Gitignore` when scaffold actually created something
- `tests/extension/project-scaffolding-gitignore.test.ts` — append / idempotency
- `tests/extension/project-scaffolding.test.ts` — mock `existsSync` for `.gitignore`
- `README.md` — scaffold + config path wording

## Testing
`npm test` (full suite) passed locally.

Made with [Cursor](https://cursor.com)