### PR TITLE
fix(webview): restore full TEC-1G display updates

### DIFF
--- a/src/extension/platform-ui-entries.ts
+++ b/src/extension/platform-ui-entries.ts
@@ -13,7 +13,6 @@ import {
 } from '../platforms/tec1/serialize-update-payload';
 import type { SimpleUiState } from '../platforms/simple/ui-panel-state';
 import {
-  serializeTec1gChangedUpdateFromUiState,
   serializeTec1gClearPanelUpdateFromUiState,
   serializeTec1gUpdateFromUiState,
 } from '../platforms/tec1g/serialize-ui-update-payload';
@@ -90,18 +89,10 @@ export function createTec1gPlatformUiEntry(): PlatformUiEntry {
         getHtml: html.getTec1gHtml,
         createUiState: state.createTec1gUiState,
         resetUiState: (uiState): void => state.resetTec1gUiState(uiState as Tec1gUiState),
-        applyUpdate: (uiState, payload, options): Record<string, unknown> => {
+        applyUpdate: (uiState, payload): Record<string, unknown> => {
           const tec1gState = uiState as Tec1gUiState;
           const tec1gPayload = payload as Parameters<typeof state.applyTec1gUpdate>[1];
-          const previous = cloneTec1gUiState(tec1gState);
           state.applyTec1gUpdate(tec1gState, tec1gPayload);
-          if (options?.forceFullUpdate !== true) {
-            return serializeTec1gChangedUpdateFromUiState(
-              previous,
-              tec1gState,
-              tec1gPayload.speakerHz
-            ) as Record<string, unknown>;
-          }
           // PlatformUiModules.applyUpdate is loosely typed; payload is TEC-1G-shaped after apply.
           return serializeTec1gUpdateFromUiState(tec1gState, tec1gPayload.speakerHz) as unknown as Record<
             string,
@@ -126,45 +117,6 @@ export function createTec1gPlatformUiEntry(): PlatformUiEntry {
         snapshotCommand: 'debug80/memorySnapshot',
       };
     },
-  };
-}
-
-function cloneTec1gUiState<T extends {
-  digits: number[];
-  matrix: number[];
-  matrixGreen: number[];
-  matrixBlue: number[];
-  matrixBrightness: number[];
-  matrixBrightnessG: number[];
-  matrixBrightnessB: number[];
-  matrixMode: boolean;
-  glcd: number[];
-  glcdDdram: number[];
-  glcdState: Record<string, boolean | number>;
-  speaker: boolean;
-  speedMode: unknown;
-  sysCtrlValue: number;
-  bankA14: boolean;
-  capsLock: boolean;
-  lcdState: Record<string, boolean | number>;
-  lcdCgram: number[];
-  lcd: number[];
-}>(state: T): T {
-  return {
-    ...state,
-    digits: [...state.digits],
-    matrix: [...state.matrix],
-    matrixGreen: [...state.matrixGreen],
-    matrixBlue: [...state.matrixBlue],
-    matrixBrightness: [...state.matrixBrightness],
-    matrixBrightnessG: [...state.matrixBrightnessG],
-    matrixBrightnessB: [...state.matrixBrightnessB],
-    glcd: [...state.glcd],
-    glcdDdram: [...state.glcdDdram],
-    glcdState: { ...state.glcdState },
-    lcdState: { ...state.lcdState },
-    lcdCgram: [...state.lcdCgram],
-    lcd: [...state.lcd],
   };
 }
 

--- a/src/extension/platform-view-manifest.ts
+++ b/src/extension/platform-view-manifest.ts
@@ -24,11 +24,7 @@ export interface PlatformUiModules<TUiState = unknown> {
   getHtml: (tab: PanelTab, webview: vscode.Webview, extensionUri: vscode.Uri) => string;
   createUiState: () => TUiState;
   resetUiState: (state: TUiState) => void;
-  applyUpdate: (
-    state: TUiState,
-    payload: unknown,
-    options?: { forceFullUpdate?: boolean }
-  ) => Record<string, unknown>;
+  applyUpdate: (state: TUiState, payload: unknown) => Record<string, unknown>;
   createMemoryViewState: () => MemoryViewState;
   handleMessage: (
     message: PlatformViewMessage,

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -220,10 +220,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     if (bundle === undefined) {
       return;
     }
-    const forceFullUpdate = !bundle.state.hasPostedRuntimeUpdate;
-    const updateFields = bundle.modules.applyUpdate(bundle.state.uiState, payload, {
-      forceFullUpdate,
-    });
+    const updateFields = bundle.modules.applyUpdate(bundle.state.uiState, payload);
     bundle.state.hasPostedRuntimeUpdate = true;
     this.postMessage({ type: 'update', uiRevision: this.nextUiRevision(), ...updateFields });
   }

--- a/src/platforms/tec1g/serialize-ui-update-payload.ts
+++ b/src/platforms/tec1g/serialize-ui-update-payload.ts
@@ -40,78 +40,6 @@ export function serializeTec1gUpdateFromUiState(state: Tec1gUiState, speakerHz?:
 }
 
 /**
- * Snapshot payload containing only fields that changed between two retained UI states.
- */
-export function serializeTec1gChangedUpdateFromUiState(
-  previous: Tec1gUiState,
-  next: Tec1gUiState,
-  speakerHz?: number
-): Partial<Tec1gUpdatePayload> {
-  const payload: Partial<Tec1gUpdatePayload> = {};
-  if (!arraysEqual(previous.digits, next.digits)) {
-    payload.digits = [...next.digits];
-  }
-  if (!arraysEqual(previous.matrix, next.matrix)) {
-    payload.matrix = [...next.matrix];
-  }
-  if (!arraysEqual(previous.matrixGreen, next.matrixGreen)) {
-    payload.matrixGreen = [...next.matrixGreen];
-  }
-  if (!arraysEqual(previous.matrixBlue, next.matrixBlue)) {
-    payload.matrixBlue = [...next.matrixBlue];
-  }
-  if (!arraysEqual(previous.matrixBrightness, next.matrixBrightness)) {
-    payload.matrixBrightness = [...next.matrixBrightness];
-  }
-  if (!arraysEqual(previous.matrixBrightnessG, next.matrixBrightnessG)) {
-    payload.matrixBrightnessG = [...next.matrixBrightnessG];
-  }
-  if (!arraysEqual(previous.matrixBrightnessB, next.matrixBrightnessB)) {
-    payload.matrixBrightnessB = [...next.matrixBrightnessB];
-  }
-  if (previous.matrixMode !== next.matrixMode) {
-    payload.matrixMode = next.matrixMode;
-  }
-  if (!arraysEqual(previous.glcd, next.glcd)) {
-    payload.glcd = [...next.glcd];
-  }
-  if (!arraysEqual(previous.glcdDdram, next.glcdDdram)) {
-    payload.glcdDdram = [...next.glcdDdram];
-  }
-  if (!objectsEqual(previous.glcdState, next.glcdState)) {
-    payload.glcdState = { ...next.glcdState };
-  }
-  if (previous.sysCtrlValue !== next.sysCtrlValue) {
-    payload.sysCtrl = next.sysCtrlValue;
-  }
-  if (previous.bankA14 !== next.bankA14) {
-    payload.bankA14 = next.bankA14;
-  }
-  if (previous.capsLock !== next.capsLock) {
-    payload.capsLock = next.capsLock;
-  }
-  if (!objectsEqual(previous.lcdState, next.lcdState)) {
-    payload.lcdState = { ...next.lcdState };
-  }
-  if (!arraysEqual(previous.lcdCgram, next.lcdCgram)) {
-    payload.lcdCgram = [...next.lcdCgram];
-  }
-  if (previous.speaker !== next.speaker) {
-    payload.speaker = next.speaker ? 1 : 0;
-  }
-  if (previous.speedMode !== next.speedMode) {
-    payload.speedMode = next.speedMode;
-  }
-  if (!arraysEqual(previous.lcd, next.lcd)) {
-    payload.lcd = [...next.lcd];
-  }
-  if (speakerHz !== undefined) {
-    payload.speakerHz = speakerHz;
-  }
-  return payload;
-}
-
-/**
  * Partial update when clearing serial / resetting speaker (matches legacy sidebar clear payload).
  */
 export function serializeTec1gClearPanelUpdateFromUiState(state: Tec1gUiState): Tec1gUpdatePayload {
@@ -133,32 +61,6 @@ export function serializeTec1gClearPanelUpdateFromUiState(state: Tec1gUiState): 
 /** Type guard for TEC-1G speed mode literals in unknown event data. */
 function isTec1gSpeedMode(value: unknown): value is Tec1gSpeedMode {
   return value === 'slow' || value === 'fast';
-}
-
-/** Returns true when two numeric arrays have identical contents. */
-function arraysEqual(left: readonly number[], right: readonly number[]): boolean {
-  if (left.length !== right.length) {
-    return false;
-  }
-  for (let i = 0; i < left.length; i += 1) {
-    if (left[i] !== right[i]) {
-      return false;
-    }
-  }
-  return true;
-}
-
-/** Returns true when two flat state objects have identical primitive fields. */
-function objectsEqual(
-  left: Record<string, boolean | number>,
-  right: Record<string, boolean | number>
-): boolean {
-  const leftKeys = Object.keys(left);
-  const rightKeys = Object.keys(right);
-  if (leftKeys.length !== rightKeys.length) {
-    return false;
-  }
-  return leftKeys.every((key) => left[key] === right[key]);
 }
 
 /** True when `value` is an array of numbers (for DAP event body parsing). */

--- a/tests/extension/platform-view-provider.test.ts
+++ b/tests/extension/platform-view-provider.test.ts
@@ -915,7 +915,7 @@ describe('PlatformViewProvider', () => {
     expect(update?.speakerHz).toBe(payload.speakerHz);
   });
 
-  it('posts only changed Tec1g display fields after the first full update', async () => {
+  it('posts full Tec1g display fields on every runtime update', async () => {
     const provider = new PlatformViewProvider(extensionRoot);
     const webviewView = createWebviewView();
     await provider.resolveWebviewView(
@@ -950,11 +950,13 @@ describe('PlatformViewProvider', () => {
     expect(updateCalls[0]?.[0].glcd).toEqual(firstPayload.glcd);
     expect(updateCalls[1]?.[0]).toMatchObject({
       type: 'update',
+      digits: firstPayload.digits,
+      matrix: firstPayload.matrix,
       matrixGreen: [0x11, 0, 0, 0, 0, 0, 0, 0],
+      matrixBlue: firstPayload.matrixBlue,
+      glcd: firstPayload.glcd,
+      lcd: firstPayload.lcd,
     });
-    expect(updateCalls[1]?.[0]).not.toHaveProperty('glcd');
-    expect(updateCalls[1]?.[0]).not.toHaveProperty('lcd');
-    expect(updateCalls[1]?.[0]).not.toHaveProperty('matrix');
   });
 
   it('routes configureProject messages as a no-op (Config tab removed)', async () => {

--- a/tests/platforms/serialize-update-payload.test.ts
+++ b/tests/platforms/serialize-update-payload.test.ts
@@ -13,7 +13,6 @@ import { createTec1Runtime, normalizeTec1Config } from '../../src/platforms/tec1
 import { createTec1UiState } from '../../src/platforms/tec1/ui-panel-state';
 import { serializeTec1gUpdateFromRuntimeState } from '../../src/platforms/tec1g/update-controller';
 import {
-  serializeTec1gChangedUpdateFromUiState,
   serializeTec1gClearPanelUpdateFromUiState,
   serializeTec1gUpdateFromUiState,
   tec1gUpdatePayloadFromDebugEventBody,
@@ -101,22 +100,5 @@ describe('TEC-1G update payload serialization', () => {
 
   it('exports runtime serializer used by update controller', () => {
     expect(typeof serializeTec1gUpdateFromRuntimeState).toBe('function');
-  });
-
-  it('serializes only changed TEC-1G fields for runtime updates', () => {
-    const previous = createTec1gUiState();
-    const next = createTec1gUiState();
-    next.matrixGreen[0] = 0x12;
-    next.glcd[10] = 0x34;
-    next.speaker = true;
-
-    const changed = serializeTec1gChangedUpdateFromUiState(previous, next, 880);
-
-    expect(changed).toEqual({
-      matrixGreen: next.matrixGreen,
-      glcd: next.glcd,
-      speaker: 1,
-      speakerHz: 880,
-    });
   });
 });

--- a/tests/webview/tec1g-platform-update.test.ts
+++ b/tests/webview/tec1g-platform-update.test.ts
@@ -47,4 +47,22 @@ describe('tec1g platform update application', () => {
 
     expect(deps.display.applyDigits).toHaveBeenCalledWith([1, 2, 3, 4, 5, 6]);
   });
+
+  it('applies partial brightness updates when only green or blue changes', () => {
+    const deps = makeDeps();
+
+    applyTec1gPlatformUpdate(deps, {
+      matrixBrightnessG: [128],
+    });
+
+    expect(deps.matrixUi.applyMatrixBrightness).toHaveBeenCalledWith(undefined, [128], undefined);
+
+    deps.matrixUi.applyMatrixBrightness.mockClear();
+
+    applyTec1gPlatformUpdate(deps, {
+      matrixBrightnessB: [64],
+    });
+
+    expect(deps.matrixUi.applyMatrixBrightness).toHaveBeenCalledWith(undefined, undefined, [64]);
+  });
 });

--- a/webview/tec1g/tec1g-platform-update.ts
+++ b/webview/tec1g/tec1g-platform-update.ts
@@ -47,9 +47,13 @@ export function applyTec1gPlatformUpdate(deps: Tec1gPlatformUpdateDeps, payload:
   if (Array.isArray(data.matrixBlue)) {
     deps.matrixUi.applyMatrixBlueRows(data.matrixBlue);
   }
-  if (Array.isArray(data.matrixBrightness)) {
+  if (
+    Array.isArray(data.matrixBrightness) ||
+    Array.isArray(data.matrixBrightnessG) ||
+    Array.isArray(data.matrixBrightnessB)
+  ) {
     deps.matrixUi.applyMatrixBrightness(
-      data.matrixBrightness,
+      Array.isArray(data.matrixBrightness) ? data.matrixBrightness : undefined,
       Array.isArray(data.matrixBrightnessG) ? data.matrixBrightnessG : undefined,
       Array.isArray(data.matrixBrightnessB) ? data.matrixBrightnessB : undefined
     );


### PR DESCRIPTION
## Summary
- removes the #382 TEC-1G changed-field display update optimization
- restores full TEC-1G runtime display payloads on every update so RGB planes stay coherent
- keeps a defensive webview regression test for partial brightness payloads, but normal matrix frames are full updates again
- does not change runtime matrix scan/staging/commit behavior

## Root cause
The new diffed TEC-1G update path could deliver independent RGB brightness-plane updates to the webview. That made the 8x8 display vulnerable to mixed old/new RGB state, visible as pieces changing color or frames appearing stale while the game continued running.

## Verification
- npx vitest run tests/extension/platform-view-provider.test.ts tests/platforms/serialize-update-payload.test.ts tests/platforms/tec1g/matrix.test.ts
- npm run test:webview -- tests/webview/tec1g-platform-update.test.ts tests/webview/tec1g-matrix-ui.test.ts
- npm run typecheck
- npm run typecheck:webview
- git diff --check