### PR TITLE
fix(webview): keep registers refreshing without memory panel

### DIFF
--- a/tests/webview/common/accordion-layout.test.ts
+++ b/tests/webview/common/accordion-layout.test.ts
@@ -28,7 +28,10 @@ describe('accordion layout controller', () => {
   it('defaults to machine and registers open and persists toggled sections', () => {
     const messages: PostedMessage[] = [];
     const memoryPanel = document.createElement('div');
-    const memoryController = { requestSnapshot: () => {} } as unknown as MemoryPanel;
+    const memoryController = {
+      requestSnapshot: () => {},
+      requestRegisterSnapshot: () => {},
+    } as unknown as MemoryPanel;
     const registersButton = button('registers');
     const memoryButton = button('memory');
     const vscode = createVscodeMock(messages);
@@ -101,11 +104,12 @@ describe('accordion layout controller', () => {
     expect(controller.getProviderTab()).toBe('memory');
   });
 
-  it('does not request memory snapshots when only registers are opened', () => {
+  it('requests a register snapshot when registers are opened without activating memory', () => {
     const messages: PostedMessage[] = [];
     const memoryPanel = document.createElement('div');
     const requestSnapshot = vi.fn();
-    const memoryController = { requestSnapshot } as unknown as MemoryPanel;
+    const requestRegisterSnapshot = vi.fn();
+    const memoryController = { requestSnapshot, requestRegisterSnapshot } as unknown as MemoryPanel;
     const registersButton = button('registers');
     const memoryButton = button('memory');
     const vscode = createVscodeMock(messages, {
@@ -135,11 +139,13 @@ describe('accordion layout controller', () => {
     expect(controller.isMemoryOpen()).toBe(false);
     expect(controller.getProviderTab()).toBe('ui');
     expect(requestSnapshot).not.toHaveBeenCalled();
+    expect(requestRegisterSnapshot).toHaveBeenCalledTimes(1);
 
     memoryButton.click();
     expect(controller.isMemoryOpen()).toBe(true);
     expect(controller.getProviderTab()).toBe('memory');
     expect(requestSnapshot).toHaveBeenCalledTimes(1);
+    expect(requestRegisterSnapshot).toHaveBeenCalledTimes(1);
   });
 
   it('closes memory when the provider selects the UI tab', () => {
@@ -149,7 +155,10 @@ describe('accordion layout controller', () => {
     const memoryContent = document.createElement('div');
     const memoryButton = button('memory');
     const requestSnapshot = vi.fn();
-    const memoryController = { requestSnapshot } as unknown as MemoryPanel;
+    const memoryController = {
+      requestSnapshot,
+      requestRegisterSnapshot: () => {},
+    } as unknown as MemoryPanel;
     const vscode = createVscodeMock(messages, {
       debug80Accordion: {
         machine: true,

--- a/tests/webview/common/accordion-layout.test.ts
+++ b/tests/webview/common/accordion-layout.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createAccordionLayoutController } from '../../../webview/common/accordion-layout';
 import type { MemoryPanel } from '../../../webview/common/memory-panel';
 import type { VscodeApi } from '../../../webview/common/vscode';
@@ -25,6 +25,10 @@ function createVscodeMock(messages: PostedMessage[], initialState: unknown = nul
 }
 
 describe('accordion layout controller', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('defaults to machine and registers open and persists toggled sections', () => {
     const messages: PostedMessage[] = [];
     const memoryPanel = document.createElement('div');
@@ -200,5 +204,49 @@ describe('accordion layout controller', () => {
         memory: false,
       },
     });
+  });
+
+  it('polls registers while registers are open and memory is closed', () => {
+    vi.useFakeTimers();
+    const messages: PostedMessage[] = [];
+    const memoryPanel = document.createElement('div');
+    const requestSnapshot = vi.fn();
+    const requestRegisterSnapshot = vi.fn();
+    const memoryController = { requestSnapshot, requestRegisterSnapshot } as unknown as MemoryPanel;
+    const memoryButton = button('memory');
+    const vscode = createVscodeMock(messages, {
+      debug80Accordion: {
+        machine: true,
+        registers: true,
+        memory: false,
+      },
+    });
+
+    const controller = createAccordionLayoutController({
+      vscode,
+      buttons: [button('machine'), button('registers'), memoryButton],
+      panels: {
+        machine: document.createElement('div'),
+        registers: document.createElement('div'),
+        memory: document.createElement('div'),
+      },
+      memoryPanel,
+      defaultTab: 'ui',
+      getMemoryPanelController: () => memoryController,
+    });
+    controller.wireButtons();
+
+    controller.setRegisterRefreshActive(true);
+    expect(requestRegisterSnapshot).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1000);
+    expect(requestRegisterSnapshot).toHaveBeenCalledTimes(3);
+    expect(requestSnapshot).not.toHaveBeenCalled();
+
+    memoryButton.click();
+    expect(requestSnapshot).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1000);
+    expect(requestRegisterSnapshot).toHaveBeenCalledTimes(3);
   });
 });

--- a/tests/webview/common/memory-panel.test.ts
+++ b/tests/webview/common/memory-panel.test.ts
@@ -19,7 +19,7 @@ function createElement<T extends HTMLElement>(
   return element;
 }
 
-function createPanel(vscode: VscodeApi, options: { withShell?: boolean } = {}) {
+function createPanel(vscode: VscodeApi, options: { withShell?: boolean; active?: boolean } = {}) {
   const registerStrip = createElement<HTMLDivElement>('div');
   const statusEl = createElement<HTMLDivElement>('div');
   const dump = createElement<HTMLDivElement>('div');
@@ -69,7 +69,7 @@ function createPanel(vscode: VscodeApi, options: { withShell?: boolean } = {}) {
       },
     ],
     getRowSize: () => 8,
-    isActive: () => true,
+    isActive: () => options.active ?? true,
   });
 
   panel.wire();
@@ -171,6 +171,23 @@ describe('shared memory panel', () => {
       type: 'refresh',
       rowSize: 8,
       views: [{ id: 'a', view: 'sp', after: 16, address: undefined }],
+    });
+  });
+
+  it('can request a register-only snapshot while the memory panel is inactive', () => {
+    const postMessage = vi.fn();
+    const { panel } = createPanel({
+      postMessage,
+      getState: vi.fn(),
+      setState: vi.fn(),
+    }, { active: false });
+
+    panel.requestRegisterSnapshot();
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'refresh',
+      rowSize: 8,
+      views: [],
     });
   });
 

--- a/webview/common/accordion-layout.ts
+++ b/webview/common/accordion-layout.ts
@@ -23,6 +23,7 @@ export type AccordionLayoutController = {
   isMachineOpen: () => boolean;
   isCpuOpen: () => boolean;
   isMemoryOpen: () => boolean;
+  refreshOpenRegisters: () => void;
   setProviderTab: (tab: string, notify: boolean) => void;
   scheduleMemoryResize: () => void;
   updateMemoryLayout: (forceRefresh: boolean) => void;
@@ -142,6 +143,12 @@ export function createAccordionLayoutController(
     }
   }
 
+  function refreshOpenRegisters(): void {
+    if (openState.registers) {
+      options.getMemoryPanelController()?.requestRegisterSnapshot();
+    }
+  }
+
   function setOpen(panel: AccordionPanel, open: boolean, notify: boolean): void {
     openState[panel] = open;
     applyPanelState(panel);
@@ -149,6 +156,9 @@ export function createAccordionLayoutController(
     syncProviderTab(notify);
     if (panel === 'memory' && open) {
       updateMemoryLayout(true);
+    }
+    if (panel === 'registers' && open) {
+      refreshOpenRegisters();
     }
   }
 
@@ -175,6 +185,7 @@ export function createAccordionLayoutController(
     isMachineOpen: () => openState.machine,
     isCpuOpen: () => openState.registers || openState.memory,
     isMemoryOpen: () => openState.memory,
+    refreshOpenRegisters,
     setProviderTab,
     scheduleMemoryResize(): void {
       if (resizeTimer !== null) {

--- a/webview/common/accordion-layout.ts
+++ b/webview/common/accordion-layout.ts
@@ -24,6 +24,7 @@ export type AccordionLayoutController = {
   isCpuOpen: () => boolean;
   isMemoryOpen: () => boolean;
   refreshOpenRegisters: () => void;
+  setRegisterRefreshActive: (active: boolean) => void;
   setProviderTab: (tab: string, notify: boolean) => void;
   scheduleMemoryResize: () => void;
   updateMemoryLayout: (forceRefresh: boolean) => void;
@@ -32,6 +33,7 @@ export type AccordionLayoutController = {
 
 const MEMORY_NARROW_MAX = 480;
 const MEMORY_WIDE_MIN = 520;
+const REGISTER_REFRESH_INTERVAL_MS = 500;
 const DEFAULT_OPEN_STATE: Record<AccordionPanel, boolean> = {
   machine: true,
   registers: true,
@@ -96,6 +98,8 @@ export function createAccordionLayoutController(
   let providerTab: ProviderPanelTab = openState.memory ? 'memory' : 'ui';
   let memoryRowSize = 16;
   let resizeTimer: number | null = null;
+  let registerRefreshActive = false;
+  let registerRefreshTimer: number | null = null;
 
   function getContent(panel: AccordionPanel): HTMLElement | null {
     return options.panels[panel] ?? null;
@@ -149,6 +153,27 @@ export function createAccordionLayoutController(
     }
   }
 
+  function syncRegisterRefresh(): void {
+    const shouldRefresh = registerRefreshActive && openState.registers && !openState.memory;
+    if (!shouldRefresh) {
+      if (registerRefreshTimer !== null) {
+        clearInterval(registerRefreshTimer);
+        registerRefreshTimer = null;
+      }
+      return;
+    }
+    if (registerRefreshTimer !== null) {
+      return;
+    }
+    refreshOpenRegisters();
+    registerRefreshTimer = window.setInterval(refreshOpenRegisters, REGISTER_REFRESH_INTERVAL_MS);
+  }
+
+  function setRegisterRefreshActive(active: boolean): void {
+    registerRefreshActive = active;
+    syncRegisterRefresh();
+  }
+
   function setOpen(panel: AccordionPanel, open: boolean, notify: boolean): void {
     openState[panel] = open;
     applyPanelState(panel);
@@ -160,6 +185,7 @@ export function createAccordionLayoutController(
     if (panel === 'registers' && open) {
       refreshOpenRegisters();
     }
+    syncRegisterRefresh();
   }
 
   function setProviderTab(tab: string, notify: boolean): void {
@@ -173,6 +199,7 @@ export function createAccordionLayoutController(
     applyPanelState('memory');
     writeStoredOpenState(options.vscode, openState);
     syncProviderTab(notify);
+    syncRegisterRefresh();
   }
 
   (Object.keys(openState) as AccordionPanel[]).forEach(applyPanelState);
@@ -186,6 +213,7 @@ export function createAccordionLayoutController(
     isCpuOpen: () => openState.registers || openState.memory,
     isMemoryOpen: () => openState.memory,
     refreshOpenRegisters,
+    setRegisterRefreshActive,
     setProviderTab,
     scheduleMemoryResize(): void {
       if (resizeTimer !== null) {

--- a/webview/common/memory-panel.ts
+++ b/webview/common/memory-panel.ts
@@ -100,8 +100,20 @@ export class MemoryPanel {
     if (!this.options.isActive()) {
       return;
     }
-    const rowSize = this.options.getRowSize();
-    const payloadViews = this.options.views.map((entry) => {
+    this.postSnapshotRequest(this.buildMemoryViewRequests());
+  }
+
+  requestRegisterSnapshot(): void {
+    this.postSnapshotRequest([]);
+  }
+
+  private buildMemoryViewRequests(): Array<{
+    id: string;
+    view: string;
+    after: number;
+    address: number | undefined;
+  }> {
+    return this.options.views.map((entry) => {
       const anchor = this.resolveAnchor(entry);
       const viewMode = anchor.view;
       let addressValue = anchor.address;
@@ -119,6 +131,17 @@ export class MemoryPanel {
         address: addressValue,
       };
     });
+  }
+
+  private postSnapshotRequest(
+    payloadViews: Array<{
+      id: string;
+      view: string;
+      after: number;
+      address: number | undefined;
+    }>
+  ): void {
+    const rowSize = this.options.getRowSize();
     this.options.vscode.postMessage({
       type: 'refresh',
       rowSize,

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -249,6 +249,9 @@ window.addEventListener('message', event => {
   }
   if (event.data.type === 'sessionStatus') {
     sessionStatusController.setStatus(event.data.status);
+    if (event.data.status === 'running' || event.data.status === 'paused') {
+      panelLayout.refreshOpenRegisters();
+    }
     return;
   }
   if (event.data.type === 'selectTab') {

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -249,9 +249,7 @@ window.addEventListener('message', event => {
   }
   if (event.data.type === 'sessionStatus') {
     sessionStatusController.setStatus(event.data.status);
-    if (event.data.status === 'running' || event.data.status === 'paused') {
-      panelLayout.refreshOpenRegisters();
-    }
+    panelLayout.setRegisterRefreshActive(event.data.status === 'running' || event.data.status === 'paused');
     return;
   }
   if (event.data.type === 'selectTab') {
@@ -288,6 +286,7 @@ panelLayout.setProviderTab(DEFAULT_TAB, false);
 vscode.postMessage({ type: 'tab', tab: panelLayout.getProviderTab() });
 keypad.focusKeypad();
 sessionStatusController.setStatus('not running');
+panelLayout.setRegisterRefreshActive(false);
 window.addEventListener('resize', () => panelLayout.scheduleMemoryResize());
 panelLayout.updateMemoryLayout(false);
 

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -233,9 +233,7 @@ window.addEventListener('message', (event: MessageEvent<IncomingMessage | undefi
   }
   if (message.type === 'sessionStatus') {
     sessionStatusController.setStatus(message.status);
-    if (message.status === 'running' || message.status === 'paused') {
-      panelLayout.refreshOpenRegisters();
-    }
+    panelLayout.setRegisterRefreshActive(message.status === 'running' || message.status === 'paused');
     return;
   }
   if (message.type === 'selectTab') {
@@ -277,6 +275,7 @@ panelLayout.setProviderTab(DEFAULT_TAB, false);
 vscode.postMessage({ type: 'tab', tab: panelLayout.getProviderTab() });
 keypad.focusKeypad();
 sessionStatusController.setStatus('not running');
+panelLayout.setRegisterRefreshActive(false);
 window.addEventListener('resize', () => {
   panelLayout.scheduleMemoryResize();
 });

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -233,6 +233,9 @@ window.addEventListener('message', (event: MessageEvent<IncomingMessage | undefi
   }
   if (message.type === 'sessionStatus') {
     sessionStatusController.setStatus(message.status);
+    if (message.status === 'running' || message.status === 'paused') {
+      panelLayout.refreshOpenRegisters();
+    }
     return;
   }
   if (message.type === 'selectTab') {


### PR DESCRIPTION
## Summary
- refresh registers with a register-only snapshot when the Registers accordion opens
- keep a lightweight register refresh loop active while Registers is open and Memory is closed
- stop the register-only loop when Memory opens, because memory snapshots already include registers

## Verification
- npm run test:webview -- tests/webview/common/accordion-layout.test.ts tests/webview/common/memory-panel.test.ts tests/webview/session-status.test.ts
- npm run typecheck
- npm run typecheck:webview