### PR TITLE
[codex] Fix target discovery and restart project selection

### DIFF
--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -45,6 +45,7 @@ import {
   maybeAutoStartSingleTargetForRootChange,
   resolveProjectPlatformForFolder,
   resolveSessionProjectConfigPath,
+  resolveSessionWorkspaceFolder,
 } from './debug-session-actions';
 import { openProjectConfigPanel } from './project-config-panel';
 
@@ -256,17 +257,25 @@ export function registerExtensionCommands({
 
   context.subscriptions.push(
     vscode.commands.registerCommand('debug80.restartDebug', async () => {
-      const folder = await workspaceSelection.resolveWorkspaceFolder({
-        prompt: true,
-        requireProject: true,
-        placeHolder: 'Select the Debug80 project folder to debug',
-      });
+      const activeSession = vscode.debug.activeDebugSession;
+      const folder =
+        activeSession?.type === 'z80'
+          ? resolveSessionWorkspaceFolder(activeSession) ??
+            (await workspaceSelection.resolveWorkspaceFolder({
+              prompt: true,
+              requireProject: true,
+              placeHolder: 'Select the Debug80 project folder to debug',
+            }))
+          : await workspaceSelection.resolveWorkspaceFolder({
+              prompt: true,
+              requireProject: true,
+              placeHolder: 'Select the Debug80 project folder to debug',
+            });
       if (!folder) {
         void vscode.window.showInformationMessage('Debug80: No configured Debug80 project found.');
         return false;
       }
 
-      const activeSession = vscode.debug.activeDebugSession;
       if (activeSession?.type === 'z80') {
         await vscode.debug.stopDebugging(activeSession);
       }

--- a/src/extension/debug-session-actions.ts
+++ b/src/extension/debug-session-actions.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import {
   findProjectConfigPath,
+  isInitializedDebug80Project,
   readProjectConfig,
   resolveProjectPlatform,
 } from './project-config';
@@ -100,4 +101,32 @@ export function resolveSessionProjectConfigPath(session: vscode.DebugSession): s
         ? path.join(session.workspaceFolder.uri.fsPath, projectConfigRaw)
         : projectConfigRaw
   );
+}
+
+export function resolveSessionWorkspaceFolder(
+  session: vscode.DebugSession
+): vscode.WorkspaceFolder | undefined {
+  const projectConfigPath = resolveSessionProjectConfigPath(session);
+  if (projectConfigPath === undefined) {
+    const sessionFolder = session.workspaceFolder;
+    return sessionFolder !== undefined && isInitializedDebug80Project(sessionFolder)
+      ? sessionFolder
+      : undefined;
+  }
+
+  const sessionFolder = session.workspaceFolder;
+  const sessionProjectConfig =
+    sessionFolder !== undefined ? findProjectConfigPath(sessionFolder) : undefined;
+  if (
+    sessionFolder !== undefined &&
+    sessionProjectConfig !== undefined &&
+    path.normalize(sessionProjectConfig) === projectConfigPath
+  ) {
+    return sessionFolder;
+  }
+
+  return (vscode.workspace.workspaceFolders ?? []).find((folder) => {
+    const candidate = findProjectConfigPath(folder);
+    return candidate !== undefined && path.normalize(candidate) === projectConfigPath;
+  });
 }

--- a/src/extension/project-config.ts
+++ b/src/extension/project-config.ts
@@ -347,22 +347,20 @@ export function updateProjectTargetSource(
 
 export function listProjectSourceFiles(rootPath: string): string[] {
   const results: string[] = [];
-  collectProjectSourceFiles(rootPath, rootPath, results);
+  const sourceRoot = path.join(rootPath, 'src');
+  const scanRoot = fs.existsSync(sourceRoot) && fs.statSync(sourceRoot).isDirectory()
+    ? sourceRoot
+    : rootPath;
+  collectProjectSourceFiles(rootPath, scanRoot, results);
   results.sort((left, right) => left.localeCompare(right));
   return results;
 }
-
-const SKIP_DIRS = new Set(['.git', '.vscode', 'node_modules', 'out', 'dist', 'build', 'coverage', 'roms']);
 
 function collectProjectSourceFiles(rootPath: string, currentPath: string, results: string[]): void {
   const entries = fs.readdirSync(currentPath, { withFileTypes: true });
   for (const entry of entries) {
     const fullPath = path.join(currentPath, entry.name);
     if (entry.isDirectory()) {
-      if (SKIP_DIRS.has(entry.name)) {
-        continue;
-      }
-      collectProjectSourceFiles(rootPath, fullPath, results);
       continue;
     }
 

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -1167,6 +1167,259 @@ describe('registerExtensionCommands', () => {
     );
   });
 
+  it('restarts the active z80 session from its session project without prompting for a project', async () => {
+    const vscode = await import('vscode');
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    const tetroRoot = '/workspace/tetro';
+    const otherRoot = '/workspace/other';
+    const tetroConfigPath = path.normalize(`${tetroRoot}/debug80.json`);
+    workspaceFolders = [
+      { name: 'other', uri: { fsPath: otherRoot }, index: 0 },
+      { name: 'tetro', uri: { fsPath: tetroRoot }, index: 1 },
+    ];
+    existsSync.mockImplementation((candidate: string) => {
+      const normalized = path.normalize(candidate);
+      return (
+        normalized === tetroConfigPath ||
+        normalized === path.normalize(`${otherRoot}/debug80.json`) ||
+        /\.(asm|zax)$/i.test(normalized)
+      );
+    });
+    const resolveWorkspaceFolder = vi.fn();
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder,
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {} as never,
+    });
+
+    const restartDebug = registeredCommands.get('debug80.restartDebug');
+    expect(restartDebug).toBeTypeOf('function');
+
+    startDebugging.mockResolvedValueOnce(true);
+    stopDebugging.mockResolvedValueOnce(undefined);
+    (vscode.debug as { activeDebugSession?: unknown }).activeDebugSession = {
+      type: 'z80',
+      id: 'session-tetro',
+      configuration: { projectConfig: tetroConfigPath },
+      workspaceFolder: { uri: { fsPath: tetroRoot } },
+    };
+
+    const result = await restartDebug?.();
+
+    expect(result).toBe(true);
+    expect(resolveWorkspaceFolder).not.toHaveBeenCalled();
+    expect(stopDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'z80', id: 'session-tetro' })
+    );
+    expect(startDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: { fsPath: tetroRoot } }),
+      expect.objectContaining({
+        type: 'z80',
+        request: 'launch',
+        projectConfig: tetroConfigPath,
+      })
+    );
+  });
+
+  it('recovers the restart project from open workspace folders when the active session folder is wrong', async () => {
+    const vscode = await import('vscode');
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    const staleRoot = '/workspace/stale';
+    const tetroRoot = '/workspace/tetro';
+    const tetroConfigPath = path.normalize(`${tetroRoot}/debug80.json`);
+    workspaceFolders = [
+      { name: 'stale', uri: { fsPath: staleRoot }, index: 0 },
+      { name: 'tetro', uri: { fsPath: tetroRoot }, index: 1 },
+    ];
+    existsSync.mockImplementation((candidate: string) => {
+      const normalized = path.normalize(candidate);
+      return (
+        normalized === tetroConfigPath ||
+        normalized === path.normalize(`${staleRoot}/debug80.json`) ||
+        /\.(asm|zax)$/i.test(normalized)
+      );
+    });
+    const resolveWorkspaceFolder = vi.fn();
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder,
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {} as never,
+    });
+
+    const restartDebug = registeredCommands.get('debug80.restartDebug');
+    expect(restartDebug).toBeTypeOf('function');
+
+    startDebugging.mockResolvedValueOnce(true);
+    stopDebugging.mockResolvedValueOnce(undefined);
+    (vscode.debug as { activeDebugSession?: unknown }).activeDebugSession = {
+      type: 'z80',
+      id: 'session-stale-folder',
+      configuration: { projectConfig: tetroConfigPath },
+      workspaceFolder: { uri: { fsPath: staleRoot } },
+    };
+
+    const result = await restartDebug?.();
+
+    expect(result).toBe(true);
+    expect(resolveWorkspaceFolder).not.toHaveBeenCalled();
+    expect(startDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: { fsPath: tetroRoot } }),
+      expect.objectContaining({
+        type: 'z80',
+        request: 'launch',
+        projectConfig: tetroConfigPath,
+      })
+    );
+  });
+
+  it('prompts on restart when an active z80 session has no project config and its folder is not a project', async () => {
+    const vscode = await import('vscode');
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    const artifactRoot = '/workspace/artifacts-only';
+    const projectRoot = '/workspace/tetro';
+    const projectConfig = path.normalize(`${projectRoot}/debug80.json`);
+    workspaceFolders = [
+      { name: 'artifacts-only', uri: { fsPath: artifactRoot }, index: 0 },
+      { name: 'tetro', uri: { fsPath: projectRoot }, index: 1 },
+    ];
+    existsSync.mockImplementation((candidate: string) => path.normalize(candidate) === projectConfig);
+    const resolveWorkspaceFolder = vi.fn().mockResolvedValue(workspaceFolders[1]);
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder,
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {} as never,
+    });
+
+    const restartDebug = registeredCommands.get('debug80.restartDebug');
+    expect(restartDebug).toBeTypeOf('function');
+
+    startDebugging.mockResolvedValueOnce(true);
+    stopDebugging.mockResolvedValueOnce(undefined);
+    (vscode.debug as { activeDebugSession?: unknown }).activeDebugSession = {
+      type: 'z80',
+      id: 'session-no-project-config',
+      configuration: { asm: 'standalone.asm' },
+      workspaceFolder: { uri: { fsPath: artifactRoot } },
+    };
+
+    const result = await restartDebug?.();
+
+    expect(result).toBe(true);
+    expect(resolveWorkspaceFolder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: true,
+        requireProject: true,
+      })
+    );
+    expect(startDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: { fsPath: projectRoot } }),
+      expect.objectContaining({
+        type: 'z80',
+        request: 'launch',
+        projectConfig,
+      })
+    );
+  });
+
+  it('prompts on restart when an active z80 session folder has an invalid project config', async () => {
+    const vscode = await import('vscode');
+    const { registerExtensionCommands } = await import('../../src/extension/commands');
+
+    const staleRoot = '/workspace/stale';
+    const projectRoot = '/workspace/tetro';
+    const staleConfig = path.normalize(`${staleRoot}/debug80.json`);
+    const projectConfig = path.normalize(`${projectRoot}/debug80.json`);
+    workspaceFolders = [
+      { name: 'stale', uri: { fsPath: staleRoot }, index: 0 },
+      { name: 'tetro', uri: { fsPath: projectRoot }, index: 1 },
+    ];
+    existsSync.mockImplementation((candidate: string) => {
+      const normalized = path.normalize(candidate);
+      return normalized === staleConfig || normalized === projectConfig;
+    });
+    readFileSync.mockImplementation((candidate: string) => {
+      const normalized = path.normalize(candidate);
+      if (normalized === staleConfig) {
+        return JSON.stringify({ targets: {} });
+      }
+      if (normalized === projectConfig) {
+        return JSON.stringify({ targets: { tetro: { sourceFile: 'src/tetro.asm' } } });
+      }
+      return JSON.stringify({ targets: {} });
+    });
+    const resolveWorkspaceFolder = vi.fn().mockResolvedValue(workspaceFolders[1]);
+
+    registerExtensionCommands({
+      context: { subscriptions: [] } as never,
+      platformViewProvider: { refreshIdleView: vi.fn() } as never,
+      sourceColumns: {} as never,
+      terminalPanel: {} as never,
+      workspaceSelection: {
+        resolveWorkspaceFolder,
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {} as never,
+    });
+
+    const restartDebug = registeredCommands.get('debug80.restartDebug');
+    expect(restartDebug).toBeTypeOf('function');
+
+    startDebugging.mockResolvedValueOnce(true);
+    stopDebugging.mockResolvedValueOnce(undefined);
+    (vscode.debug as { activeDebugSession?: unknown }).activeDebugSession = {
+      type: 'z80',
+      id: 'session-invalid-config',
+      configuration: { asm: 'standalone.asm' },
+      workspaceFolder: { uri: { fsPath: staleRoot } },
+    };
+
+    const result = await restartDebug?.();
+
+    expect(result).toBe(true);
+    expect(resolveWorkspaceFolder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: true,
+        requireProject: true,
+      })
+    );
+    expect(startDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: { fsPath: projectRoot } }),
+      expect.objectContaining({
+        type: 'z80',
+        request: 'launch',
+        projectConfig,
+      })
+    );
+  });
+
   it('restarts with the current stop-on-entry state', async () => {
     const vscode = await import('vscode');
     const { registerExtensionCommands } = await import('../../src/extension/commands');

--- a/tests/extension/project-config.test.ts
+++ b/tests/extension/project-config.test.ts
@@ -21,16 +21,30 @@ describe('project-config helpers', () => {
   it('lists asm and zax source files relative to the project root', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-project-sources-'));
     fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'src', 'shared'), { recursive: true });
     fs.mkdirSync(path.join(root, 'tools'), { recursive: true });
     fs.mkdirSync(path.join(root, 'build'), { recursive: true });
     fs.writeFileSync(path.join(root, 'src', 'main.asm'), 'nop\n');
     fs.writeFileSync(path.join(root, 'src', 'helpers.zax'), 'nop\n');
+    fs.writeFileSync(path.join(root, 'src', 'shared', 'include.asm'), 'nop\n');
     fs.writeFileSync(path.join(root, 'tools', 'ignore.txt'), 'x\n');
     fs.writeFileSync(path.join(root, 'build', 'generated.asm'), 'nop\n');
 
     const files = listProjectSourceFiles(root);
 
     expect(files).toEqual(['src/helpers.zax', 'src/main.asm']);
+  });
+
+  it('falls back to top-level project source files when no src folder exists', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-project-root-sources-'));
+    fs.mkdirSync(path.join(root, 'lib'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'main.asm'), 'nop\n');
+    fs.writeFileSync(path.join(root, 'alt.zax'), 'nop\n');
+    fs.writeFileSync(path.join(root, 'lib', 'include.asm'), 'nop\n');
+
+    const files = listProjectSourceFiles(root);
+
+    expect(files).toEqual(['alt.zax', 'main.asm']);
   });
 
   it('updates the selected target source in debug80.json', () => {


### PR DESCRIPTION
## Summary

- Limit auto-discovered target candidates to top-level source entry files instead of recursive include/module files.
- Restart active z80 sessions from their session project config when available, recovering the matching workspace folder without prompting.
- Fall back to prompting unless a no-projectConfig session folder is an initialized Debug80 project.

## Validation

- npx vitest run tests/extension/project-target-selection.test.ts tests/extension/commands.test.ts tests/extension/workspace-selection.test.ts tests/extension/project-config.test.ts
- npm run typecheck
- git diff --check

## Review Loop

- Sub-agent review pass 1: no correctness findings; residual coverage gaps noted and covered.
- Sub-agent review pass 2: P2 no-projectConfig restart fallback fixed.
- Sub-agent review pass 3: P2 invalid debug80.json fallback fixed.
- Sub-agent review pass 4: no findings.
