### PR TITLE
[codex] Fix TEC keypad shortcuts

### DIFF
--- a/src/platforms/tec1/README.md
+++ b/src/platforms/tec1/README.md
@@ -137,8 +137,10 @@ focus ring appears around the keypad while it is active.
 | `Space` | `0` | 0x00 |
 | `Tab` | ADDRESS | 0x13 |
 | `Enter` | GO | 0x12 |
-| `←` / `↑` | ◀ (left) / UP | 0x11 |
-| `→` / `↓` | ▶ (right) / DOWN | 0x10 |
+| `←` | ◀ (left) | 0x11 |
+| `→` | ▶ (right) | 0x10 |
+| `↑` | ADDRESS | 0x13 |
+| `↓` | GO | 0x12 |
 
 ### Special keys
 

--- a/src/platforms/tec1g/README.md
+++ b/src/platforms/tec1g/README.md
@@ -146,8 +146,10 @@ focus ring appears around the keypad while it is active.
 | `Space` | `0` | 0x00 |
 | `Tab` | AD | 0x13 |
 | `Enter` | GO | 0x12 |
-| `←` / `↑` | ◀ (left) | 0x11 |
-| `→` / `↓` | ▶ (right) | 0x10 |
+| `←` | ◀ (left) | 0x11 |
+| `→` | ▶ (right) | 0x10 |
+| `↑` | AD | 0x13 |
+| `↓` | GO | 0x12 |
 
 ### Special keys
 

--- a/tests/webview/common/tec-keyboard-shortcuts.test.ts
+++ b/tests/webview/common/tec-keyboard-shortcuts.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTecKeypadShortcut } from '../../../webview/common/tec-keyboard-shortcuts';
+
+describe('TEC keypad keyboard shortcuts', () => {
+  it('does not reset or consume Caps Lock', () => {
+    expect(resolveTecKeypadShortcut('CapsLock')).toEqual({ kind: 'none' });
+  });
+
+  it('maps Escape to reset', () => {
+    expect(resolveTecKeypadShortcut('Escape')).toEqual({ kind: 'reset' });
+  });
+
+  it('maps arrow keys to four distinct monitor controls', () => {
+    expect(resolveTecKeypadShortcut('ArrowLeft')).toEqual({ kind: 'key', code: 0x11 });
+    expect(resolveTecKeypadShortcut('ArrowRight')).toEqual({ kind: 'key', code: 0x10 });
+    expect(resolveTecKeypadShortcut('ArrowUp')).toEqual({ kind: 'key', code: 0x13 });
+    expect(resolveTecKeypadShortcut('ArrowDown')).toEqual({ kind: 'key', code: 0x12 });
+  });
+});

--- a/webview/common/tec-keyboard-shortcuts.ts
+++ b/webview/common/tec-keyboard-shortcuts.ts
@@ -1,0 +1,43 @@
+import { TEC1G_KEY_MAP } from './tec-keypad-layout';
+
+export type TecKeypadShortcut =
+  | { kind: 'key'; code: number }
+  | { kind: 'reset' }
+  | { kind: 'shift'; latched: boolean }
+  | { kind: 'none' };
+
+export function resolveTecKeypadShortcut(key: string): TecKeypadShortcut {
+  if (key === 'CapsLock') {
+    return { kind: 'none' };
+  }
+  if (key === ' ') {
+    return { kind: 'key', code: TEC1G_KEY_MAP['0'] };
+  }
+  if (key === 'Escape') {
+    return { kind: 'reset' };
+  }
+  if (key === 'Shift') {
+    return { kind: 'shift', latched: true };
+  }
+  if (key === 'Enter') {
+    return { kind: 'key', code: TEC1G_KEY_MAP.GO };
+  }
+  if (key === 'ArrowLeft') {
+    return { kind: 'key', code: TEC1G_KEY_MAP.LEFT };
+  }
+  if (key === 'ArrowRight') {
+    return { kind: 'key', code: TEC1G_KEY_MAP.RIGHT };
+  }
+  if (key === 'ArrowUp') {
+    return { kind: 'key', code: TEC1G_KEY_MAP.AD };
+  }
+  if (key === 'ArrowDown') {
+    return { kind: 'key', code: TEC1G_KEY_MAP.GO };
+  }
+  if (key === 'Tab') {
+    return { kind: 'key', code: TEC1G_KEY_MAP.AD };
+  }
+
+  const mapped = TEC1G_KEY_MAP[key.toUpperCase()];
+  return mapped !== undefined ? { kind: 'key', code: mapped } : { kind: 'none' };
+}

--- a/webview/tec1/index.ts
+++ b/webview/tec1/index.ts
@@ -1,6 +1,7 @@
 import { createMatrixRenderer } from '../common/matrix-renderer';
 import { createTecKeypad } from '../common/tec-keypad';
-import { TEC1G_DIGITS, TEC1G_KEY_MAP } from '../common/tec-keypad-layout';
+import { resolveTecKeypadShortcut } from '../common/tec-keyboard-shortcuts';
+import { TEC1G_DIGITS } from '../common/tec-keypad-layout';
 import { wireSerialUi } from '../common/serial-ui';
 import { createSevenSegDisplay } from '../common/seven-seg-display';
 import { applyInitializedProjectControls } from '../common/project-controls';
@@ -292,39 +293,16 @@ panelLayout.updateMemoryLayout(false);
 
 keypadEl.addEventListener('keydown', (event) => {
   if (event.repeat) return;
-  if (event.key === ' ') {
-    keypad.sendKey(TEC1G_KEY_MAP['0']);
+  const shortcut = resolveTecKeypadShortcut(event.key);
+  if (shortcut.kind === 'key') {
+    keypad.sendKey(shortcut.code);
     event.preventDefault();
-    return;
-  }
-  if (event.key === 'Escape') {
+  } else if (shortcut.kind === 'reset') {
     keypad.setShiftLatched(false);
     vscode.postMessage({ type: 'reset' });
     event.preventDefault();
-    return;
-  }
-  if (event.key === 'Shift') {
-    keypad.setShiftLatched(true);
-    event.preventDefault();
-    return;
-  }
-  const key = event.key.toUpperCase();
-  if (TEC1G_KEY_MAP[key] !== undefined) {
-    keypad.sendKey(TEC1G_KEY_MAP[key]);
-    event.preventDefault();
-    return;
-  }
-  if (event.key === 'Enter') {
-    keypad.sendKey(0x12);
-    event.preventDefault();
-  } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
-    keypad.sendKey(0x11);
-    event.preventDefault();
-  } else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
-    keypad.sendKey(0x10);
-    event.preventDefault();
-  } else if (event.key === 'Tab') {
-    keypad.sendKey(0x13);
+  } else if (shortcut.kind === 'shift') {
+    keypad.setShiftLatched(shortcut.latched);
     event.preventDefault();
   }
 });

--- a/webview/tec1g/index.ts
+++ b/webview/tec1g/index.ts
@@ -16,9 +16,10 @@ import { wireSerialUi } from '../common/serial-ui';
 import { createVisibilityController } from './visibility-controller';
 import type { IncomingMessage, Tec1gSpeedMode, Tec1gUpdatePayload } from './entry-types';
 import { TEC1G_DIGITS } from '../common/tec-keypad-layout';
+import { resolveTecKeypadShortcut } from '../common/tec-keyboard-shortcuts';
 import { createTec1gMemoryViews } from './tec1g-memory-views';
 import { createTec1gAudio } from './tec1g-audio';
-import { createTec1gKeypad, TEC1G_KEY_MAP } from './tec1g-keypad';
+import { createTec1gKeypad } from './tec1g-keypad';
 import { applyTec1gPlatformUpdate } from './tec1g-platform-update';
 import { createTec1gProjectStatusUi } from './tec1g-project-status-ui';
 
@@ -299,46 +300,18 @@ keypadEl.addEventListener('keydown', (event) => {
   if (event.repeat) {
     return;
   }
-  if (event.key === ' ') {
-    keypad.sendKey(TEC1G_KEY_MAP['0']);
+  const shortcut = resolveTecKeypadShortcut(event.key);
+  if (shortcut.kind === 'key') {
+    keypad.sendKey(shortcut.code);
     event.preventDefault();
     event.stopPropagation();
-    return;
-  }
-  if (event.key === 'Escape') {
+  } else if (shortcut.kind === 'reset') {
     keypad.setShiftLatched(false);
     vscode.postMessage({ type: 'reset' });
     event.preventDefault();
     event.stopPropagation();
-    return;
-  }
-  if (event.key === 'Shift') {
-    keypad.setShiftLatched(true);
-    event.preventDefault();
-    event.stopPropagation();
-    return;
-  }
-  const key = event.key.toUpperCase();
-  if (TEC1G_KEY_MAP[key] !== undefined) {
-    keypad.sendKey(TEC1G_KEY_MAP[key]);
-    event.preventDefault();
-    event.stopPropagation();
-    return;
-  }
-  if (event.key === 'Enter') {
-    keypad.sendKey(0x12);
-    event.preventDefault();
-    event.stopPropagation();
-  } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
-    keypad.sendKey(0x11);
-    event.preventDefault();
-    event.stopPropagation();
-  } else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
-    keypad.sendKey(0x10);
-    event.preventDefault();
-    event.stopPropagation();
-  } else if (event.key === 'Tab') {
-    keypad.sendKey(0x13);
+  } else if (shortcut.kind === 'shift') {
+    keypad.setShiftLatched(shortcut.latched);
     event.preventDefault();
     event.stopPropagation();
   }


### PR DESCRIPTION
## Summary
- centralise TEC keypad keyboard shortcut resolution for TEC-1 and TEC-1G webviews
- ignore Caps Lock so it no longer triggers keypad reset behavior
- map Escape to reset and split arrow keys into left/right/AD/GO mappings
- update platform README shortcut tables

## Validation
- npx vitest run -c vitest.webview.config.ts tests/webview/common/tec-keyboard-shortcuts.test.ts
- npm run typecheck:webview
- npm run build:webview
- npm run test:webview
- npm run lint -- --max-warnings=0
