### PR TITLE
[codex] Extract platform view project status

### DIFF
--- a/src/extension/platform-view-project-status.ts
+++ b/src/extension/platform-view-project-status.ts
@@ -1,0 +1,86 @@
+import * as vscode from 'vscode';
+import type { PlatformId, ProjectStatusPayload } from '../contracts/platform-view';
+import { findProjectConfigPath, readProjectConfig, resolveProjectPlatform } from './project-config';
+import { listProjectTargetChoices } from './project-target-selection';
+import { resolveProjectStatusSummary } from './project-status';
+import { resolveRememberedWorkspaceFolder } from './workspace-selection';
+
+export interface PlatformViewProjectStatusContext {
+  workspaceState: vscode.Memento | undefined;
+  selectedWorkspace: vscode.WorkspaceFolder | undefined;
+  currentPlatform: PlatformId | undefined;
+  stopOnEntry: boolean;
+}
+
+export function resolvePlatformViewWorkspace(
+  ctx: Pick<PlatformViewProjectStatusContext, 'workspaceState' | 'selectedWorkspace'>,
+  folders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders ?? []
+): vscode.WorkspaceFolder | undefined {
+  if (
+    ctx.selectedWorkspace !== undefined &&
+    folders.some((folder) => folder.uri.fsPath === ctx.selectedWorkspace?.uri.fsPath)
+  ) {
+    return ctx.selectedWorkspace;
+  }
+  return (
+    resolveRememberedWorkspaceFolder(ctx.workspaceState, folders) ??
+    (folders.length === 1 ? folders[0] : undefined)
+  );
+}
+
+export function buildPlatformViewProjectStatus(
+  ctx: PlatformViewProjectStatusContext,
+  folders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders ?? []
+): ProjectStatusPayload {
+  const roots = folders.map((folder) => ({
+    name: folder.name,
+    path: folder.uri.fsPath,
+    hasProject: findProjectConfigPath(folder) !== undefined,
+  }));
+  const folder = resolvePlatformViewWorkspace(ctx, folders);
+  if (folder === undefined) {
+    return {
+      roots,
+      targets: [],
+      projectState: roots.length === 0 ? 'noWorkspace' : 'uninitialized',
+      hasProject: false,
+      platform: ctx.currentPlatform ?? 'simple',
+      stopOnEntry: ctx.stopOnEntry,
+    };
+  }
+
+  const projectConfigPath = findProjectConfigPath(folder);
+  const hasProject = projectConfigPath !== undefined;
+  const projectStatus =
+    hasProject && ctx.workspaceState !== undefined
+      ? resolveProjectStatusSummary(ctx.workspaceState, folder)
+      : undefined;
+  if (!hasProject) {
+    return {
+      roots,
+      targets: [],
+      rootName: folder.name,
+      rootPath: folder.uri.fsPath,
+      projectState: 'uninitialized',
+      hasProject: false,
+      platform: ctx.currentPlatform ?? 'simple',
+      stopOnEntry: ctx.stopOnEntry,
+    };
+  }
+
+  const config = readProjectConfig(projectConfigPath);
+  const platform = resolveProjectPlatform(config) ?? 'simple';
+
+  return {
+    roots,
+    targets: listProjectTargetChoices(projectConfigPath),
+    rootName: folder.name,
+    rootPath: folder.uri.fsPath,
+    projectState: 'initialized',
+    hasProject: true,
+    platform,
+    stopOnEntry: ctx.stopOnEntry,
+    ...(projectStatus?.targetName !== undefined ? { targetName: projectStatus.targetName } : {}),
+    ...(projectStatus?.entrySource !== undefined ? { entrySource: projectStatus.entrySource } : {}),
+  };
+}

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -28,7 +28,6 @@ import {
 import type { MemoryViewState } from '../platforms/panel-memory';
 import type { PanelTab } from '../platforms/panel-html';
 import { getTec1gHtml } from '../platforms/tec1g/ui-panel-html';
-import { listProjectTargetChoices } from './project-target-selection';
 import { resolveProjectStatusSummary } from './project-status';
 import {
   getMementoForTarget,
@@ -36,21 +35,20 @@ import {
   TEC1G_UI_VISIBILITY_MEMENTO_KEY,
   type Tec1gVisibilityByTarget,
 } from './tec1g-ui-visibility-memento';
-import { findProjectConfigPath, readProjectConfig, resolveProjectPlatform } from './project-config';
+import { findProjectConfigPath } from './project-config';
 import { handlePlatformViewMessage } from './platform-view-messages';
 import {
   handlePlatformSerialSave,
   handlePlatformSerialSendFile,
 } from './platform-view-serial-actions';
 import { loadPlatformUi, listPlatformUis, type PlatformUiModules } from './platform-view-manifest';
-import { resolveRememberedWorkspaceFolder } from './workspace-selection';
-import type {
-  PlatformId,
-  PlatformViewInboundMessage,
-  ProjectStatusPayload,
-} from '../contracts/platform-view';
+import type { PlatformId, PlatformViewInboundMessage } from '../contracts/platform-view';
 import { NullLogger, type Logger } from '../util/logger';
 import { createUiPerformanceMonitor, type UiPerformanceMonitor } from './ui-performance-monitor';
+import {
+  buildPlatformViewProjectStatus,
+  resolvePlatformViewWorkspace,
+} from './platform-view-project-status';
 
 const MEMORY_REFRESH_INTERVAL_MS = 500;
 
@@ -598,7 +596,15 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     if (!this.view) {
       return;
     }
-    this.postMessage({ type: 'projectStatus', ...this.getProjectStatusPayload() });
+    this.postMessage({
+      type: 'projectStatus',
+      ...buildPlatformViewProjectStatus({
+        workspaceState: this.workspaceState,
+        selectedWorkspace: this.selectedWorkspace,
+        currentPlatform: this.currentPlatform,
+        stopOnEntry: this.stopOnEntry,
+      }),
+    });
   }
 
   private postSessionStatus(): void {
@@ -606,63 +612,6 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       return;
     }
     this.postMessage({ type: 'sessionStatus', status: this.sessionStatus });
-  }
-
-  private getProjectStatusPayload(): ProjectStatusPayload {
-    const workspaceFolders = vscode.workspace.workspaceFolders ?? [];
-    const roots = workspaceFolders.map((folder) => ({
-      name: folder.name,
-      path: folder.uri.fsPath,
-      hasProject: findProjectConfigPath(folder) !== undefined,
-    }));
-    const folder = this.resolveSelectedWorkspace(workspaceFolders);
-    if (folder === undefined) {
-      return {
-        roots,
-        targets: [],
-        projectState: roots.length === 0 ? 'noWorkspace' : 'uninitialized',
-        hasProject: false,
-        platform: this.currentPlatform ?? 'simple',
-        stopOnEntry: this.stopOnEntry,
-      };
-    }
-
-    const projectConfigPath = findProjectConfigPath(folder);
-    const hasProject = projectConfigPath !== undefined;
-    const projectStatus =
-      hasProject && this.workspaceState !== undefined
-        ? resolveProjectStatusSummary(this.workspaceState, folder)
-        : undefined;
-    if (!hasProject) {
-      return {
-        roots,
-        targets: [],
-        rootName: folder.name,
-        rootPath: folder.uri.fsPath,
-        projectState: 'uninitialized',
-        hasProject: false,
-        platform: this.currentPlatform ?? 'simple',
-        stopOnEntry: this.stopOnEntry,
-      };
-    }
-
-    const config = readProjectConfig(projectConfigPath);
-    const platform = resolveProjectPlatform(config) ?? 'simple';
-
-    return {
-      roots,
-      targets: listProjectTargetChoices(projectConfigPath),
-      rootName: folder.name,
-      rootPath: folder.uri.fsPath,
-      projectState: 'initialized',
-      hasProject: true,
-      platform,
-      stopOnEntry: this.stopOnEntry,
-      ...(projectStatus?.targetName !== undefined ? { targetName: projectStatus.targetName } : {}),
-      ...(projectStatus?.entrySource !== undefined
-        ? { entrySource: projectStatus.entrySource }
-        : {}),
-    };
   }
 
   private mergeAndPostTec1gPanelVisibility(): void {
@@ -721,15 +670,9 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   private resolveSelectedWorkspace(
     folders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders ?? []
   ): vscode.WorkspaceFolder | undefined {
-    if (
-      this.selectedWorkspace !== undefined &&
-      folders.some((folder) => folder.uri.fsPath === this.selectedWorkspace?.uri.fsPath)
-    ) {
-      return this.selectedWorkspace;
-    }
-    return (
-      resolveRememberedWorkspaceFolder(this.workspaceState, folders) ??
-      (folders.length === 1 ? folders[0] : undefined)
+    return resolvePlatformViewWorkspace(
+      { workspaceState: this.workspaceState, selectedWorkspace: this.selectedWorkspace },
+      folders
     );
   }
 

--- a/tests/extension/platform-view-project-status.test.ts
+++ b/tests/extension/platform-view-project-status.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  findProjectConfigPath,
+  readProjectConfig,
+  resolveProjectPlatform,
+  listProjectTargetChoices,
+  resolveProjectStatusSummary,
+  resolveRememberedWorkspaceFolder,
+} = vi.hoisted(() => ({
+  findProjectConfigPath: vi.fn(),
+  readProjectConfig: vi.fn(),
+  resolveProjectPlatform: vi.fn(),
+  listProjectTargetChoices: vi.fn(),
+  resolveProjectStatusSummary: vi.fn(),
+  resolveRememberedWorkspaceFolder: vi.fn(),
+}));
+
+let workspaceFolders: Array<{ name: string; uri: { fsPath: string } }> | undefined;
+
+vi.mock('vscode', () => ({
+  workspace: {
+    get workspaceFolders() {
+      return workspaceFolders;
+    },
+  },
+}));
+
+vi.mock('../../src/extension/project-config', () => ({
+  findProjectConfigPath,
+  readProjectConfig,
+  resolveProjectPlatform,
+}));
+
+vi.mock('../../src/extension/project-target-selection', () => ({
+  listProjectTargetChoices,
+}));
+
+vi.mock('../../src/extension/project-status', () => ({
+  resolveProjectStatusSummary,
+}));
+
+vi.mock('../../src/extension/workspace-selection', () => ({
+  resolveRememberedWorkspaceFolder,
+}));
+
+import {
+  buildPlatformViewProjectStatus,
+  resolvePlatformViewWorkspace,
+} from '../../src/extension/platform-view-project-status';
+
+const folder = (name: string, fsPath: string) => ({ name, uri: { fsPath } });
+
+describe('platform-view-project-status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    workspaceFolders = undefined;
+    findProjectConfigPath.mockImplementation((target: { uri: { fsPath: string } }) =>
+      target.uri.fsPath.includes('project') ? `${target.uri.fsPath}/debug80.json` : undefined
+    );
+    readProjectConfig.mockReturnValue({ projectPlatform: 'tec1g', targets: {} });
+    resolveProjectPlatform.mockReturnValue('tec1g');
+    listProjectTargetChoices.mockReturnValue([
+      { name: 'app', description: 'src/main.asm', detail: 'src/main.asm' },
+    ]);
+    resolveProjectStatusSummary.mockReturnValue({
+      projectName: 'project',
+      targetName: 'app',
+      entrySource: 'src/main.asm',
+    });
+    resolveRememberedWorkspaceFolder.mockReturnValue(undefined);
+  });
+
+  it('uses the selected workspace when it is still open', () => {
+    const selected = folder('project', '/workspace/project');
+    const openFolders = [folder('other', '/workspace/other'), selected];
+
+    expect(resolvePlatformViewWorkspace({ selectedWorkspace: selected }, openFolders)).toBe(
+      selected
+    );
+    expect(resolveRememberedWorkspaceFolder).not.toHaveBeenCalled();
+  });
+
+  it('falls back to remembered workspace before single-folder fallback', () => {
+    const remembered = folder('project', '/workspace/project');
+    const workspaceState = { get: vi.fn(), update: vi.fn() };
+    resolveRememberedWorkspaceFolder.mockReturnValue(remembered);
+
+    expect(resolvePlatformViewWorkspace({ workspaceState: workspaceState as never }, [])).toBe(
+      remembered
+    );
+    expect(resolveRememberedWorkspaceFolder).toHaveBeenCalledWith(workspaceState, []);
+  });
+
+  it('builds an initialized project status payload with target and entry source', () => {
+    const project = folder('project', '/workspace/project');
+
+    expect(
+      buildPlatformViewProjectStatus(
+        {
+          workspaceState: { get: vi.fn(), update: vi.fn() } as never,
+          selectedWorkspace: project,
+          currentPlatform: 'simple',
+          stopOnEntry: true,
+        },
+        [project]
+      )
+    ).toEqual({
+      roots: [{ name: 'project', path: '/workspace/project', hasProject: true }],
+      targets: [{ name: 'app', description: 'src/main.asm', detail: 'src/main.asm' }],
+      rootName: 'project',
+      rootPath: '/workspace/project',
+      projectState: 'initialized',
+      hasProject: true,
+      platform: 'tec1g',
+      stopOnEntry: true,
+      targetName: 'app',
+      entrySource: 'src/main.asm',
+    });
+  });
+
+  it('builds an uninitialized status for a selected folder without a project', () => {
+    const openFolder = folder('scratch', '/workspace/scratch');
+
+    expect(
+      buildPlatformViewProjectStatus(
+        { selectedWorkspace: openFolder, currentPlatform: 'tec1', stopOnEntry: false },
+        [openFolder]
+      )
+    ).toMatchObject({
+      rootName: 'scratch',
+      rootPath: '/workspace/scratch',
+      projectState: 'uninitialized',
+      hasProject: false,
+      platform: 'tec1',
+      targets: [],
+    });
+  });
+});

--- a/tests/extension/platform-view-project-status.test.ts
+++ b/tests/extension/platform-view-project-status.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as vscode from 'vscode';
 
 const {
   findProjectConfigPath,
@@ -16,7 +17,7 @@ const {
   resolveRememberedWorkspaceFolder: vi.fn(),
 }));
 
-let workspaceFolders: Array<{ name: string; uri: { fsPath: string } }> | undefined;
+let workspaceFolders: vscode.WorkspaceFolder[] | undefined;
 
 vi.mock('vscode', () => ({
   workspace: {
@@ -49,7 +50,8 @@ import {
   resolvePlatformViewWorkspace,
 } from '../../src/extension/platform-view-project-status';
 
-const folder = (name: string, fsPath: string) => ({ name, uri: { fsPath } });
+const folder = (name: string, fsPath: string, index = 0): vscode.WorkspaceFolder =>
+  ({ name, index, uri: { fsPath } }) as vscode.WorkspaceFolder;
 
 describe('platform-view-project-status', () => {
   beforeEach(() => {
@@ -75,21 +77,46 @@ describe('platform-view-project-status', () => {
     const selected = folder('project', '/workspace/project');
     const openFolders = [folder('other', '/workspace/other'), selected];
 
-    expect(resolvePlatformViewWorkspace({ selectedWorkspace: selected }, openFolders)).toBe(
-      selected
-    );
+    expect(
+      resolvePlatformViewWorkspace(
+        { workspaceState: undefined, selectedWorkspace: selected },
+        openFolders
+      )
+    ).toBe(selected);
     expect(resolveRememberedWorkspaceFolder).not.toHaveBeenCalled();
   });
 
   it('falls back to remembered workspace before single-folder fallback', () => {
     const remembered = folder('project', '/workspace/project');
+    const singleFolder = folder('fallback', '/workspace/fallback');
     const workspaceState = { get: vi.fn(), update: vi.fn() };
     resolveRememberedWorkspaceFolder.mockReturnValue(remembered);
 
-    expect(resolvePlatformViewWorkspace({ workspaceState: workspaceState as never }, [])).toBe(
-      remembered
-    );
-    expect(resolveRememberedWorkspaceFolder).toHaveBeenCalledWith(workspaceState, []);
+    expect(
+      resolvePlatformViewWorkspace(
+        { workspaceState: workspaceState as never, selectedWorkspace: undefined },
+        [singleFolder]
+      )
+    ).toBe(remembered);
+    expect(resolveRememberedWorkspaceFolder).toHaveBeenCalledWith(workspaceState, [singleFolder]);
+  });
+
+  it('builds a no-workspace project status payload when no folders are open', () => {
+    expect(
+      buildPlatformViewProjectStatus({
+        workspaceState: undefined,
+        selectedWorkspace: undefined,
+        currentPlatform: undefined,
+        stopOnEntry: false,
+      })
+    ).toEqual({
+      roots: [],
+      targets: [],
+      projectState: 'noWorkspace',
+      hasProject: false,
+      platform: 'simple',
+      stopOnEntry: false,
+    });
   });
 
   it('builds an initialized project status payload with target and entry source', () => {
@@ -124,7 +151,12 @@ describe('platform-view-project-status', () => {
 
     expect(
       buildPlatformViewProjectStatus(
-        { selectedWorkspace: openFolder, currentPlatform: 'tec1', stopOnEntry: false },
+        {
+          workspaceState: undefined,
+          selectedWorkspace: openFolder,
+          currentPlatform: 'tec1',
+          stopOnEntry: false,
+        },
         [openFolder]
       )
     ).toMatchObject({


### PR DESCRIPTION
## Summary
- extract platform-view project status payload construction into `platform-view-project-status.ts`
- keep `PlatformViewProvider` responsible for posting messages while delegating workspace/status resolution
- add focused tests for selected/remembered workspace resolution and initialized/uninitialized project status payloads

## Validation
- `npx vitest run tests/extension/platform-view-project-status.test.ts tests/extension/platform-view-provider.test.ts`
- `npm run typecheck`
- `npm run lint -- --max-warnings=0`
- `npm run format:check`
- `npm run typecheck:webview`
- `npm test`
- `npm run package:verify --if-present`
- `git diff --check`
