### PR TITLE
[codex] Extract platform view serial state

### DIFF
--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -12,12 +12,6 @@ import type { DebugSessionStatus } from '../debug/session/session-status';
 import type { Tec1UpdatePayload } from '../platforms/tec1/types';
 import type { Tec1gUpdatePayload } from '../platforms/tec1g/types';
 import {
-  appendSerialText,
-  clearSerialBuffer,
-  createSerialBuffer,
-  type SerialBuffer,
-} from '../platforms/panel-serial';
-import {
   createRefreshController,
   refreshSnapshot,
   startAutoRefresh,
@@ -49,6 +43,13 @@ import {
   buildPlatformViewProjectStatus,
   resolvePlatformViewWorkspace,
 } from './platform-view-project-status';
+import {
+  appendPlatformSerial,
+  buildSerialInitMessage,
+  clearPlatformSerial,
+  createSerialBuffer,
+  type SerialBuffer,
+} from './platform-view-serial-state';
 
 const MEMORY_REFRESH_INTERVAL_MS = 500;
 
@@ -229,45 +230,15 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   }
 
   appendTec1Serial(text: string, sessionId?: string): void {
-    if (!this.shouldAcceptSession(sessionId) || text.length === 0) {
-      return;
-    }
-    const bundle = this.getActiveBundle('tec1');
-    if (bundle === undefined) {
-      return;
-    }
-    appendSerialText(bundle.state.serialBuffer, text);
-    if (this.currentPlatform === 'tec1') {
-      this.postMessage({ type: 'serial', text });
-    }
+    this.appendSerial('tec1', text, sessionId);
   }
 
   appendSimpleTerminal(text: string, sessionId?: string): void {
-    if (!this.shouldAcceptSession(sessionId) || text.length === 0) {
-      return;
-    }
-    const bundle = this.getActiveBundle('simple');
-    if (bundle === undefined) {
-      return;
-    }
-    appendSerialText(bundle.state.serialBuffer, text);
-    if (this.currentPlatform === 'simple') {
-      this.postMessage({ type: 'serial', text });
-    }
+    this.appendSerial('simple', text, sessionId);
   }
 
   appendTec1gSerial(text: string, sessionId?: string): void {
-    if (!this.shouldAcceptSession(sessionId) || text.length === 0) {
-      return;
-    }
-    const bundle = this.getActiveBundle('tec1g');
-    if (bundle === undefined) {
-      return;
-    }
-    appendSerialText(bundle.state.serialBuffer, text);
-    if (this.currentPlatform === 'tec1g') {
-      this.postMessage({ type: 'serial', text });
-    }
+    this.appendSerial('tec1g', text, sessionId);
   }
 
   clear(): void {
@@ -278,7 +249,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
         state.memoryViews = modules.createMemoryViewState();
         state.hasPostedRuntimeUpdate = false;
       }
-      clearSerialBuffer(state.serialBuffer);
+      clearPlatformSerial(state.serialBuffer);
     }
     const bundle = this.getCurrentBundle();
     if (bundle !== undefined) {
@@ -367,7 +338,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
         clearSerialBuffer: (platform) => {
           const bundle = this.getActiveBundle(platform);
           if (bundle !== undefined) {
-            clearSerialBuffer(bundle.state.serialBuffer);
+            clearPlatformSerial(bundle.state.serialBuffer);
           }
         },
         handlePlatformMessage: async (platform, platformMsg) => {
@@ -430,8 +401,9 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       this.postMessage(
         bundle.modules.buildUpdateMessage(bundle.state.uiState, this.nextUiRevision())
       );
-      if (bundle.state.serialBuffer.text.length > 0) {
-        this.postMessage({ type: 'serialInit', text: bundle.state.serialBuffer.text });
+      const serialInitMessage = buildSerialInitMessage(bundle.state.serialBuffer);
+      if (serialInitMessage !== undefined) {
+        this.postMessage(serialInitMessage);
       }
       this.postMessage({ type: 'selectTab', tab: bundle.state.activeTab });
       this.syncMemoryRefresh(bundle, rehydrate);
@@ -512,6 +484,23 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       return undefined;
     }
     return this.getActiveBundle(this.currentPlatform);
+  }
+
+  private appendSerial(platform: PlatformId, text: string, sessionId?: string): void {
+    if (!this.shouldAcceptSession(sessionId)) {
+      return;
+    }
+    const bundle = this.getActiveBundle(platform);
+    if (bundle === undefined) {
+      return;
+    }
+    const message = appendPlatformSerial(bundle.state.serialBuffer, text, {
+      platform,
+      currentPlatform: this.currentPlatform,
+    });
+    if (message !== undefined) {
+      this.postMessage(message);
+    }
   }
 
   private syncMemoryRefresh(

--- a/src/extension/platform-view-serial-state.ts
+++ b/src/extension/platform-view-serial-state.ts
@@ -1,0 +1,36 @@
+import {
+  appendSerialText,
+  clearSerialBuffer,
+  createSerialBuffer,
+  type SerialBuffer,
+} from '../platforms/panel-serial';
+import type { PlatformId } from '../contracts/platform-view';
+
+export { createSerialBuffer, type SerialBuffer };
+
+export type PlatformViewSerialMessage =
+  | { type: 'serial'; text: string }
+  | { type: 'serialClear' }
+  | { type: 'serialInit'; text: string };
+
+export function appendPlatformSerial(
+  serialBuffer: SerialBuffer,
+  text: string,
+  options: { platform: PlatformId; currentPlatform: PlatformId | undefined }
+): PlatformViewSerialMessage | undefined {
+  if (text.length === 0) {
+    return undefined;
+  }
+  appendSerialText(serialBuffer, text);
+  return options.currentPlatform === options.platform ? { type: 'serial', text } : undefined;
+}
+
+export function clearPlatformSerial(serialBuffer: SerialBuffer): void {
+  clearSerialBuffer(serialBuffer);
+}
+
+export function buildSerialInitMessage(
+  serialBuffer: SerialBuffer
+): PlatformViewSerialMessage | undefined {
+  return serialBuffer.text.length > 0 ? { type: 'serialInit', text: serialBuffer.text } : undefined;
+}

--- a/tests/extension/platform-view-serial-state.test.ts
+++ b/tests/extension/platform-view-serial-state.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendPlatformSerial,
+  buildSerialInitMessage,
+  clearPlatformSerial,
+  createSerialBuffer,
+} from '../../src/extension/platform-view-serial-state';
+
+describe('platform-view-serial-state', () => {
+  it('appends serial text and emits when the platform is active', () => {
+    const buffer = createSerialBuffer();
+
+    expect(
+      appendPlatformSerial(buffer, 'HELLO', { platform: 'tec1', currentPlatform: 'tec1' })
+    ).toEqual({ type: 'serial', text: 'HELLO' });
+    expect(buffer.text).toBe('HELLO');
+  });
+
+  it('appends serial text without emitting when another platform is active', () => {
+    const buffer = createSerialBuffer();
+
+    expect(
+      appendPlatformSerial(buffer, 'HIDDEN', { platform: 'tec1g', currentPlatform: 'tec1' })
+    ).toBeUndefined();
+    expect(buffer.text).toBe('HIDDEN');
+  });
+
+  it('ignores empty serial text', () => {
+    const buffer = createSerialBuffer();
+
+    expect(
+      appendPlatformSerial(buffer, '', { platform: 'simple', currentPlatform: 'simple' })
+    ).toBeUndefined();
+    expect(buffer.text).toBe('');
+  });
+
+  it('builds serial init only when buffered text exists', () => {
+    const buffer = createSerialBuffer();
+
+    expect(buildSerialInitMessage(buffer)).toBeUndefined();
+
+    appendPlatformSerial(buffer, 'READY', { platform: 'simple', currentPlatform: undefined });
+
+    expect(buildSerialInitMessage(buffer)).toEqual({ type: 'serialInit', text: 'READY' });
+  });
+
+  it('clears buffered serial text', () => {
+    const buffer = createSerialBuffer();
+    appendPlatformSerial(buffer, 'READY', { platform: 'simple', currentPlatform: undefined });
+
+    clearPlatformSerial(buffer);
+
+    expect(buffer.text).toBe('');
+    expect(buildSerialInitMessage(buffer)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- extract platform-view serial buffer mutation into `platform-view-serial-state.ts`
- keep `PlatformViewProvider` responsible for platform/session routing and message posting
- add focused tests for serial append, hidden-platform buffering, init messages, empty input, and clearing

## Validation
- `npx vitest run tests/extension/platform-view-serial-state.test.ts tests/extension/platform-view-provider.test.ts tests/extension/platform-view-serial-actions.test.ts`
- `npm run typecheck`
- `npm run lint -- --max-warnings=0`
- `npm run format:check`
- `npm run typecheck:webview`
- `npm test`
- `npm run package:verify --if-present`
- `git diff --check`
