### PR TITLE
[codex] Extract TEC-1G panel visibility state

### DIFF
--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -22,13 +22,10 @@ import {
 import type { MemoryViewState } from '../platforms/panel-memory';
 import type { PanelTab } from '../platforms/panel-html';
 import { getTec1gHtml } from '../platforms/tec1g/ui-panel-html';
-import { resolveProjectStatusSummary } from './project-status';
 import {
-  getMementoForTarget,
-  mergeTec1gPanelVisibility,
-  TEC1G_UI_VISIBILITY_MEMENTO_KEY,
-  type Tec1gVisibilityByTarget,
-} from './tec1g-ui-visibility-memento';
+  buildTec1gVisibilityMessage,
+  saveTec1gPanelVisibility,
+} from './platform-view-tec1g-visibility';
 import { findProjectConfigPath } from './project-config';
 import { handlePlatformViewMessage } from './platform-view-messages';
 import {
@@ -321,7 +318,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
         },
         currentPlatform: () => this.currentPlatform,
         handleSaveTec1gPanelVisibility: (args) => {
-          this.saveTec1gPanelVisibility(args.visibility, args.targetName);
+          this.persistTec1gPanelVisibility(args.visibility, args.targetName);
         },
         handleStartDebug: async (args) => {
           await vscode.commands.executeCommand('debug80.startDebug', args);
@@ -607,53 +604,22 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     if (!this.view || this.currentPlatform !== 'tec1g') {
       return;
     }
-    const memento = this.readTec1gPanelVisibilityMemento();
-    const merged = mergeTec1gPanelVisibility(this.tec1gAdapterVisibility, memento);
-    this.postMessage({ type: 'uiVisibility', visibility: merged, persist: true });
-  }
-
-  private readTec1gPanelVisibilityMemento(): Record<string, boolean> | undefined {
-    if (this.workspaceState === undefined) {
-      return undefined;
-    }
-    const folder = this.resolveSelectedWorkspace();
-    if (folder === undefined) {
-      return undefined;
-    }
-    if (findProjectConfigPath(folder) === undefined) {
-      return undefined;
-    }
-    const summary = resolveProjectStatusSummary(this.workspaceState, folder);
-    const targetName = summary?.targetName ?? '__default__';
-    const byTarget = this.workspaceState.get<Tec1gVisibilityByTarget>(
-      TEC1G_UI_VISIBILITY_MEMENTO_KEY
+    this.postMessage(
+      buildTec1gVisibilityMessage(this.tec1gAdapterVisibility, {
+        workspaceState: this.workspaceState,
+        resolveWorkspace: () => this.resolveSelectedWorkspace(),
+      })
     );
-    return getMementoForTarget(byTarget, targetName);
   }
 
-  private saveTec1gPanelVisibility(
+  private persistTec1gPanelVisibility(
     visibility: Record<string, boolean>,
     targetNameFromWebview?: string
   ): void {
-    if (this.workspaceState === undefined) {
-      return;
-    }
-    const folder = this.resolveSelectedWorkspace();
-    if (folder === undefined) {
-      return;
-    }
-    if (findProjectConfigPath(folder) === undefined) {
-      return;
-    }
-    const resolved =
-      targetNameFromWebview !== undefined && targetNameFromWebview.length > 0
-        ? targetNameFromWebview
-        : (resolveProjectStatusSummary(this.workspaceState, folder)?.targetName ?? '__default__');
-    const byTarget: Tec1gVisibilityByTarget = {
-      ...(this.workspaceState.get<Tec1gVisibilityByTarget>(TEC1G_UI_VISIBILITY_MEMENTO_KEY) ?? {}),
-    };
-    byTarget[resolved] = { ...visibility };
-    void this.workspaceState.update(TEC1G_UI_VISIBILITY_MEMENTO_KEY, byTarget);
+    saveTec1gPanelVisibility(visibility, targetNameFromWebview, {
+      workspaceState: this.workspaceState,
+      resolveWorkspace: () => this.resolveSelectedWorkspace(),
+    });
   }
 
   private resolveSelectedWorkspace(

--- a/src/extension/platform-view-tec1g-visibility.ts
+++ b/src/extension/platform-view-tec1g-visibility.ts
@@ -1,0 +1,70 @@
+import type * as vscode from 'vscode';
+import {
+  getMementoForTarget,
+  mergeTec1gPanelVisibility,
+  TEC1G_UI_VISIBILITY_MEMENTO_KEY,
+  type Tec1gVisibilityByTarget,
+} from './tec1g-ui-visibility-memento';
+import { findProjectConfigPath } from './project-config';
+import { resolveProjectStatusSummary } from './project-status';
+
+export interface Tec1gVisibilityContext {
+  workspaceState: vscode.Memento | undefined;
+  resolveWorkspace: () => vscode.WorkspaceFolder | undefined;
+}
+
+export function buildTec1gVisibilityMessage(
+  adapterVisibility: Record<string, boolean> | undefined,
+  ctx: Tec1gVisibilityContext
+): { type: 'uiVisibility'; visibility: Record<string, boolean>; persist: true } {
+  return {
+    type: 'uiVisibility',
+    visibility: mergeTec1gPanelVisibility(adapterVisibility, readTec1gPanelVisibilityMemento(ctx)),
+    persist: true,
+  };
+}
+
+export function readTec1gPanelVisibilityMemento(
+  ctx: Tec1gVisibilityContext
+): Record<string, boolean> | undefined {
+  if (ctx.workspaceState === undefined) {
+    return undefined;
+  }
+  const folder = ctx.resolveWorkspace();
+  if (folder === undefined) {
+    return undefined;
+  }
+  if (findProjectConfigPath(folder) === undefined) {
+    return undefined;
+  }
+  const summary = resolveProjectStatusSummary(ctx.workspaceState, folder);
+  const targetName = summary?.targetName ?? '__default__';
+  const byTarget = ctx.workspaceState.get<Tec1gVisibilityByTarget>(TEC1G_UI_VISIBILITY_MEMENTO_KEY);
+  return getMementoForTarget(byTarget, targetName);
+}
+
+export function saveTec1gPanelVisibility(
+  visibility: Record<string, boolean>,
+  targetNameFromWebview: string | undefined,
+  ctx: Tec1gVisibilityContext
+): void {
+  if (ctx.workspaceState === undefined) {
+    return;
+  }
+  const folder = ctx.resolveWorkspace();
+  if (folder === undefined) {
+    return;
+  }
+  if (findProjectConfigPath(folder) === undefined) {
+    return;
+  }
+  const resolved =
+    targetNameFromWebview !== undefined && targetNameFromWebview.length > 0
+      ? targetNameFromWebview
+      : (resolveProjectStatusSummary(ctx.workspaceState, folder)?.targetName ?? '__default__');
+  const byTarget: Tec1gVisibilityByTarget = {
+    ...(ctx.workspaceState.get<Tec1gVisibilityByTarget>(TEC1G_UI_VISIBILITY_MEMENTO_KEY) ?? {}),
+  };
+  byTarget[resolved] = { ...visibility };
+  void ctx.workspaceState.update(TEC1G_UI_VISIBILITY_MEMENTO_KEY, byTarget);
+}

--- a/tests/extension/platform-view-tec1g-visibility.test.ts
+++ b/tests/extension/platform-view-tec1g-visibility.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as vscode from 'vscode';
+import { TEC1G_DEFAULT_PANEL_VISIBILITY } from '../../src/tec1g/visibility-defaults';
+import { TEC1G_UI_VISIBILITY_MEMENTO_KEY } from '../../src/extension/tec1g-ui-visibility-memento';
+
+const { findProjectConfigPath, resolveProjectStatusSummary } = vi.hoisted(() => ({
+  findProjectConfigPath: vi.fn(),
+  resolveProjectStatusSummary: vi.fn(),
+}));
+
+vi.mock('../../src/extension/project-config', () => ({
+  findProjectConfigPath,
+}));
+
+vi.mock('../../src/extension/project-status', () => ({
+  resolveProjectStatusSummary,
+}));
+
+import {
+  buildTec1gVisibilityMessage,
+  readTec1gPanelVisibilityMemento,
+  saveTec1gPanelVisibility,
+} from '../../src/extension/platform-view-tec1g-visibility';
+
+const folder = (name: string, fsPath: string, index = 0): vscode.WorkspaceFolder =>
+  ({ name, index, uri: { fsPath } }) as vscode.WorkspaceFolder;
+
+function createWorkspaceState(initial?: unknown): {
+  workspaceState: vscode.Memento;
+  update: ReturnType<typeof vi.fn>;
+} {
+  let stored = initial;
+  const update = vi.fn((_key: string, value: unknown) => {
+    stored = value;
+    return Promise.resolve();
+  });
+  return {
+    workspaceState: {
+      get: vi.fn(() => stored),
+      update,
+    },
+    update,
+  };
+}
+
+describe('platform-view-tec1g-visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findProjectConfigPath.mockImplementation(
+      (target: vscode.WorkspaceFolder) => `${target.uri.fsPath}/debug80.json`
+    );
+    resolveProjectStatusSummary.mockReturnValue({ targetName: 'app' });
+  });
+
+  it('builds the uiVisibility message by merging defaults, adapter config, and memento', () => {
+    const { workspaceState } = createWorkspaceState({ app: { glcd: true, serial: false } });
+    const project = folder('project', '/workspace/project');
+
+    expect(
+      buildTec1gVisibilityMessage(
+        { glcd: false, matrix: true },
+        { workspaceState, resolveWorkspace: () => project }
+      )
+    ).toEqual({
+      type: 'uiVisibility',
+      visibility: {
+        ...TEC1G_DEFAULT_PANEL_VISIBILITY,
+        glcd: true,
+        matrix: true,
+        serial: false,
+      },
+      persist: true,
+    });
+  });
+
+  it('returns undefined memento when workspace state, workspace, or project config is unavailable', () => {
+    const project = folder('project', '/workspace/project');
+
+    expect(
+      readTec1gPanelVisibilityMemento({
+        workspaceState: undefined,
+        resolveWorkspace: () => project,
+      })
+    ).toBeUndefined();
+    const missingWorkspace = createWorkspaceState();
+    expect(
+      readTec1gPanelVisibilityMemento({
+        workspaceState: missingWorkspace.workspaceState,
+        resolveWorkspace: () => undefined,
+      })
+    ).toBeUndefined();
+
+    findProjectConfigPath.mockReturnValue(undefined);
+    const missingProject = createWorkspaceState();
+    expect(
+      readTec1gPanelVisibilityMemento({
+        workspaceState: missingProject.workspaceState,
+        resolveWorkspace: () => project,
+      })
+    ).toBeUndefined();
+  });
+
+  it('saves visibility under the target supplied by the webview', () => {
+    const { workspaceState, update } = createWorkspaceState({ app: { glcd: false } });
+    const project = folder('project', '/workspace/project');
+
+    saveTec1gPanelVisibility({ lcd: false }, 'serial', {
+      workspaceState,
+      resolveWorkspace: () => project,
+    });
+
+    expect(update).toHaveBeenCalledWith(TEC1G_UI_VISIBILITY_MEMENTO_KEY, {
+      app: { glcd: false },
+      serial: { lcd: false },
+    });
+    expect(resolveProjectStatusSummary).not.toHaveBeenCalled();
+  });
+
+  it('falls back to resolved project status target when webview target is absent', () => {
+    const { workspaceState, update } = createWorkspaceState();
+    const project = folder('project', '/workspace/project');
+
+    saveTec1gPanelVisibility({ lcd: false }, undefined, {
+      workspaceState,
+      resolveWorkspace: () => project,
+    });
+
+    expect(resolveProjectStatusSummary).toHaveBeenCalledWith(workspaceState, project);
+    expect(update).toHaveBeenCalledWith(TEC1G_UI_VISIBILITY_MEMENTO_KEY, {
+      app: { lcd: false },
+    });
+  });
+
+  it('does not save visibility without workspace state, workspace, or project config', () => {
+    const { workspaceState, update } = createWorkspaceState();
+    const project = folder('project', '/workspace/project');
+
+    saveTec1gPanelVisibility({ lcd: false }, 'app', {
+      workspaceState: undefined,
+      resolveWorkspace: () => project,
+    });
+    saveTec1gPanelVisibility({ lcd: false }, 'app', {
+      workspaceState,
+      resolveWorkspace: () => undefined,
+    });
+
+    findProjectConfigPath.mockReturnValue(undefined);
+    saveTec1gPanelVisibility({ lcd: false }, 'app', {
+      workspaceState,
+      resolveWorkspace: () => project,
+    });
+
+    expect(update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- extract TEC-1G panel visibility merge/read/save logic from `PlatformViewProvider`
- keep the provider responsible for deciding when to post `uiVisibility`
- add focused tests for adapter+memento merge messages, unavailable workspace/config behavior, webview target persistence, resolved target fallback, and no-op save cases

## Validation
- `npx vitest run tests/extension/platform-view-tec1g-visibility.test.ts tests/extension/tec1g-ui-visibility-memento.test.ts tests/extension/platform-view-provider.test.ts tests/extension/platform-view-messages.test.ts`
- `npm run typecheck`
- `npm run lint -- --max-warnings=0`
- `npm run format:check`
- `npm run typecheck:webview`
- `npm test`
- `npm run package:verify --if-present`
- `git diff --check`
