### PR TITLE
Extract platform view memory refresh helpers

### DIFF
--- a/src/extension/platform-view-memory-refresh.ts
+++ b/src/extension/platform-view-memory-refresh.ts
@@ -1,0 +1,74 @@
+/**
+ * @file Memory refresh helpers for the Debug80 platform webview.
+ */
+
+import type { PanelTab } from '../platforms/panel-html';
+import type { MemoryViewState } from '../platforms/panel-memory';
+import {
+  refreshSnapshot,
+  startAutoRefresh,
+  stopAutoRefresh,
+  type RefreshController,
+  type SnapshotRequest,
+} from '../platforms/panel-refresh';
+
+export type MemoryRefreshSyncOptions = {
+  visible: boolean;
+  activeTab: PanelTab;
+  refreshController: RefreshController;
+  intervalMs: number;
+  rehydrate: boolean;
+};
+
+/**
+ * Builds the debug adapter snapshot request for the current panel memory views.
+ */
+export function buildMemorySnapshotPayload(memoryViews: MemoryViewState): SnapshotRequest {
+  const { viewModes, viewAfter, viewAddress } = memoryViews;
+  const views = Object.keys(viewModes).map((id) => ({
+    id,
+    view: viewModes[id] ?? 'hl',
+    after: viewAfter[id] ?? 16,
+    ...(viewModes[id] === 'absolute' && typeof viewAddress[id] === 'number'
+      ? { address: viewAddress[id] }
+      : {}),
+  }));
+  return { views };
+}
+
+/**
+ * Keeps the memory snapshot timer aligned with webview visibility and active tab.
+ */
+export function syncMemoryRefresh(options: MemoryRefreshSyncOptions): void {
+  const { visible, activeTab, refreshController, intervalMs, rehydrate } = options;
+  if (!visible) {
+    return;
+  }
+  if (activeTab !== 'memory') {
+    stopAutoRefresh(refreshController.state);
+    return;
+  }
+  startAutoRefresh(refreshController.state, intervalMs, () => {
+    void refreshSnapshot(
+      refreshController.state,
+      refreshController.handlers,
+      refreshController.snapshotPayload(),
+      { allowErrors: false }
+    );
+  });
+  if (rehydrate) {
+    void refreshSnapshot(
+      refreshController.state,
+      refreshController.handlers,
+      refreshController.snapshotPayload(),
+      { allowErrors: true }
+    );
+  }
+}
+
+/**
+ * Stops the memory snapshot timer for a platform.
+ */
+export function stopMemoryRefresh(refreshController: RefreshController): void {
+  stopAutoRefresh(refreshController.state);
+}

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -11,14 +11,7 @@ import * as vscode from 'vscode';
 import type { DebugSessionStatus } from '../debug/session/session-status';
 import type { Tec1UpdatePayload } from '../platforms/tec1/types';
 import type { Tec1gUpdatePayload } from '../platforms/tec1g/types';
-import {
-  createRefreshController,
-  refreshSnapshot,
-  startAutoRefresh,
-  stopAutoRefresh,
-  type RefreshController,
-  type SnapshotRequest,
-} from '../platforms/panel-refresh';
+import { createRefreshController, type RefreshController } from '../platforms/panel-refresh';
 import type { MemoryViewState } from '../platforms/panel-memory';
 import type { PanelTab } from '../platforms/panel-html';
 import { getTec1gHtml } from '../platforms/tec1g/ui-panel-html';
@@ -40,6 +33,11 @@ import {
   buildPlatformViewProjectStatus,
   resolvePlatformViewWorkspace,
 } from './platform-view-project-status';
+import {
+  buildMemorySnapshotPayload,
+  stopMemoryRefresh,
+  syncMemoryRefresh,
+} from './platform-view-memory-refresh';
 import {
   appendPlatformSerial,
   buildSerialInitMessage,
@@ -403,7 +401,13 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
         this.postMessage(serialInitMessage);
       }
       this.postMessage({ type: 'selectTab', tab: bundle.state.activeTab });
-      this.syncMemoryRefresh(bundle, rehydrate);
+      syncMemoryRefresh({
+        visible: this.view.visible,
+        activeTab: bundle.state.activeTab,
+        refreshController: bundle.state.refreshController,
+        intervalMs: MEMORY_REFRESH_INTERVAL_MS,
+        rehydrate,
+      });
       this.mergeAndPostTec1gPanelVisibility();
       return;
     }
@@ -452,7 +456,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       refreshController: null as unknown as RefreshController,
     };
     state.refreshController = createRefreshController(
-      () => this.buildSnapshotPayload(state.memoryViews),
+      () => buildMemorySnapshotPayload(state.memoryViews),
       {
         postSnapshot: (payload) => this.postSnapshot(modules.snapshotCommand, payload),
         onSnapshotPosted: () => undefined,
@@ -500,38 +504,9 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  private syncMemoryRefresh(
-    bundle: { modules: PlatformUiModules; state: PerPlatformState },
-    rehydrate: boolean
-  ): void {
-    if (this.view?.visible !== true) {
-      return;
-    }
-    if (bundle.state.activeTab !== 'memory') {
-      stopAutoRefresh(bundle.state.refreshController.state);
-      return;
-    }
-    startAutoRefresh(bundle.state.refreshController.state, MEMORY_REFRESH_INTERVAL_MS, () => {
-      void refreshSnapshot(
-        bundle.state.refreshController.state,
-        bundle.state.refreshController.handlers,
-        bundle.state.refreshController.snapshotPayload(),
-        { allowErrors: false }
-      );
-    });
-    if (rehydrate) {
-      void refreshSnapshot(
-        bundle.state.refreshController.state,
-        bundle.state.refreshController.handlers,
-        bundle.state.refreshController.snapshotPayload(),
-        { allowErrors: true }
-      );
-    }
-  }
-
   private stopAllPlatformRefresh(): void {
     for (const state of this.platformStates.values()) {
-      stopAutoRefresh(state.refreshController.state);
+      stopMemoryRefresh(state.refreshController);
     }
   }
 
@@ -631,19 +606,6 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     );
   }
 
-  private buildSnapshotPayload(memoryViews: MemoryViewState): SnapshotRequest {
-    const { viewModes, viewAfter, viewAddress } = memoryViews;
-    const views = Object.keys(viewModes).map((id) => ({
-      id,
-      view: viewModes[id] ?? 'hl',
-      after: viewAfter[id] ?? 16,
-      ...(viewModes[id] === 'absolute' && typeof viewAddress[id] === 'number'
-        ? { address: viewAddress[id] }
-        : {}),
-    }));
-    return { views };
-  }
-
   private onSnapshotFailed(allowErrors: boolean): void {
     if (!allowErrors || !this.view) {
       return;
@@ -673,7 +635,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
 
   private async postSnapshot(
     command: 'debug80/memorySnapshot',
-    payload: SnapshotRequest
+    payload: ReturnType<typeof buildMemorySnapshotPayload>
   ): Promise<void> {
     if (!this.view) {
       throw new Error('Debug80: view unavailable');

--- a/tests/extension/platform-view-memory-refresh.test.ts
+++ b/tests/extension/platform-view-memory-refresh.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @file Platform view memory refresh helper tests.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMemoryViewState } from '../../src/platforms/panel-memory';
+import { createRefreshController } from '../../src/platforms/panel-refresh';
+import {
+  buildMemorySnapshotPayload,
+  stopMemoryRefresh,
+  syncMemoryRefresh,
+} from '../../src/extension/platform-view-memory-refresh';
+
+describe('platform-view-memory-refresh', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('builds snapshot payloads from the current memory view state', () => {
+    const memoryViews = createMemoryViewState();
+    memoryViews.viewModes.a = 'pc';
+    memoryViews.viewAfter.a = 8;
+    memoryViews.viewModes.b = 'absolute';
+    memoryViews.viewAfter.b = 32;
+    memoryViews.viewAddress.b = 0x1234;
+
+    expect(buildMemorySnapshotPayload(memoryViews)).toEqual({
+      views: [
+        { id: 'a', view: 'pc', after: 8 },
+        { id: 'b', view: 'absolute', after: 32, address: 0x1234 },
+        { id: 'c', view: 'hl', after: 16 },
+        { id: 'd', view: 'de', after: 16 },
+      ],
+    });
+  });
+
+  it('starts refresh and rehydrates when the visible active tab is memory', async () => {
+    vi.useFakeTimers();
+    const postSnapshot = vi.fn().mockResolvedValue(undefined);
+    const refreshController = createRefreshController(() => ({ views: [] }), {
+      postSnapshot,
+      onSnapshotPosted: vi.fn(),
+      onSnapshotFailed: vi.fn(),
+    });
+
+    syncMemoryRefresh({
+      visible: true,
+      activeTab: 'memory',
+      refreshController,
+      intervalMs: 50,
+      rehydrate: true,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(postSnapshot).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(postSnapshot).toHaveBeenCalledTimes(2);
+    stopMemoryRefresh(refreshController);
+  });
+
+  it('stops refresh when the visible active tab is not memory', () => {
+    vi.useFakeTimers();
+    const postSnapshot = vi.fn().mockResolvedValue(undefined);
+    const refreshController = createRefreshController(() => ({ views: [] }), {
+      postSnapshot,
+      onSnapshotPosted: vi.fn(),
+      onSnapshotFailed: vi.fn(),
+    });
+
+    syncMemoryRefresh({
+      visible: true,
+      activeTab: 'memory',
+      refreshController,
+      intervalMs: 50,
+      rehydrate: false,
+    });
+    expect(refreshController.state.timer).not.toBeUndefined();
+
+    syncMemoryRefresh({
+      visible: true,
+      activeTab: 'ui',
+      refreshController,
+      intervalMs: 50,
+      rehydrate: false,
+    });
+
+    expect(refreshController.state.timer).toBeUndefined();
+  });
+
+  it('does not start refresh while the view is hidden', () => {
+    vi.useFakeTimers();
+    const postSnapshot = vi.fn().mockResolvedValue(undefined);
+    const refreshController = createRefreshController(() => ({ views: [] }), {
+      postSnapshot,
+      onSnapshotPosted: vi.fn(),
+      onSnapshotFailed: vi.fn(),
+    });
+
+    syncMemoryRefresh({
+      visible: false,
+      activeTab: 'memory',
+      refreshController,
+      intervalMs: 50,
+      rehydrate: true,
+    });
+
+    expect(refreshController.state.timer).toBeUndefined();
+    expect(postSnapshot).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Move platform view memory snapshot payload and refresh timer decisions into a dedicated helper module
- Keep VS Code session/webview snapshot posting inside PlatformViewProvider
- Add focused tests for payload creation, visible memory-tab refresh, tab stop, and hidden view behavior

## Verification
- npx vitest run tests/extension/platform-view-memory-refresh.test.ts tests/extension/platform-view-provider.test.ts
- npm run typecheck
- npm run typecheck:webview
- npm run lint -- --max-warnings=0
- npm run format:check
- npm test
- git diff --check