### PR TITLE
Extract platform view config controls

### DIFF
--- a/src/extension/platform-view-config-controls.ts
+++ b/src/extension/platform-view-config-controls.ts
@@ -1,0 +1,50 @@
+/**
+ * @file Project/config control helpers for the Debug80 platform view.
+ */
+
+import * as vscode from 'vscode';
+import type { PlatformId } from '../contracts/platform-view';
+import { findProjectConfigPath } from './project-config';
+
+export type SaveProjectConfigResult =
+  | { kind: 'noWorkspace' }
+  | { kind: 'selectPlatform'; platform: PlatformId }
+  | { kind: 'invalidPlatform' }
+  | { kind: 'projectAlreadyInitialized' };
+
+export interface SaveProjectConfigContext {
+  resolveWorkspace: () => vscode.WorkspaceFolder | undefined;
+}
+
+/**
+ * Normalizes user/webview platform strings to supported platform ids.
+ */
+export function normalizePlatformId(platform: string): PlatformId | undefined {
+  const normalized = platform.trim().toLowerCase();
+  if (normalized === 'simple' || normalized === 'tec1' || normalized === 'tec1g') {
+    return normalized;
+  }
+  return undefined;
+}
+
+/**
+ * Resolves how the provider should respond to the webview's saveProjectConfig action.
+ */
+export function resolveSaveProjectConfigAction(
+  platform: string,
+  ctx: SaveProjectConfigContext
+): SaveProjectConfigResult {
+  const folder = ctx.resolveWorkspace();
+  if (folder === undefined) {
+    return { kind: 'noWorkspace' };
+  }
+  const configPath = findProjectConfigPath(folder);
+  if (configPath !== undefined) {
+    return { kind: 'projectAlreadyInitialized' };
+  }
+  const normalized = normalizePlatformId(platform);
+  if (normalized === undefined) {
+    return { kind: 'invalidPlatform' };
+  }
+  return { kind: 'selectPlatform', platform: normalized };
+}

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -19,7 +19,6 @@ import {
   buildTec1gVisibilityMessage,
   saveTec1gPanelVisibility,
 } from './platform-view-tec1g-visibility';
-import { findProjectConfigPath } from './project-config';
 import { handlePlatformViewMessage } from './platform-view-messages';
 import {
   handlePlatformSerialSave,
@@ -38,6 +37,7 @@ import {
   stopMemoryRefresh,
   syncMemoryRefresh,
 } from './platform-view-memory-refresh';
+import { resolveSaveProjectConfigAction } from './platform-view-config-controls';
 import {
   appendPlatformSerial,
   buildSerialInitMessage,
@@ -516,32 +516,24 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
 
   /** Applies the shared platform selector only for uninitialized workspaces. */
   private handleSaveProjectConfig(platform: string): void {
-    const folder = this.resolveSelectedWorkspace();
-    if (folder === undefined) {
+    const action = resolveSaveProjectConfigAction(platform, {
+      resolveWorkspace: () => this.resolveSelectedWorkspace(),
+    });
+    if (action.kind === 'noWorkspace') {
       void vscode.window.showErrorMessage('Debug80: No workspace folder selected.');
       return;
     }
-    const configPath = findProjectConfigPath(folder);
-    if (configPath === undefined) {
-      const normalized = this.normalizePlatformId(platform);
-      if (normalized !== undefined) {
-        this.currentPlatform = normalized;
-        this.renderCurrentView(true);
-        return;
-      }
+    if (action.kind === 'selectPlatform') {
+      this.currentPlatform = action.platform;
+      this.renderCurrentView(true);
+      return;
+    }
+    if (action.kind === 'invalidPlatform') {
       void vscode.window.showErrorMessage('Debug80: No project config found in workspace.');
       return;
     }
     this.postProjectStatus();
     this.mergeAndPostTec1gPanelVisibility();
-  }
-
-  private normalizePlatformId(platform: string): PlatformId | undefined {
-    const normalized = platform.trim().toLowerCase();
-    if (normalized === 'simple' || normalized === 'tec1' || normalized === 'tec1g') {
-      return normalized;
-    }
-    return undefined;
   }
 
   private handleSetStopOnEntry(value: boolean): void {

--- a/tests/extension/platform-view-config-controls.test.ts
+++ b/tests/extension/platform-view-config-controls.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @file Platform view config control helper tests.
+ */
+
+import { existsSync } from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as vscode from 'vscode';
+import {
+  normalizePlatformId,
+  resolveSaveProjectConfigAction,
+} from '../../src/extension/platform-view-config-controls';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+  };
+});
+
+describe('platform-view-config-controls', () => {
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReset();
+  });
+
+  it('normalizes supported platform ids', () => {
+    expect(normalizePlatformId(' SIMPLE ')).toBe('simple');
+    expect(normalizePlatformId('Tec1')).toBe('tec1');
+    expect(normalizePlatformId('tec1g')).toBe('tec1g');
+    expect(normalizePlatformId('unknown')).toBeUndefined();
+  });
+
+  it('reports no workspace when no selected workspace can be resolved', () => {
+    expect(
+      resolveSaveProjectConfigAction('tec1g', {
+        resolveWorkspace: () => undefined,
+      })
+    ).toEqual({ kind: 'noWorkspace' });
+  });
+
+  it('selects a platform for uninitialized workspaces', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(
+      resolveSaveProjectConfigAction('tec1g', {
+        resolveWorkspace: () => createFolder('/workspace/demo'),
+      })
+    ).toEqual({ kind: 'selectPlatform', platform: 'tec1g' });
+  });
+
+  it('rejects invalid platform values for uninitialized workspaces', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(
+      resolveSaveProjectConfigAction('bad', {
+        resolveWorkspace: () => createFolder('/workspace/demo'),
+      })
+    ).toEqual({ kind: 'invalidPlatform' });
+  });
+
+  it('keeps initialized projects unchanged', () => {
+    vi.mocked(existsSync).mockImplementation((path) => String(path).endsWith('/debug80.json'));
+
+    expect(
+      resolveSaveProjectConfigAction('simple', {
+        resolveWorkspace: () => createFolder('/workspace/demo'),
+      })
+    ).toEqual({ kind: 'projectAlreadyInitialized' });
+  });
+});
+
+function createFolder(fsPath: string): vscode.WorkspaceFolder {
+  return { name: 'demo', uri: { fsPath } } as vscode.WorkspaceFolder;
+}

--- a/tests/extension/platform-view-config-controls.test.ts
+++ b/tests/extension/platform-view-config-controls.test.ts
@@ -59,7 +59,9 @@ describe('platform-view-config-controls', () => {
   });
 
   it('keeps initialized projects unchanged', () => {
-    vi.mocked(existsSync).mockImplementation((path) => String(path).endsWith('/debug80.json'));
+    vi.mocked(existsSync).mockImplementation((candidate) =>
+      String(candidate).replace(/\\/g, '/').endsWith('/debug80.json')
+    );
 
     expect(
       resolveSaveProjectConfigAction('simple', {


### PR DESCRIPTION
## Summary
- Move platform normalization and saveProjectConfig decision logic out of PlatformViewProvider
- Keep VS Code UI messaging and render/status side effects inside the provider
- Add focused tests for no-workspace, initialized-project, uninitialized-project, and invalid-platform outcomes

## Verification
- npx vitest run tests/extension/platform-view-config-controls.test.ts tests/extension/platform-view-provider.test.ts tests/extension/platform-view-messages.test.ts
- npm run typecheck
- npm run typecheck:webview
- npm run lint -- --max-warnings=0
- npm run format:check
- npm test
- npm run package:verify --if-present
- git diff --check