### PR TITLE
Extract platform view runtime state helpers

### DIFF
--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -12,7 +12,6 @@ import type { DebugSessionStatus } from '../debug/session/session-status';
 import type { Tec1UpdatePayload } from '../platforms/tec1/types';
 import type { Tec1gUpdatePayload } from '../platforms/tec1g/types';
 import { createRefreshController, type RefreshController } from '../platforms/panel-refresh';
-import type { MemoryViewState } from '../platforms/panel-memory';
 import type { PanelTab } from '../platforms/panel-html';
 import { getTec1gHtml } from '../platforms/tec1g/ui-panel-html';
 import {
@@ -43,8 +42,14 @@ import {
   buildSerialInitMessage,
   clearPlatformSerial,
   createSerialBuffer,
-  type SerialBuffer,
 } from './platform-view-serial-state';
+import {
+  applyPlatformRuntimeUpdate,
+  buildPlatformRuntimeClearMessage,
+  buildPlatformRuntimeUpdateMessage,
+  clearPlatformRuntimeState,
+  type PlatformRuntimeState,
+} from './platform-view-runtime-state';
 
 const MEMORY_REFRESH_INTERVAL_MS = 500;
 
@@ -56,12 +61,8 @@ const MEMORY_REFRESH_INTERVAL_MS = 500;
  * Mutable state held by the provider for each loaded platform.
  * One instance exists per registered platform for the lifetime of the provider.
  */
-interface PerPlatformState {
+interface PerPlatformState extends PlatformRuntimeState {
   activeTab: PanelTab;
-  uiState: unknown;
-  hasPostedRuntimeUpdate: boolean;
-  serialBuffer: SerialBuffer;
-  memoryViews: MemoryViewState;
   refreshController: RefreshController;
 }
 
@@ -206,9 +207,9 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     if (bundle === undefined) {
       return;
     }
-    const updateFields = bundle.modules.applyUpdate(bundle.state.uiState, payload);
-    bundle.state.hasPostedRuntimeUpdate = true;
-    this.postMessage({ type: 'update', uiRevision: this.nextUiRevision(), ...updateFields });
+    this.postMessage(
+      applyPlatformRuntimeUpdate(bundle.modules, bundle.state, payload, this.nextUiRevision())
+    );
   }
 
   updateTec1g(payload: Tec1gUpdatePayload, sessionId?: string): void {
@@ -219,9 +220,9 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     if (bundle === undefined) {
       return;
     }
-    const updateFields = bundle.modules.applyUpdate(bundle.state.uiState, payload);
-    bundle.state.hasPostedRuntimeUpdate = true;
-    this.postMessage({ type: 'update', uiRevision: this.nextUiRevision(), ...updateFields });
+    this.postMessage(
+      applyPlatformRuntimeUpdate(bundle.modules, bundle.state, payload, this.nextUiRevision())
+    );
   }
 
   appendTec1Serial(text: string, sessionId?: string): void {
@@ -240,16 +241,15 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     for (const [id, state] of this.platformStates) {
       const modules = this.loadedModules.get(id);
       if (modules !== undefined) {
-        modules.resetUiState(state.uiState);
-        state.memoryViews = modules.createMemoryViewState();
-        state.hasPostedRuntimeUpdate = false;
+        clearPlatformRuntimeState(modules, state);
+      } else {
+        clearPlatformSerial(state.serialBuffer);
       }
-      clearPlatformSerial(state.serialBuffer);
     }
     const bundle = this.getCurrentBundle();
     if (bundle !== undefined) {
       this.postMessage(
-        bundle.modules.buildClearMessage(bundle.state.uiState, this.nextUiRevision())
+        buildPlatformRuntimeClearMessage(bundle.modules, bundle.state, this.nextUiRevision())
       );
       this.postMessage({ type: 'serialClear' });
     }
@@ -394,7 +394,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       this.postProjectStatus();
       this.postSessionStatus();
       this.postMessage(
-        bundle.modules.buildUpdateMessage(bundle.state.uiState, this.nextUiRevision())
+        buildPlatformRuntimeUpdateMessage(bundle.modules, bundle.state, this.nextUiRevision())
       );
       const serialInitMessage = buildSerialInitMessage(bundle.state.serialBuffer);
       if (serialInitMessage !== undefined) {

--- a/src/extension/platform-view-runtime-state.ts
+++ b/src/extension/platform-view-runtime-state.ts
@@ -1,0 +1,63 @@
+/**
+ * @file Runtime UI state helpers for the Debug80 platform view.
+ */
+
+import type { MemoryViewState } from '../platforms/panel-memory';
+import type { PlatformUiModules } from './platform-view-manifest';
+import { clearPlatformSerial, type SerialBuffer } from './platform-view-serial-state';
+
+export interface PlatformRuntimeState {
+  uiState: unknown;
+  hasPostedRuntimeUpdate: boolean;
+  serialBuffer: SerialBuffer;
+  memoryViews: MemoryViewState;
+}
+
+/**
+ * Applies an adapter update and returns the message payload for the webview.
+ */
+export function applyPlatformRuntimeUpdate(
+  modules: PlatformUiModules,
+  state: PlatformRuntimeState,
+  payload: unknown,
+  uiRevision: number
+): Record<string, unknown> {
+  const updateFields = modules.applyUpdate(state.uiState, payload);
+  state.hasPostedRuntimeUpdate = true;
+  return { type: 'update', uiRevision, ...updateFields };
+}
+
+/**
+ * Builds a render-time update message for the current runtime state.
+ */
+export function buildPlatformRuntimeUpdateMessage(
+  modules: PlatformUiModules,
+  state: Pick<PlatformRuntimeState, 'uiState'>,
+  uiRevision: number
+): Record<string, unknown> {
+  return modules.buildUpdateMessage(state.uiState, uiRevision);
+}
+
+/**
+ * Resets one platform's runtime UI, memory, and serial state.
+ */
+export function clearPlatformRuntimeState(
+  modules: PlatformUiModules,
+  state: PlatformRuntimeState
+): void {
+  modules.resetUiState(state.uiState);
+  state.memoryViews = modules.createMemoryViewState();
+  state.hasPostedRuntimeUpdate = false;
+  clearPlatformSerial(state.serialBuffer);
+}
+
+/**
+ * Builds a clear message for a platform after its state has been reset.
+ */
+export function buildPlatformRuntimeClearMessage(
+  modules: PlatformUiModules,
+  state: Pick<PlatformRuntimeState, 'uiState'>,
+  uiRevision: number
+): Record<string, unknown> {
+  return modules.buildClearMessage(state.uiState, uiRevision);
+}

--- a/tests/extension/platform-view-runtime-state.test.ts
+++ b/tests/extension/platform-view-runtime-state.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @file Platform view runtime state helper tests.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { createMemoryViewState } from '../../src/platforms/panel-memory';
+import type { PlatformUiModules } from '../../src/extension/platform-view-manifest';
+import {
+  applyPlatformRuntimeUpdate,
+  buildPlatformRuntimeClearMessage,
+  buildPlatformRuntimeUpdateMessage,
+  clearPlatformRuntimeState,
+  type PlatformRuntimeState,
+} from '../../src/extension/platform-view-runtime-state';
+import {
+  appendPlatformSerial,
+  buildSerialInitMessage,
+  createSerialBuffer,
+} from '../../src/extension/platform-view-serial-state';
+
+describe('platform-view-runtime-state', () => {
+  it('applies adapter updates and marks runtime state as posted', () => {
+    const modules = createModules();
+    const state = createState();
+
+    expect(applyPlatformRuntimeUpdate(modules, state, { digits: [1, 2, 3] }, 7)).toEqual({
+      type: 'update',
+      uiRevision: 7,
+      display: 'updated',
+    });
+    expect(modules.applyUpdate).toHaveBeenCalledWith(state.uiState, { digits: [1, 2, 3] });
+    expect(state.hasPostedRuntimeUpdate).toBe(true);
+  });
+
+  it('builds render-time update messages without mutating posted state', () => {
+    const modules = createModules();
+    const state = createState();
+
+    expect(buildPlatformRuntimeUpdateMessage(modules, state, 3)).toEqual({
+      type: 'update',
+      uiRevision: 3,
+      display: 'rendered',
+    });
+    expect(state.hasPostedRuntimeUpdate).toBe(false);
+  });
+
+  it('clears platform runtime state', () => {
+    const modules = createModules();
+    const state = createState();
+    state.hasPostedRuntimeUpdate = true;
+    state.memoryViews.viewModes.a = 'absolute';
+    appendPlatformSerial(state.serialBuffer, 'hello', {
+      platform: 'tec1',
+      currentPlatform: 'tec1',
+    });
+
+    clearPlatformRuntimeState(modules, state);
+
+    expect(modules.resetUiState).toHaveBeenCalledWith(state.uiState);
+    expect(state.hasPostedRuntimeUpdate).toBe(false);
+    expect(state.memoryViews.viewModes.a).toBe('pc');
+    expect(buildSerialInitMessage(state.serialBuffer)).toBeUndefined();
+  });
+
+  it('builds clear messages from the current UI state', () => {
+    const modules = createModules();
+    const state = createState();
+
+    expect(buildPlatformRuntimeClearMessage(modules, state, 12)).toEqual({
+      type: 'clear',
+      uiRevision: 12,
+    });
+    expect(modules.buildClearMessage).toHaveBeenCalledWith(state.uiState, 12);
+  });
+});
+
+function createState(): PlatformRuntimeState {
+  return {
+    uiState: { display: 'initial' },
+    hasPostedRuntimeUpdate: false,
+    serialBuffer: createSerialBuffer(),
+    memoryViews: createMemoryViewState(),
+  };
+}
+
+function createModules(): PlatformUiModules {
+  return {
+    createUiState: vi.fn(() => ({ display: 'initial' })),
+    resetUiState: vi.fn(),
+    applyUpdate: vi.fn(() => ({ display: 'updated' })),
+    createMemoryViewState,
+    getHtml: vi.fn(),
+    handleMessage: vi.fn(),
+    buildUpdateMessage: vi.fn((_state, uiRevision) => ({
+      type: 'update',
+      uiRevision,
+      display: 'rendered',
+    })),
+    buildClearMessage: vi.fn((_state, uiRevision) => ({ type: 'clear', uiRevision })),
+    snapshotCommand: 'debug80/memorySnapshot',
+  };
+}


### PR DESCRIPTION
## Summary
- Move adapter update, render update, clear message, and per-platform runtime reset logic into a dedicated helper module
- Keep PlatformViewProvider responsible for session/platform routing and webview posting
- Add focused tests for update application, render messages, clear messages, and runtime state reset

## Verification
- npx vitest run tests/extension/platform-view-runtime-state.test.ts tests/extension/platform-view-provider.test.ts
- npm run typecheck
- npm run typecheck:webview
- npm run lint -- --max-warnings=0
- npm run format:check
- npm test
- npm run package:verify --if-present
- git diff --check