### PR TITLE
Extract platform view session state helpers

### DIFF
--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -50,6 +50,16 @@ import {
   clearPlatformRuntimeState,
   type PlatformRuntimeState,
 } from './platform-view-runtime-state';
+import {
+  buildPlatformViewSessionStatusMessage,
+  clearPlatformViewSession,
+  createPlatformViewSessionState,
+  isCurrentPlatformViewSession,
+  resolvePlatformViewDebugSession,
+  setPlatformViewSession,
+  setPlatformViewSessionStatus,
+  shouldAcceptPlatformViewSession,
+} from './platform-view-session-state';
 
 const MEMORY_REFRESH_INTERVAL_MS = 500;
 
@@ -75,11 +85,9 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
 
   private view: vscode.WebviewView | undefined;
   private currentPlatform: PlatformId | undefined;
-  private currentSession: vscode.DebugSession | undefined;
-  private currentSessionId: string | undefined;
+  private readonly sessionState = createPlatformViewSessionState();
   private uiRevision = 0;
   private selectedWorkspace: vscode.WorkspaceFolder | undefined;
-  private sessionStatus: DebugSessionStatus = 'not running';
   private readonly workspaceState: vscode.Memento | undefined;
   private readonly extensionUri: vscode.Uri;
   private readonly performanceMonitor: UiPerformanceMonitor;
@@ -164,8 +172,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   ): void {
     this.currentPlatform = platform;
     if (session !== undefined) {
-      this.currentSession = session;
-      this.currentSessionId = session.id;
+      setPlatformViewSession(this.sessionState, session);
     }
     if (options?.tab === 'ui' || options?.tab === 'memory') {
       const bundle = this.getActiveBundle(platform);
@@ -180,11 +187,11 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   }
 
   setSessionStatus(status: DebugSessionStatus): void {
-    this.sessionStatus = status;
+    setPlatformViewSessionStatus(this.sessionState, status);
     if (!this.currentPlatform) {
       return;
     }
-    this.postMessage({ type: 'sessionStatus', status });
+    this.postMessage(buildPlatformViewSessionStatusMessage(this.sessionState));
   }
 
   /**
@@ -200,7 +207,10 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   }
 
   updateTec1(payload: Tec1UpdatePayload, sessionId?: string): void {
-    if (!this.shouldAcceptSession(sessionId) || this.currentPlatform !== 'tec1') {
+    if (
+      !shouldAcceptPlatformViewSession(this.sessionState, sessionId) ||
+      this.currentPlatform !== 'tec1'
+    ) {
       return;
     }
     const bundle = this.getActiveBundle('tec1');
@@ -213,7 +223,10 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   }
 
   updateTec1g(payload: Tec1gUpdatePayload, sessionId?: string): void {
-    if (!this.shouldAcceptSession(sessionId) || this.currentPlatform !== 'tec1g') {
+    if (
+      !shouldAcceptPlatformViewSession(this.sessionState, sessionId) ||
+      this.currentPlatform !== 'tec1g'
+    ) {
       return;
     }
     const bundle = this.getActiveBundle('tec1g');
@@ -256,11 +269,10 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   }
 
   handleSessionTerminated(sessionId: string): void {
-    if (this.currentSessionId !== sessionId) {
+    if (!isCurrentPlatformViewSession(this.sessionState, sessionId)) {
       return;
     }
-    this.currentSession = undefined;
-    this.currentSessionId = undefined;
+    clearPlatformViewSession(this.sessionState);
     this.tec1gAdapterVisibility = undefined;
     this.setSessionStatus('not running');
     this.stopAllPlatformRefresh();
@@ -323,7 +335,8 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
         },
         handleSerialSendFile: async () => {
           await handlePlatformSerialSendFile({
-            getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
+            getSession: () =>
+              resolvePlatformViewDebugSession(this.sessionState, vscode.debug.activeDebugSession),
             getPlatform: () => this.currentPlatform,
           });
         },
@@ -342,7 +355,8 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
             return;
           }
           await bundle.modules.handleMessage(platformMsg, {
-            getSession: () => this.currentSession ?? vscode.debug.activeDebugSession,
+            getSession: () =>
+              resolvePlatformViewDebugSession(this.sessionState, vscode.debug.activeDebugSession),
             refreshController: bundle.state.refreshController,
             autoRefreshMs: MEMORY_REFRESH_INTERVAL_MS,
             setActiveTab: (tab) => {
@@ -488,7 +502,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   }
 
   private appendSerial(platform: PlatformId, text: string, sessionId?: string): void {
-    if (!this.shouldAcceptSession(sessionId)) {
+    if (!shouldAcceptPlatformViewSession(this.sessionState, sessionId)) {
       return;
     }
     const bundle = this.getActiveBundle(platform);
@@ -564,7 +578,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     if (!this.view || !this.currentPlatform) {
       return;
     }
-    this.postMessage({ type: 'sessionStatus', status: this.sessionStatus });
+    this.postMessage(buildPlatformViewSessionStatusMessage(this.sessionState));
   }
 
   private mergeAndPostTec1gPanelVisibility(): void {
@@ -613,13 +627,6 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     void this.view.webview.postMessage(payload);
   }
 
-  private shouldAcceptSession(sessionId?: string): boolean {
-    if (sessionId === undefined || this.currentSessionId === undefined) {
-      return true;
-    }
-    return this.currentSessionId === sessionId;
-  }
-
   private nextUiRevision(): number {
     this.uiRevision += 1;
     return this.uiRevision;
@@ -632,7 +639,10 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     if (!this.view) {
       throw new Error('Debug80: view unavailable');
     }
-    const target = this.currentSession ?? vscode.debug.activeDebugSession;
+    const target = resolvePlatformViewDebugSession(
+      this.sessionState,
+      vscode.debug.activeDebugSession
+    );
     if (!target || target.type !== 'z80') {
       throw new Error('Debug80: No active z80 session.');
     }

--- a/src/extension/platform-view-session-state.ts
+++ b/src/extension/platform-view-session-state.ts
@@ -1,0 +1,94 @@
+/**
+ * @file Debug session state helpers for the Debug80 platform view.
+ */
+
+import type * as vscode from 'vscode';
+import type { DebugSessionStatus } from '../debug/session/session-status';
+
+export interface PlatformViewSessionState {
+  currentSession: vscode.DebugSession | undefined;
+  currentSessionId: string | undefined;
+  sessionStatus: DebugSessionStatus;
+}
+
+/**
+ * Creates the provider's initial debug session state.
+ */
+export function createPlatformViewSessionState(): PlatformViewSessionState {
+  return {
+    currentSession: undefined,
+    currentSessionId: undefined,
+    sessionStatus: 'not running',
+  };
+}
+
+/**
+ * Tracks a newly associated platform debug session.
+ */
+export function setPlatformViewSession(
+  state: PlatformViewSessionState,
+  session: vscode.DebugSession
+): void {
+  state.currentSession = session;
+  state.currentSessionId = session.id;
+}
+
+/**
+ * Clears the currently tracked platform debug session.
+ */
+export function clearPlatformViewSession(state: PlatformViewSessionState): void {
+  state.currentSession = undefined;
+  state.currentSessionId = undefined;
+}
+
+/**
+ * Updates the tracked session status.
+ */
+export function setPlatformViewSessionStatus(
+  state: PlatformViewSessionState,
+  status: DebugSessionStatus
+): void {
+  state.sessionStatus = status;
+}
+
+/**
+ * Returns true when an incoming event belongs to the tracked session.
+ */
+export function isCurrentPlatformViewSession(
+  state: PlatformViewSessionState,
+  sessionId: string
+): boolean {
+  return state.currentSessionId === sessionId;
+}
+
+/**
+ * Returns true when an optional event session id should be accepted.
+ */
+export function shouldAcceptPlatformViewSession(
+  state: PlatformViewSessionState,
+  sessionId?: string
+): boolean {
+  if (sessionId === undefined || state.currentSessionId === undefined) {
+    return true;
+  }
+  return state.currentSessionId === sessionId;
+}
+
+/**
+ * Resolves the best debug session for platform webview requests.
+ */
+export function resolvePlatformViewDebugSession(
+  state: PlatformViewSessionState,
+  activeSession: vscode.DebugSession | undefined
+): vscode.DebugSession | undefined {
+  return state.currentSession ?? activeSession;
+}
+
+/**
+ * Builds the session status message for the webview.
+ */
+export function buildPlatformViewSessionStatusMessage(
+  state: PlatformViewSessionState
+): Record<string, unknown> {
+  return { type: 'sessionStatus', status: state.sessionStatus };
+}

--- a/tests/extension/platform-view-session-state.test.ts
+++ b/tests/extension/platform-view-session-state.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @file Platform view debug session state helper tests.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type * as vscode from 'vscode';
+import {
+  buildPlatformViewSessionStatusMessage,
+  clearPlatformViewSession,
+  createPlatformViewSessionState,
+  isCurrentPlatformViewSession,
+  resolvePlatformViewDebugSession,
+  setPlatformViewSession,
+  setPlatformViewSessionStatus,
+  shouldAcceptPlatformViewSession,
+} from '../../src/extension/platform-view-session-state';
+
+describe('platform-view-session-state', () => {
+  it('tracks and clears the current debug session', () => {
+    const state = createPlatformViewSessionState();
+    const session = createSession('session-1');
+
+    setPlatformViewSession(state, session);
+
+    expect(state.currentSession).toBe(session);
+    expect(state.currentSessionId).toBe('session-1');
+    expect(isCurrentPlatformViewSession(state, 'session-1')).toBe(true);
+    expect(isCurrentPlatformViewSession(state, 'session-2')).toBe(false);
+
+    clearPlatformViewSession(state);
+
+    expect(state.currentSession).toBeUndefined();
+    expect(state.currentSessionId).toBeUndefined();
+  });
+
+  it('accepts unscoped events and filters scoped events by tracked session id', () => {
+    const state = createPlatformViewSessionState();
+
+    expect(shouldAcceptPlatformViewSession(state)).toBe(true);
+    expect(shouldAcceptPlatformViewSession(state, 'session-1')).toBe(true);
+
+    setPlatformViewSession(state, createSession('session-1'));
+
+    expect(shouldAcceptPlatformViewSession(state)).toBe(true);
+    expect(shouldAcceptPlatformViewSession(state, 'session-1')).toBe(true);
+    expect(shouldAcceptPlatformViewSession(state, 'session-2')).toBe(false);
+  });
+
+  it('prefers the tracked session over the active debug session', () => {
+    const state = createPlatformViewSessionState();
+    const tracked = createSession('tracked');
+    const active = createSession('active');
+
+    expect(resolvePlatformViewDebugSession(state, active)).toBe(active);
+
+    setPlatformViewSession(state, tracked);
+
+    expect(resolvePlatformViewDebugSession(state, active)).toBe(tracked);
+  });
+
+  it('builds session status messages from tracked status', () => {
+    const state = createPlatformViewSessionState();
+
+    expect(buildPlatformViewSessionStatusMessage(state)).toEqual({
+      type: 'sessionStatus',
+      status: 'not running',
+    });
+
+    setPlatformViewSessionStatus(state, 'running');
+
+    expect(buildPlatformViewSessionStatusMessage(state)).toEqual({
+      type: 'sessionStatus',
+      status: 'running',
+    });
+  });
+});
+
+function createSession(id: string): vscode.DebugSession {
+  return { id, type: 'z80' } as vscode.DebugSession;
+}


### PR DESCRIPTION
## Summary
- Move platform view debug session tracking, session-id filtering, active-session fallback, and status message construction into a helper module
- Keep PlatformViewProvider responsible for webview posting, platform routing, and termination side effects
- Add focused tests for tracking/clearing sessions, scoped event filtering, active-session fallback, and status messages

## Verification
- npx vitest run tests/extension/platform-view-session-state.test.ts tests/extension/platform-view-provider.test.ts
- npm run typecheck
- npm run typecheck:webview
- npm run lint -- --max-warnings=0
- npm run format:check
- npm test
- npm run package:verify --if-present
- git diff --check