### PR TITLE
Extract platform view reveal helper

### DIFF
--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -60,6 +60,7 @@ import {
   setPlatformViewSessionStatus,
   shouldAcceptPlatformViewSession,
 } from './platform-view-session-state';
+import { revealPlatformView } from './platform-view-reveal';
 
 const MEMORY_REFRESH_INTERVAL_MS = 500;
 
@@ -121,25 +122,12 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   // -------------------------------------------------------------------------
 
   reveal(focus = false): void {
-    const focusCommand = `${PlatformViewProvider.viewType}.focus`;
-    const fallbackCommand = 'workbench.view.debug';
-    const command = focus ? focusCommand : fallbackCommand;
-
-    void vscode.commands.executeCommand(command).then(
-      () => {
-        this.view?.show?.(!focus);
-      },
-      () => {
-        void vscode.commands.executeCommand(fallbackCommand).then(
-          () => {
-            this.view?.show?.(!focus);
-          },
-          () => {
-            this.view?.show?.(!focus);
-          }
-        );
-      }
-    );
+    revealPlatformView({
+      focusCommand: `${PlatformViewProvider.viewType}.focus`,
+      fallbackCommand: 'workbench.view.debug',
+      focus,
+      target: this.view,
+    });
   }
 
   setSelectedWorkspace(folder: vscode.WorkspaceFolder | undefined): void {

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -126,7 +126,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       focusCommand: `${PlatformViewProvider.viewType}.focus`,
       fallbackCommand: 'workbench.view.debug',
       focus,
-      target: this.view,
+      target: () => this.view,
     });
   }
 

--- a/src/extension/platform-view-reveal.ts
+++ b/src/extension/platform-view-reveal.ts
@@ -1,0 +1,49 @@
+/**
+ * @file Reveal/focus helper for the Debug80 platform view.
+ */
+
+import * as vscode from 'vscode';
+
+export interface PlatformViewRevealCommands {
+  executeCommand: (command: string) => Thenable<unknown>;
+}
+
+export interface PlatformViewRevealTarget {
+  show?: (preserveFocus?: boolean) => void;
+}
+
+export interface PlatformViewRevealOptions {
+  focusCommand: string;
+  fallbackCommand: string;
+  focus: boolean;
+  target: PlatformViewRevealTarget | undefined;
+  commands?: PlatformViewRevealCommands;
+}
+
+/**
+ * Reveals the platform view, falling back to the Debug view if direct focus fails.
+ */
+export function revealPlatformView(options: PlatformViewRevealOptions): void {
+  const { focusCommand, fallbackCommand, focus, target, commands = vscodeCommands() } = options;
+  const command = focus ? focusCommand : fallbackCommand;
+
+  void commands.executeCommand(command).then(
+    () => {
+      target?.show?.(!focus);
+    },
+    () => {
+      void commands.executeCommand(fallbackCommand).then(
+        () => {
+          target?.show?.(!focus);
+        },
+        () => {
+          target?.show?.(!focus);
+        }
+      );
+    }
+  );
+}
+
+function vscodeCommands(): PlatformViewRevealCommands {
+  return vscode.commands;
+}

--- a/src/extension/platform-view-reveal.ts
+++ b/src/extension/platform-view-reveal.ts
@@ -16,7 +16,7 @@ export interface PlatformViewRevealOptions {
   focusCommand: string;
   fallbackCommand: string;
   focus: boolean;
-  target: PlatformViewRevealTarget | undefined;
+  target: () => PlatformViewRevealTarget | undefined;
   commands?: PlatformViewRevealCommands;
 }
 
@@ -29,15 +29,15 @@ export function revealPlatformView(options: PlatformViewRevealOptions): void {
 
   void commands.executeCommand(command).then(
     () => {
-      target?.show?.(!focus);
+      target()?.show?.(!focus);
     },
     () => {
       void commands.executeCommand(fallbackCommand).then(
         () => {
-          target?.show?.(!focus);
+          target()?.show?.(!focus);
         },
         () => {
-          target?.show?.(!focus);
+          target()?.show?.(!focus);
         }
       );
     }

--- a/tests/extension/platform-view-reveal.test.ts
+++ b/tests/extension/platform-view-reveal.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @file Platform view reveal helper tests.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { revealPlatformView } from '../../src/extension/platform-view-reveal';
+
+vi.mock('vscode', () => ({
+  commands: {
+    executeCommand: vi.fn(),
+  },
+}));
+
+describe('platform-view-reveal', () => {
+  it('focuses the platform view command and shows without preserving focus', () => {
+    const executeCommand = vi.fn(() => resolvedThenable());
+    const show = vi.fn();
+
+    revealPlatformView({
+      focusCommand: 'debug80.platformView.focus',
+      fallbackCommand: 'workbench.view.debug',
+      focus: true,
+      target: { show },
+      commands: { executeCommand },
+    });
+
+    expect(executeCommand).toHaveBeenCalledWith('debug80.platformView.focus');
+    expect(show).toHaveBeenCalledWith(false);
+  });
+
+  it('uses the fallback command when focus is not requested', () => {
+    const executeCommand = vi.fn(() => resolvedThenable());
+    const show = vi.fn();
+
+    revealPlatformView({
+      focusCommand: 'debug80.platformView.focus',
+      fallbackCommand: 'workbench.view.debug',
+      focus: false,
+      target: { show },
+      commands: { executeCommand },
+    });
+
+    expect(executeCommand).toHaveBeenCalledWith('workbench.view.debug');
+    expect(show).toHaveBeenCalledWith(true);
+  });
+
+  it('falls back to the debug view when direct focus fails', () => {
+    const executeCommand = vi
+      .fn()
+      .mockReturnValueOnce(rejectedThenable())
+      .mockReturnValueOnce(resolvedThenable());
+    const show = vi.fn();
+
+    revealPlatformView({
+      focusCommand: 'debug80.platformView.focus',
+      fallbackCommand: 'workbench.view.debug',
+      focus: true,
+      target: { show },
+      commands: { executeCommand },
+    });
+
+    expect(executeCommand).toHaveBeenNthCalledWith(1, 'debug80.platformView.focus');
+    expect(executeCommand).toHaveBeenNthCalledWith(2, 'workbench.view.debug');
+    expect(show).toHaveBeenCalledWith(false);
+  });
+
+  it('still shows the view when both commands fail', () => {
+    const executeCommand = vi.fn(() => rejectedThenable());
+    const show = vi.fn();
+
+    revealPlatformView({
+      focusCommand: 'debug80.platformView.focus',
+      fallbackCommand: 'workbench.view.debug',
+      focus: true,
+      target: { show },
+      commands: { executeCommand },
+    });
+    expect(show).toHaveBeenCalledWith(false);
+  });
+});
+
+function resolvedThenable(): Thenable<unknown> {
+  return {
+    then: (onFulfilled) => {
+      onFulfilled(undefined);
+      return resolvedThenable();
+    },
+  };
+}
+
+function rejectedThenable(): Thenable<unknown> {
+  return {
+    then: (_onFulfilled, onRejected) => {
+      onRejected?.(new Error('command failed'));
+      return resolvedThenable();
+    },
+  };
+}

--- a/tests/extension/platform-view-reveal.test.ts
+++ b/tests/extension/platform-view-reveal.test.ts
@@ -20,7 +20,7 @@ describe('platform-view-reveal', () => {
       focusCommand: 'debug80.platformView.focus',
       fallbackCommand: 'workbench.view.debug',
       focus: true,
-      target: { show },
+      target: () => ({ show }),
       commands: { executeCommand },
     });
 
@@ -36,7 +36,7 @@ describe('platform-view-reveal', () => {
       focusCommand: 'debug80.platformView.focus',
       fallbackCommand: 'workbench.view.debug',
       focus: false,
-      target: { show },
+      target: () => ({ show }),
       commands: { executeCommand },
     });
 
@@ -55,7 +55,7 @@ describe('platform-view-reveal', () => {
       focusCommand: 'debug80.platformView.focus',
       fallbackCommand: 'workbench.view.debug',
       focus: true,
-      target: { show },
+      target: () => ({ show }),
       commands: { executeCommand },
     });
 
@@ -72,9 +72,28 @@ describe('platform-view-reveal', () => {
       focusCommand: 'debug80.platformView.focus',
       fallbackCommand: 'workbench.view.debug',
       focus: true,
-      target: { show },
+      target: () => ({ show }),
       commands: { executeCommand },
     });
+    expect(show).toHaveBeenCalledWith(false);
+  });
+
+  it('looks up the target after the command resolves', () => {
+    const show = vi.fn();
+    let target: { show: typeof show } | undefined;
+    const executeCommand = vi.fn(() => {
+      target = { show };
+      return resolvedThenable();
+    });
+
+    revealPlatformView({
+      focusCommand: 'debug80.platformView.focus',
+      fallbackCommand: 'workbench.view.debug',
+      focus: true,
+      target: () => target,
+      commands: { executeCommand },
+    });
+
     expect(show).toHaveBeenCalledWith(false);
   });
 });


### PR DESCRIPTION
## Summary
- Move platform view reveal/focus command fallback handling into a dedicated helper
- Keep PlatformViewProvider responsible for passing its current webview target and command names
- Add focused tests for focus reveal, fallback reveal, direct focus failure, and double-command failure

## Verification
- npx vitest run tests/extension/platform-view-reveal.test.ts tests/extension/platform-view-provider.test.ts
- npm run typecheck
- npm run typecheck:webview
- npm run lint -- --max-warnings=0
- npm run format:check
- npm test
- npm run package:verify --if-present
- git diff --check