### PR TITLE
Extract platform view registry

### DIFF
--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -11,7 +11,6 @@ import * as vscode from 'vscode';
 import type { DebugSessionStatus } from '../debug/session/session-status';
 import type { Tec1UpdatePayload } from '../platforms/tec1/types';
 import type { Tec1gUpdatePayload } from '../platforms/tec1g/types';
-import { createRefreshController, type RefreshController } from '../platforms/panel-refresh';
 import type { PanelTab } from '../platforms/panel-html';
 import { getTec1gHtml } from '../platforms/tec1g/ui-panel-html';
 import {
@@ -23,7 +22,6 @@ import {
   handlePlatformSerialSave,
   handlePlatformSerialSendFile,
 } from './platform-view-serial-actions';
-import { loadPlatformUi, listPlatformUis, type PlatformUiModules } from './platform-view-manifest';
 import type { PlatformId, PlatformViewInboundMessage } from '../contracts/platform-view';
 import { NullLogger, type Logger } from '../util/logger';
 import { createUiPerformanceMonitor, type UiPerformanceMonitor } from './ui-performance-monitor';
@@ -41,14 +39,12 @@ import {
   appendPlatformSerial,
   buildSerialInitMessage,
   clearPlatformSerial,
-  createSerialBuffer,
 } from './platform-view-serial-state';
 import {
   applyPlatformRuntimeUpdate,
   buildPlatformRuntimeClearMessage,
   buildPlatformRuntimeUpdateMessage,
   clearPlatformRuntimeState,
-  type PlatformRuntimeState,
 } from './platform-view-runtime-state';
 import {
   buildPlatformViewSessionStatusMessage,
@@ -61,21 +57,9 @@ import {
   shouldAcceptPlatformViewSession,
 } from './platform-view-session-state';
 import { revealPlatformView } from './platform-view-reveal';
+import { PlatformViewRegistry, type PlatformViewBundle } from './platform-view-registry';
 
 const MEMORY_REFRESH_INTERVAL_MS = 500;
-
-// ---------------------------------------------------------------------------
-// Per-platform runtime state
-// ---------------------------------------------------------------------------
-
-/**
- * Mutable state held by the provider for each loaded platform.
- * One instance exists per registered platform for the lifetime of the provider.
- */
-interface PerPlatformState extends PlatformRuntimeState {
-  activeTab: PanelTab;
-  refreshController: RefreshController;
-}
 
 // ---------------------------------------------------------------------------
 // Provider
@@ -92,11 +76,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   private readonly workspaceState: vscode.Memento | undefined;
   private readonly extensionUri: vscode.Uri;
   private readonly performanceMonitor: UiPerformanceMonitor;
-
-  /** Cached loaded modules, keyed by platform id. */
-  private readonly loadedModules = new Map<string, PlatformUiModules>();
-  /** Per-platform mutable state, keyed by platform id. */
-  private readonly platformStates = new Map<string, PerPlatformState>();
+  private readonly registry: PlatformViewRegistry;
 
   /** TEC-1G only: `tec1g.uiVisibility` from launch config (debug80.json) for this session. */
   private tec1gAdapterVisibility: Record<string, boolean> | undefined;
@@ -114,6 +94,10 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     this.performanceMonitor = createUiPerformanceMonitor({
       logger,
       label: 'platform-view',
+    });
+    this.registry = new PlatformViewRegistry({
+      postSnapshot: (command, payload): Promise<void> => this.postSnapshot(command, payload),
+      onSnapshotFailed: (allowErrors): void => this.onSnapshotFailed(allowErrors),
     });
   }
 
@@ -239,14 +223,13 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   }
 
   clear(): void {
-    for (const [id, state] of this.platformStates) {
-      const modules = this.loadedModules.get(id);
+    this.registry.forEachState((_id, state, modules) => {
       if (modules !== undefined) {
         clearPlatformRuntimeState(modules, state);
       } else {
         clearPlatformSerial(state.serialBuffer);
       }
-    }
+    });
     const bundle = this.getCurrentBundle();
     if (bundle !== undefined) {
       this.postMessage(
@@ -373,7 +356,7 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
 
     // Load all registered platform UIs eagerly so subsequent synchronous
     // operations (updateTec1, clear, etc.) can access modules without async.
-    return this.preloadAllPlatforms().then(() => {
+    return this.registry.preloadAll().then(() => {
       this.renderCurrentView(false);
     });
   }
@@ -421,68 +404,13 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  /**
-   * Loads all registered platform UI modules and initialises per-platform
-   * state for each.  Subsequent synchronous operations can rely on the
-   * Maps being populated.
-   */
-  private async preloadAllPlatforms(): Promise<void> {
-    await Promise.all(
-      listPlatformUis().map(async (entry) => {
-        if (!this.loadedModules.has(entry.id)) {
-          const modules = await loadPlatformUi(entry.id);
-          this.loadedModules.set(entry.id, modules);
-          this.initPlatformState(entry.id, modules);
-        }
-      })
-    );
-  }
-
-  /**
-   * Creates and caches the {@link PerPlatformState} for a platform whose
-   * modules have just been loaded.
-   */
-  private initPlatformState(id: string, modules: PlatformUiModules): PerPlatformState {
-    const existing = this.platformStates.get(id);
-    if (existing !== undefined) {
-      return existing;
-    }
-    const state: PerPlatformState = {
-      activeTab: 'ui' as PanelTab,
-      uiState: modules.createUiState(),
-      hasPostedRuntimeUpdate: false,
-      serialBuffer: createSerialBuffer(),
-      memoryViews: modules.createMemoryViewState(),
-      // refreshController is created separately so its snapshotPayload
-      // closure captures the state object reference (not a stale copy).
-      refreshController: null as unknown as RefreshController,
-    };
-    state.refreshController = createRefreshController(
-      () => buildMemorySnapshotPayload(state.memoryViews),
-      {
-        postSnapshot: (payload) => this.postSnapshot(modules.snapshotCommand, payload),
-        onSnapshotPosted: () => undefined,
-        onSnapshotFailed: (allowErrors) => this.onSnapshotFailed(allowErrors),
-      }
-    );
-    this.platformStates.set(id, state);
-    return state;
-  }
-
   /** Returns the loaded modules + state bundle for the given platform id, or undefined. */
-  private getActiveBundle(
-    id: string
-  ): { modules: PlatformUiModules; state: PerPlatformState } | undefined {
-    const modules = this.loadedModules.get(id);
-    const state = this.platformStates.get(id);
-    if (modules === undefined || state === undefined) {
-      return undefined;
-    }
-    return { modules, state };
+  private getActiveBundle(id: string): PlatformViewBundle | undefined {
+    return this.registry.getBundle(id);
   }
 
   /** Returns the bundle for the currently active platform, or undefined. */
-  private getCurrentBundle(): { modules: PlatformUiModules; state: PerPlatformState } | undefined {
+  private getCurrentBundle(): PlatformViewBundle | undefined {
     if (this.currentPlatform === undefined) {
       return undefined;
     }
@@ -507,9 +435,9 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
   }
 
   private stopAllPlatformRefresh(): void {
-    for (const state of this.platformStates.values()) {
+    this.registry.forEachState((_id, state) => {
       stopMemoryRefresh(state.refreshController);
-    }
+    });
   }
 
   // -------------------------------------------------------------------------

--- a/src/extension/platform-view-registry.ts
+++ b/src/extension/platform-view-registry.ts
@@ -1,0 +1,103 @@
+/**
+ * @file Platform UI module/state registry for the Debug80 platform view.
+ */
+
+import type { PanelTab } from '../platforms/panel-html';
+import { createRefreshController, type RefreshController } from '../platforms/panel-refresh';
+import { createSerialBuffer } from './platform-view-serial-state';
+import { buildMemorySnapshotPayload } from './platform-view-memory-refresh';
+import type { PlatformRuntimeState } from './platform-view-runtime-state';
+import { loadPlatformUi, listPlatformUis, type PlatformUiModules } from './platform-view-manifest';
+
+export interface PerPlatformState extends PlatformRuntimeState {
+  activeTab: PanelTab;
+  refreshController: RefreshController;
+}
+
+export interface PlatformViewBundle {
+  modules: PlatformUiModules;
+  state: PerPlatformState;
+}
+
+export interface PlatformRefreshHandlers {
+  postSnapshot: (
+    command: 'debug80/memorySnapshot',
+    payload: ReturnType<typeof buildMemorySnapshotPayload>
+  ) => Promise<void>;
+  onSnapshotFailed: (allowErrors: boolean) => void;
+}
+
+/**
+ * Holds loaded platform UI modules and their mutable per-platform state.
+ */
+export class PlatformViewRegistry {
+  private readonly loadedModules = new Map<string, PlatformUiModules>();
+  private readonly platformStates = new Map<string, PerPlatformState>();
+
+  constructor(private readonly refreshHandlers: PlatformRefreshHandlers) {}
+
+  /**
+   * Loads all registered platform UI modules and creates matching state.
+   */
+  async preloadAll(): Promise<void> {
+    await Promise.all(
+      listPlatformUis().map(async (entry) => {
+        if (!this.loadedModules.has(entry.id)) {
+          const modules = await loadPlatformUi(entry.id);
+          this.loadedModules.set(entry.id, modules);
+          this.initPlatformState(entry.id, modules);
+        }
+      })
+    );
+  }
+
+  /**
+   * Returns the loaded modules + state bundle for a platform id, if loaded.
+   */
+  getBundle(id: string): PlatformViewBundle | undefined {
+    const modules = this.loadedModules.get(id);
+    const state = this.platformStates.get(id);
+    if (modules === undefined || state === undefined) {
+      return undefined;
+    }
+    return { modules, state };
+  }
+
+  /**
+   * Iterates over each known platform state with its loaded modules when available.
+   */
+  forEachState(
+    callback: (id: string, state: PerPlatformState, modules?: PlatformUiModules) => void
+  ): void {
+    for (const [id, state] of this.platformStates) {
+      callback(id, state, this.loadedModules.get(id));
+    }
+  }
+
+  private initPlatformState(id: string, modules: PlatformUiModules): PerPlatformState {
+    const existing = this.platformStates.get(id);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const state: PerPlatformState = {
+      activeTab: 'ui' as PanelTab,
+      uiState: modules.createUiState(),
+      hasPostedRuntimeUpdate: false,
+      serialBuffer: createSerialBuffer(),
+      memoryViews: modules.createMemoryViewState(),
+      // Created after state allocation so snapshotPayload captures the state object.
+      refreshController: null as unknown as RefreshController,
+    };
+    state.refreshController = createRefreshController(
+      () => buildMemorySnapshotPayload(state.memoryViews),
+      {
+        postSnapshot: (payload) =>
+          this.refreshHandlers.postSnapshot(modules.snapshotCommand, payload),
+        onSnapshotPosted: () => undefined,
+        onSnapshotFailed: (allowErrors) => this.refreshHandlers.onSnapshotFailed(allowErrors),
+      }
+    );
+    this.platformStates.set(id, state);
+    return state;
+  }
+}

--- a/tests/extension/platform-view-registry.test.ts
+++ b/tests/extension/platform-view-registry.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @file Platform view registry tests.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { createMemoryViewState } from '../../src/platforms/panel-memory';
+import type { PlatformUiModules } from '../../src/extension/platform-view-manifest';
+import {
+  registerPlatformUi,
+  type PlatformUiEntry,
+} from '../../src/extension/platform-view-manifest';
+import { PlatformViewRegistry } from '../../src/extension/platform-view-registry';
+
+describe('platform-view-registry', () => {
+  it('preloads registered modules and creates per-platform state', async () => {
+    const modules = createModules();
+    registerPlatformUi(createEntry('registry-test-a', modules));
+    const registry = new PlatformViewRegistry({
+      postSnapshot: vi.fn().mockResolvedValue(undefined),
+      onSnapshotFailed: vi.fn(),
+    });
+
+    await registry.preloadAll();
+
+    const bundle = registry.getBundle('registry-test-a');
+    expect(bundle?.modules).toBe(modules);
+    expect(bundle?.state.activeTab).toBe('ui');
+    expect(bundle?.state.uiState).toEqual({ id: 'state' });
+    expect(bundle?.state.serialBuffer).toBeDefined();
+    expect(bundle?.state.memoryViews.viewModes.a).toBe('pc');
+    expect(bundle?.state.refreshController).toBeDefined();
+  });
+
+  it('does not reload modules that are already cached', async () => {
+    const modules = createModules();
+    const loadUiModules = vi.fn().mockResolvedValue(modules);
+    registerPlatformUi({ id: 'registry-test-b', loadUiModules });
+    const registry = new PlatformViewRegistry({
+      postSnapshot: vi.fn().mockResolvedValue(undefined),
+      onSnapshotFailed: vi.fn(),
+    });
+
+    await registry.preloadAll();
+    const firstBundle = registry.getBundle('registry-test-b');
+    if (firstBundle !== undefined) {
+      firstBundle.state.activeTab = 'memory';
+      firstBundle.state.memoryViews.viewAfter.a = 128;
+    }
+    await registry.preloadAll();
+
+    expect(loadUiModules).toHaveBeenCalledTimes(1);
+    const secondBundle = registry.getBundle('registry-test-b');
+    expect(secondBundle?.state).toBe(firstBundle?.state);
+    expect(secondBundle?.state.activeTab).toBe('memory');
+    expect(secondBundle?.state.memoryViews.viewAfter.a).toBe(128);
+  });
+
+  it('wires snapshot handlers through the registry callbacks', async () => {
+    const modules = createModules();
+    const postSnapshot = vi.fn().mockResolvedValue(undefined);
+    const onSnapshotFailed = vi.fn();
+    registerPlatformUi(createEntry('registry-test-c', modules));
+    const registry = new PlatformViewRegistry({ postSnapshot, onSnapshotFailed });
+
+    await registry.preloadAll();
+    const bundle = registry.getBundle('registry-test-c');
+    await bundle?.state.refreshController.handlers.postSnapshot(
+      bundle.state.refreshController.snapshotPayload()
+    );
+    bundle?.state.refreshController.handlers.onSnapshotFailed(true);
+
+    expect(postSnapshot).toHaveBeenCalledWith('debug80/memorySnapshot', {
+      views: expect.any(Array),
+    });
+    expect(onSnapshotFailed).toHaveBeenCalledWith(true);
+  });
+
+  it('iterates known platform states with their modules', async () => {
+    const modules = createModules();
+    registerPlatformUi(createEntry('registry-test-d', modules));
+    const registry = new PlatformViewRegistry({
+      postSnapshot: vi.fn().mockResolvedValue(undefined),
+      onSnapshotFailed: vi.fn(),
+    });
+
+    await registry.preloadAll();
+    const seen: string[] = [];
+    registry.forEachState((id, state, entryModules) => {
+      seen.push(id);
+      if (id === 'registry-test-d') {
+        expect(state.activeTab).toBe('ui');
+        expect(entryModules).toBe(modules);
+      }
+    });
+
+    expect(seen).toContain('registry-test-d');
+  });
+});
+
+function createEntry(id: string, modules: PlatformUiModules): PlatformUiEntry {
+  return {
+    id,
+    loadUiModules: vi.fn().mockResolvedValue(modules),
+  };
+}
+
+function createModules(): PlatformUiModules {
+  return {
+    getHtml: vi.fn(),
+    createUiState: vi.fn(() => ({ id: 'state' })),
+    resetUiState: vi.fn(),
+    applyUpdate: vi.fn(() => ({})),
+    createMemoryViewState,
+    handleMessage: vi.fn(),
+    buildUpdateMessage: vi.fn(() => ({ type: 'update' })),
+    buildClearMessage: vi.fn(() => ({ type: 'clear' })),
+    snapshotCommand: 'debug80/memorySnapshot',
+  };
+}

--- a/tests/extension/platform-view-registry.test.ts
+++ b/tests/extension/platform-view-registry.test.ts
@@ -2,17 +2,20 @@
  * @file Platform view registry tests.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMemoryViewState } from '../../src/platforms/panel-memory';
-import type { PlatformUiModules } from '../../src/extension/platform-view-manifest';
-import {
-  registerPlatformUi,
-  type PlatformUiEntry,
+import type {
+  PlatformUiEntry,
+  PlatformUiModules,
 } from '../../src/extension/platform-view-manifest';
-import { PlatformViewRegistry } from '../../src/extension/platform-view-registry';
 
 describe('platform-view-registry', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
   it('preloads registered modules and creates per-platform state', async () => {
+    const { PlatformViewRegistry, registerPlatformUi } = await loadRegistryModules();
     const modules = createModules();
     registerPlatformUi(createEntry('registry-test-a', modules));
     const registry = new PlatformViewRegistry({
@@ -32,6 +35,7 @@ describe('platform-view-registry', () => {
   });
 
   it('does not reload modules that are already cached', async () => {
+    const { PlatformViewRegistry, registerPlatformUi } = await loadRegistryModules();
     const modules = createModules();
     const loadUiModules = vi.fn().mockResolvedValue(modules);
     registerPlatformUi({ id: 'registry-test-b', loadUiModules });
@@ -56,6 +60,7 @@ describe('platform-view-registry', () => {
   });
 
   it('wires snapshot handlers through the registry callbacks', async () => {
+    const { PlatformViewRegistry, registerPlatformUi } = await loadRegistryModules();
     const modules = createModules();
     const postSnapshot = vi.fn().mockResolvedValue(undefined);
     const onSnapshotFailed = vi.fn();
@@ -76,6 +81,7 @@ describe('platform-view-registry', () => {
   });
 
   it('iterates known platform states with their modules', async () => {
+    const { PlatformViewRegistry, registerPlatformUi } = await loadRegistryModules();
     const modules = createModules();
     registerPlatformUi(createEntry('registry-test-d', modules));
     const registry = new PlatformViewRegistry({
@@ -102,6 +108,17 @@ function createEntry(id: string, modules: PlatformUiModules): PlatformUiEntry {
     id,
     loadUiModules: vi.fn().mockResolvedValue(modules),
   };
+}
+
+async function loadRegistryModules(): Promise<{
+  PlatformViewRegistry: typeof import('../../src/extension/platform-view-registry').PlatformViewRegistry;
+  registerPlatformUi: typeof import('../../src/extension/platform-view-manifest').registerPlatformUi;
+}> {
+  const [{ PlatformViewRegistry }, { registerPlatformUi }] = await Promise.all([
+    import('../../src/extension/platform-view-registry'),
+    import('../../src/extension/platform-view-manifest'),
+  ]);
+  return { PlatformViewRegistry, registerPlatformUi };
 }
 
 function createModules(): PlatformUiModules {


### PR DESCRIPTION
## Summary
- Move platform UI module loading, per-platform state creation, bundle lookup, and state iteration into PlatformViewRegistry
- Keep PlatformViewProvider responsible for active platform routing, webview posting, and snapshot/session side effects
- Add registry tests for preload, idempotency/state preservation, snapshot handler wiring, and state iteration

## Verification
- npx vitest run tests/extension/platform-view-registry.test.ts tests/extension/platform-view-provider.test.ts
- npm run typecheck
- npm run typecheck:webview
- npm run lint -- --max-warnings=0
- npm run format:check
- npm test
- npm run package:verify --if-present
- git diff --check