### PR TITLE
Extract platform view webview handler

### DIFF
--- a/src/extension/platform-view-constants.ts
+++ b/src/extension/platform-view-constants.ts
@@ -1,0 +1,5 @@
+/**
+ * @file Shared constants for the platform view provider.
+ */
+
+export const MEMORY_REFRESH_INTERVAL_MS = 500;

--- a/src/extension/platform-view-provider.ts
+++ b/src/extension/platform-view-provider.ts
@@ -17,12 +17,7 @@ import {
   buildTec1gVisibilityMessage,
   saveTec1gPanelVisibility,
 } from './platform-view-tec1g-visibility';
-import { handlePlatformViewMessage } from './platform-view-messages';
-import {
-  handlePlatformSerialSave,
-  handlePlatformSerialSendFile,
-} from './platform-view-serial-actions';
-import type { PlatformId, PlatformViewInboundMessage } from '../contracts/platform-view';
+import type { PlatformId } from '../contracts/platform-view';
 import { NullLogger, type Logger } from '../util/logger';
 import { createUiPerformanceMonitor, type UiPerformanceMonitor } from './ui-performance-monitor';
 import {
@@ -58,8 +53,8 @@ import {
 } from './platform-view-session-state';
 import { revealPlatformView } from './platform-view-reveal';
 import { PlatformViewRegistry, type PlatformViewBundle } from './platform-view-registry';
-
-const MEMORY_REFRESH_INTERVAL_MS = 500;
+import { createPlatformViewWebviewHandler } from './platform-view-webview-handler';
+import { MEMORY_REFRESH_INTERVAL_MS } from './platform-view-constants';
 
 // ---------------------------------------------------------------------------
 // Provider
@@ -266,80 +261,19 @@ export class PlatformViewProvider implements vscode.WebviewViewProvider {
       localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'out', 'webview')],
     };
 
-    webviewView.webview.onDidReceiveMessage(async (msg: PlatformViewInboundMessage) => {
-      await handlePlatformViewMessage(msg, {
-        handleCreateProject: async (args) => {
-          await vscode.commands.executeCommand('debug80.createProject', args);
-        },
-        handleOpenWorkspaceFolder: async () => {
-          await vscode.commands.executeCommand('debug80.addWorkspaceFolder');
-        },
-        handleSelectProject: async (args) => {
-          await vscode.commands.executeCommand('debug80.selectWorkspaceFolder', args);
-        },
-        handleConfigureProject: () => {
-          return Promise.resolve();
-        },
-        handleSaveProjectConfig: (platform) => {
-          this.handleSaveProjectConfig(platform);
-          return Promise.resolve();
-        },
-        handleSetStopOnEntry: (value) => {
-          this.handleSetStopOnEntry(value);
-          return Promise.resolve();
-        },
-        handleSelectTarget: async (args) => {
-          await vscode.commands.executeCommand('debug80.selectTarget', args);
-        },
-        handleRestartDebug: async () => {
-          await vscode.commands.executeCommand('debug80.restartDebug');
-        },
-        handleSetEntrySource: async () => {
-          await vscode.commands.executeCommand('debug80.setEntrySource');
-        },
+    webviewView.webview.onDidReceiveMessage(
+      createPlatformViewWebviewHandler({
         currentPlatform: () => this.currentPlatform,
-        handleSaveTec1gPanelVisibility: (args) => {
-          this.persistTec1gPanelVisibility(args.visibility, args.targetName);
+        sessionState: this.sessionState,
+        getActiveBundle: (platform) => this.getActiveBundle(platform),
+        handleSaveProjectConfig: (platform) => this.handleSaveProjectConfig(platform),
+        handleSetStopOnEntry: (value) => this.handleSetStopOnEntry(value),
+        persistTec1gPanelVisibility: (visibility, targetNameFromWebview) => {
+          this.persistTec1gPanelVisibility(visibility, targetNameFromWebview);
         },
-        handleStartDebug: async (args) => {
-          await vscode.commands.executeCommand('debug80.startDebug', args);
-        },
-        handleSerialSendFile: async () => {
-          await handlePlatformSerialSendFile({
-            getSession: () =>
-              resolvePlatformViewDebugSession(this.sessionState, vscode.debug.activeDebugSession),
-            getPlatform: () => this.currentPlatform,
-          });
-        },
-        handleSerialSave: async (text) => {
-          await handlePlatformSerialSave(text);
-        },
-        clearSerialBuffer: (platform) => {
-          const bundle = this.getActiveBundle(platform);
-          if (bundle !== undefined) {
-            clearPlatformSerial(bundle.state.serialBuffer);
-          }
-        },
-        handlePlatformMessage: async (platform, platformMsg) => {
-          const bundle = this.getActiveBundle(platform);
-          if (bundle === undefined) {
-            return;
-          }
-          await bundle.modules.handleMessage(platformMsg, {
-            getSession: () =>
-              resolvePlatformViewDebugSession(this.sessionState, vscode.debug.activeDebugSession),
-            refreshController: bundle.state.refreshController,
-            autoRefreshMs: MEMORY_REFRESH_INTERVAL_MS,
-            setActiveTab: (tab) => {
-              bundle.state.activeTab = tab;
-            },
-            getActiveTab: () => bundle.state.activeTab,
-            isPanelVisible: () => this.view?.visible === true,
-            memoryViews: bundle.state.memoryViews,
-          });
-        },
-      });
-    });
+        isPanelVisible: () => this.view?.visible === true,
+      })
+    );
 
     webviewView.onDidDispose(() => {
       this.view = undefined;

--- a/src/extension/platform-view-webview-handler.ts
+++ b/src/extension/platform-view-webview-handler.ts
@@ -1,0 +1,109 @@
+/**
+ * @file Webview inbound message handler construction for the platform view.
+ */
+
+import * as vscode from 'vscode';
+import type { PlatformId, PlatformViewInboundMessage } from '../contracts/platform-view';
+import type { PanelTab } from '../platforms/panel-html';
+import { MEMORY_REFRESH_INTERVAL_MS } from './platform-view-constants';
+import { handlePlatformViewMessage } from './platform-view-messages';
+import {
+  handlePlatformSerialSave,
+  handlePlatformSerialSendFile,
+} from './platform-view-serial-actions';
+import type { PlatformViewSessionState } from './platform-view-session-state';
+import { resolvePlatformViewDebugSession } from './platform-view-session-state';
+import { clearPlatformSerial } from './platform-view-serial-state';
+import type { PlatformViewBundle } from './platform-view-registry';
+
+export interface PlatformViewWebviewHandlerContext {
+  currentPlatform: () => PlatformId | undefined;
+  sessionState: PlatformViewSessionState;
+  getActiveBundle: (platform: PlatformId) => PlatformViewBundle | undefined;
+  handleSaveProjectConfig: (platform: string) => void;
+  handleSetStopOnEntry: (value: boolean) => void;
+  persistTec1gPanelVisibility: (
+    visibility: Record<string, boolean>,
+    targetNameFromWebview?: string
+  ) => void;
+  isPanelVisible: () => boolean;
+}
+
+export function createPlatformViewWebviewHandler(
+  context: PlatformViewWebviewHandlerContext
+): (msg: PlatformViewInboundMessage) => Promise<void> {
+  return async (msg: PlatformViewInboundMessage): Promise<void> => {
+    await handlePlatformViewMessage(msg, {
+      handleCreateProject: async (args) => {
+        await vscode.commands.executeCommand('debug80.createProject', args);
+      },
+      handleOpenWorkspaceFolder: async () => {
+        await vscode.commands.executeCommand('debug80.addWorkspaceFolder');
+      },
+      handleSelectProject: async (args) => {
+        await vscode.commands.executeCommand('debug80.selectWorkspaceFolder', args);
+      },
+      handleConfigureProject: () => {
+        return Promise.resolve();
+      },
+      handleSaveProjectConfig: (platform) => {
+        context.handleSaveProjectConfig(platform);
+        return Promise.resolve();
+      },
+      handleSetStopOnEntry: (value) => {
+        context.handleSetStopOnEntry(value);
+        return Promise.resolve();
+      },
+      handleSelectTarget: async (args) => {
+        await vscode.commands.executeCommand('debug80.selectTarget', args);
+      },
+      handleRestartDebug: async () => {
+        await vscode.commands.executeCommand('debug80.restartDebug');
+      },
+      handleSetEntrySource: async () => {
+        await vscode.commands.executeCommand('debug80.setEntrySource');
+      },
+      currentPlatform: context.currentPlatform,
+      handleSaveTec1gPanelVisibility: (args) => {
+        context.persistTec1gPanelVisibility(args.visibility, args.targetName);
+      },
+      handleStartDebug: async (args) => {
+        await vscode.commands.executeCommand('debug80.startDebug', args);
+      },
+      handleSerialSendFile: async () => {
+        await handlePlatformSerialSendFile({
+          getSession: () =>
+            resolvePlatformViewDebugSession(context.sessionState, vscode.debug.activeDebugSession),
+          getPlatform: context.currentPlatform,
+        });
+      },
+      handleSerialSave: async (text) => {
+        await handlePlatformSerialSave(text);
+      },
+      clearSerialBuffer: (platform) => {
+        const bundle = context.getActiveBundle(platform);
+        if (bundle !== undefined) {
+          clearPlatformSerial(bundle.state.serialBuffer);
+        }
+      },
+      handlePlatformMessage: async (platform, platformMsg) => {
+        const bundle = context.getActiveBundle(platform);
+        if (bundle === undefined) {
+          return;
+        }
+        await bundle.modules.handleMessage(platformMsg, {
+          getSession: () =>
+            resolvePlatformViewDebugSession(context.sessionState, vscode.debug.activeDebugSession),
+          refreshController: bundle.state.refreshController,
+          autoRefreshMs: MEMORY_REFRESH_INTERVAL_MS,
+          setActiveTab: (tab: PanelTab) => {
+            bundle.state.activeTab = tab;
+          },
+          getActiveTab: () => bundle.state.activeTab,
+          isPanelVisible: context.isPanelVisible,
+          memoryViews: bundle.state.memoryViews,
+        });
+      },
+    });
+  };
+}

--- a/tests/extension/platform-view-webview-handler.test.ts
+++ b/tests/extension/platform-view-webview-handler.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @file Platform view webview handler construction tests.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPlatformViewWebviewHandler } from '../../src/extension/platform-view-webview-handler';
+import { createPlatformViewSessionState } from '../../src/extension/platform-view-session-state';
+import { createSerialBuffer } from '../../src/extension/platform-view-serial-state';
+import type { PlatformViewBundle } from '../../src/extension/platform-view-registry';
+
+const { executeCommand } = vi.hoisted(() => ({
+  executeCommand: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+vi.mock('vscode', () => ({
+  commands: { executeCommand },
+  debug: { activeDebugSession: undefined },
+}));
+
+vi.mock('../../src/extension/platform-view-serial-actions', () => ({
+  handlePlatformSerialSave: vi.fn(() => Promise.resolve(undefined)),
+  handlePlatformSerialSendFile: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+describe('platform-view webview handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes VS Code command messages through the command palette ids', async () => {
+    const handler = createPlatformViewWebviewHandler(createContext());
+
+    await handler({ type: 'createProject', rootPath: '/workspace/demo', platform: 'tec1g' });
+    await handler({ type: 'selectProject', rootPath: '/workspace/demo' });
+    await handler({ type: 'selectTarget', rootPath: '/workspace/demo', targetName: 'app' });
+    await handler({ type: 'restartDebug' });
+    await handler({ type: 'setEntrySource' });
+    await handler({ type: 'startDebug', rootPath: '/workspace/demo' });
+    await handler({ type: 'openWorkspaceFolder' });
+
+    expect(executeCommand).toHaveBeenCalledWith('debug80.createProject', {
+      rootPath: '/workspace/demo',
+      platform: 'tec1g',
+    });
+    expect(executeCommand).toHaveBeenCalledWith('debug80.selectWorkspaceFolder', {
+      rootPath: '/workspace/demo',
+    });
+    expect(executeCommand).toHaveBeenCalledWith('debug80.selectTarget', {
+      rootPath: '/workspace/demo',
+      targetName: 'app',
+    });
+    expect(executeCommand).toHaveBeenCalledWith('debug80.restartDebug');
+    expect(executeCommand).toHaveBeenCalledWith('debug80.setEntrySource');
+    expect(executeCommand).toHaveBeenCalledWith('debug80.startDebug', {
+      rootPath: '/workspace/demo',
+    });
+    expect(executeCommand).toHaveBeenCalledWith('debug80.addWorkspaceFolder');
+  });
+
+  it('routes provider-owned state callbacks without going through commands', async () => {
+    const context = createContext();
+    const handler = createPlatformViewWebviewHandler(context);
+
+    await handler({ type: 'saveProjectConfig', platform: 'tec1' });
+    await handler({ type: 'setStopOnEntry', stopOnEntry: true });
+    await handler({
+      type: 'saveTec1gPanelVisibility',
+      targetName: 'main',
+      visibility: { glcd: false },
+    });
+
+    expect(context.handleSaveProjectConfig).toHaveBeenCalledWith('tec1');
+    expect(context.handleSetStopOnEntry).toHaveBeenCalledWith(true);
+    expect(context.persistTec1gPanelVisibility).toHaveBeenCalledWith({ glcd: false }, 'main');
+  });
+
+  it('clears the active platform serial buffer', async () => {
+    const bundle = createBundle();
+    bundle.state.serialBuffer.text = 'hello';
+    const handler = createPlatformViewWebviewHandler(
+      createContext({ currentPlatform: () => 'tec1', getActiveBundle: () => bundle })
+    );
+
+    await handler({ type: 'serialClear' });
+
+    expect(bundle.state.serialBuffer.text).toBe('');
+  });
+
+  it('forwards platform payloads with runtime context', async () => {
+    const bundle = createBundle();
+    const handler = createPlatformViewWebviewHandler(
+      createContext({ currentPlatform: () => 'tec1g', getActiveBundle: () => bundle })
+    );
+
+    await handler({ type: 'selectTab', tab: 'memory' });
+
+    expect(bundle.modules.handleMessage).toHaveBeenCalledWith(
+      { type: 'selectTab', tab: 'memory' },
+      expect.objectContaining({
+        autoRefreshMs: 500,
+        refreshController: bundle.state.refreshController,
+        memoryViews: bundle.state.memoryViews,
+      })
+    );
+    const messageContext = (bundle.modules.handleMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]?.[1] as { setActiveTab: (tab: 'memory') => void; getActiveTab: () => string };
+    messageContext.setActiveTab('memory');
+    expect(messageContext.getActiveTab()).toBe('memory');
+  });
+});
+
+function createContext(
+  overrides: Partial<Parameters<typeof createPlatformViewWebviewHandler>[0]> = {}
+): Parameters<typeof createPlatformViewWebviewHandler>[0] {
+  return {
+    currentPlatform: () => 'simple',
+    sessionState: createPlatformViewSessionState(),
+    getActiveBundle: () => undefined,
+    handleSaveProjectConfig: vi.fn(),
+    handleSetStopOnEntry: vi.fn(),
+    persistTec1gPanelVisibility: vi.fn(),
+    isPanelVisible: () => true,
+    ...overrides,
+  };
+}
+
+function createBundle(): PlatformViewBundle {
+  return {
+    modules: {
+      getHtml: vi.fn(),
+      createUiState: vi.fn(),
+      resetUiState: vi.fn(),
+      applyUpdate: vi.fn(),
+      createMemoryViewState: vi.fn(),
+      handleMessage: vi.fn(() => Promise.resolve(undefined)),
+      buildUpdateMessage: vi.fn(),
+      buildClearMessage: vi.fn(),
+      snapshotCommand: 'debug80/memorySnapshot',
+    },
+    state: {
+      activeTab: 'ui',
+      uiState: {},
+      hasPostedRuntimeUpdate: false,
+      serialBuffer: createSerialBuffer(),
+      memoryViews: {},
+      refreshController: {} as PlatformViewBundle['state']['refreshController'],
+    },
+  } as PlatformViewBundle;
+}


### PR DESCRIPTION
## Summary
- move platform view inbound webview message wiring out of PlatformViewProvider
- share the memory refresh interval through a small constants module
- add focused tests for command routing, provider callbacks, serial clearing, and platform message context

## Verification
- npx vitest run tests/extension/platform-view-webview-handler.test.ts tests/extension/platform-view-provider.test.ts tests/extension/platform-view-messages.test.ts
- npm run typecheck
- npm run lint -- --max-warnings=0
- npm run format:check
- git diff --check