### PR TITLE
Extract set entry source selection helpers

### DIFF
--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -40,6 +40,7 @@ import {
   resolveFolderForProjectCreation,
   resolveProjectFolderFromResource,
 } from './workspace-folder-resolver';
+import { buildSourcePickItems, resolveResourceSourceSelection } from './source-selection';
 import {
   startCurrentProjectDebugging,
   maybeAutoStartSingleTargetForRootChange,
@@ -712,28 +713,19 @@ export function registerExtensionCommands({
         return undefined;
       }
 
-      const resourceRelative =
-        resource !== undefined && resource.fsPath.startsWith(folder.uri.fsPath)
-          ? path.relative(folder.uri.fsPath, resource.fsPath).split(path.sep).join('/')
-          : undefined;
-      const initialSelection =
-        resourceRelative !== undefined && candidates.includes(resourceRelative)
-          ? resourceRelative
-          : undefined;
+      const initialSelection = resolveResourceSourceSelection(
+        resource?.fsPath,
+        folder.uri.fsPath,
+        candidates
+      );
 
       const picked =
         initialSelection ??
         (
-          await vscode.window.showQuickPick(
-            candidates.map((candidate) => ({
-              label: candidate,
-              ...(candidate === currentSource ? { description: 'current program file' } : {}),
-            })),
-            {
-              placeHolder: 'Select the program file for the active Debug80 target',
-              matchOnDescription: true,
-            }
-          )
+          await vscode.window.showQuickPick(buildSourcePickItems(candidates, currentSource), {
+            placeHolder: 'Select the program file for the active Debug80 target',
+            matchOnDescription: true,
+          })
         )?.label;
 
       if (picked === undefined) {

--- a/src/extension/source-selection.ts
+++ b/src/extension/source-selection.ts
@@ -1,0 +1,36 @@
+/**
+ * @file Source file selection helpers for Debug80 commands.
+ */
+
+import * as path from 'path';
+
+export type SourcePickItem = {
+  label: string;
+  description?: string;
+};
+
+export function resolveResourceSourceSelection(
+  resourcePath: string | undefined,
+  folderPath: string,
+  candidates: readonly string[]
+): string | undefined {
+  if (resourcePath === undefined) {
+    return undefined;
+  }
+  const relative = path.relative(folderPath, resourcePath);
+  if (relative.length === 0 || relative.startsWith('..') || path.isAbsolute(relative)) {
+    return undefined;
+  }
+  const normalized = relative.split(path.sep).join('/');
+  return candidates.includes(normalized) ? normalized : undefined;
+}
+
+export function buildSourcePickItems(
+  candidates: readonly string[],
+  currentSource: string | undefined
+): SourcePickItem[] {
+  return candidates.map((candidate) => ({
+    label: candidate,
+    ...(candidate === currentSource ? { description: 'current program file' } : {}),
+  }));
+}

--- a/src/extension/source-selection.ts
+++ b/src/extension/source-selection.ts
@@ -18,7 +18,12 @@ export function resolveResourceSourceSelection(
     return undefined;
   }
   const relative = path.relative(folderPath, resourcePath);
-  if (relative.length === 0 || relative.startsWith('..') || path.isAbsolute(relative)) {
+  if (
+    relative.length === 0 ||
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
     return undefined;
   }
   const normalized = relative.split(path.sep).join('/');

--- a/tests/extension/source-selection.test.ts
+++ b/tests/extension/source-selection.test.ts
@@ -26,6 +26,14 @@ describe('source-selection', () => {
     ).toBeUndefined();
   });
 
+  it('allows in-project filenames that begin with two dots', () => {
+    expect(
+      resolveResourceSourceSelection('/workspace/proj/..main.asm', '/workspace/proj', [
+        '..main.asm',
+      ])
+    ).toBe('..main.asm');
+  });
+
   it('normalizes host path separators to Debug80 project paths', () => {
     const folder = path.join('/workspace', 'proj');
     const resource = path.join(folder, 'src', 'main.asm');

--- a/tests/extension/source-selection.test.ts
+++ b/tests/extension/source-selection.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @file Source file selection helper tests.
+ */
+
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+  buildSourcePickItems,
+  resolveResourceSourceSelection,
+} from '../../src/extension/source-selection';
+
+describe('source-selection', () => {
+  it('selects an open resource when it is a candidate inside the project folder', () => {
+    expect(
+      resolveResourceSourceSelection('/workspace/proj/src/main.asm', '/workspace/proj', [
+        'src/main.asm',
+      ])
+    ).toBe('src/main.asm');
+  });
+
+  it('does not treat sibling folder prefixes as project-relative paths', () => {
+    expect(
+      resolveResourceSourceSelection('/workspace/proj2/src/main.asm', '/workspace/proj', [
+        'src/main.asm',
+      ])
+    ).toBeUndefined();
+  });
+
+  it('normalizes host path separators to Debug80 project paths', () => {
+    const folder = path.join('/workspace', 'proj');
+    const resource = path.join(folder, 'src', 'main.asm');
+
+    expect(resolveResourceSourceSelection(resource, folder, ['src/main.asm'])).toBe('src/main.asm');
+  });
+
+  it('marks the current source in pick items', () => {
+    expect(buildSourcePickItems(['src/main.asm', 'src/other.asm'], 'src/main.asm')).toEqual([
+      { label: 'src/main.asm', description: 'current program file' },
+      { label: 'src/other.asm' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- move setEntrySource resource matching and quick-pick item construction into pure helpers
- avoid treating sibling folder prefixes as project-relative resources
- add focused tests for resource selection, separator normalization, and current-source labels

## Verification
- npx vitest run tests/extension/source-selection.test.ts tests/extension/commands.test.ts
- npm run typecheck
- npm run lint -- --max-warnings=0
- npm run format:check
- git diff --check