### PR TITLE
Extract configure project target edit logic

### DIFF
--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -6,7 +6,6 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { PlatformViewProvider } from './platform-view-provider';
 import {
-  DEBUG80_PROJECT_VERSION,
   findProjectConfigPath,
   listProjectSourceFiles,
   readProjectConfig,
@@ -25,16 +24,11 @@ import { fetchRomSources } from './rom-sources';
 import { SourceColumnController } from './source-columns';
 import { TerminalPanelController } from './terminal-panel';
 import { WorkspaceSelectionController } from './workspace-selection';
-import type { ProjectConfig } from '../debug/session/types';
+import type { Debug80PlatformId } from '../debug/session/types';
 import {
   buildBundledAssetFallbackPlans,
   resolveProjectBundledAssetInstallPlan,
 } from './bundle-asset-installer';
-import {
-  createSimplePlatformDefaults,
-  createTec1PlatformDefaults,
-  createTec1gPlatformDefaults,
-} from './config-panel-html';
 import {
   findWorkspaceFolder,
   resolveFolderForProjectCreation,
@@ -49,6 +43,10 @@ import {
   resolveSessionWorkspaceFolder,
 } from './debug-session-actions';
 import { openProjectConfigPanel } from './project-config-panel';
+import {
+  applyConfigureProjectTargetEdit,
+  type ConfigureProjectTargetEdit,
+} from './configure-project-edit';
 
 type CommandDependencies = {
   context: vscode.ExtensionContext;
@@ -517,15 +515,13 @@ export function registerExtensionCommands({
         return undefined;
       }
 
-      const targets = (config.targets ?? {}) as Record<string, Record<string, unknown>>;
-      const currentTarget = targets[target];
+      const currentTarget = config.targets?.[target];
       if (currentTarget === undefined) {
         void vscode.window.showErrorMessage(`Debug80: Target ${target} no longer exists.`);
         return undefined;
       }
 
-      const updatedTarget: Record<string, unknown> = { ...currentTarget };
-      let nextTargetName = target;
+      let edit: ConfigureProjectTargetEdit | undefined;
 
       if (pick.value === 'targetPlatformOverride') {
         const platformPick = await vscode.window.showQuickPick(
@@ -539,23 +535,10 @@ export function registerExtensionCommands({
         if (!platformPick) {
           return undefined;
         }
-        const platform = platformPick.label as 'simple' | 'tec1' | 'tec1g';
-        updatedTarget.platform = platform;
-        delete updatedTarget.simple;
-        delete updatedTarget.tec1;
-        delete updatedTarget.tec1g;
-        if (platform === 'tec1') {
-          updatedTarget.tec1 = createTec1PlatformDefaults();
-        } else if (platform === 'tec1g') {
-          updatedTarget.tec1g = createTec1gPlatformDefaults();
-        } else {
-          updatedTarget.simple = createSimplePlatformDefaults();
-        }
-        config.projectVersion = DEBUG80_PROJECT_VERSION;
-        // Keep project-level platform stable for mixed-target projects.
-        if (Object.keys(targets).length <= 1) {
-          config.projectPlatform = platform;
-        }
+        edit = {
+          kind: 'targetPlatformOverride',
+          platform: platformPick.label as Debug80PlatformId,
+        };
       } else if (pick.value === 'program') {
         const sources = listProjectSourceFiles(folder.uri.fsPath);
         if (sources.length === 0) {
@@ -571,13 +554,7 @@ export function registerExtensionCommands({
         if (!sourcePick) {
           return undefined;
         }
-        updatedTarget.sourceFile = sourcePick.label;
-        updatedTarget.asm = sourcePick.label;
-        if (sourcePick.label.toLowerCase().endsWith('.zax')) {
-          updatedTarget.assembler = 'zax';
-        } else if (updatedTarget.assembler === 'zax') {
-          delete updatedTarget.assembler;
-        }
+        edit = { kind: 'program', sourceFile: sourcePick.label };
       } else if (pick.value === 'assembler') {
         const assemblerPick = await vscode.window.showQuickPick(
           [
@@ -590,12 +567,12 @@ export function registerExtensionCommands({
         if (!assemblerPick) {
           return undefined;
         }
-        if (assemblerPick.label === 'default') {
-          delete updatedTarget.assembler;
-        } else {
-          updatedTarget.assembler = assemblerPick.label;
-        }
+        edit = {
+          kind: 'assembler',
+          assembler: assemblerPick.label === 'default' ? undefined : assemblerPick.label,
+        };
       } else if (pick.value === 'targetName') {
+        const targets = config.targets ?? {};
         const targetName = (
           await vscode.window.showInputBox({
             prompt: 'Debug80 target name',
@@ -615,55 +592,56 @@ export function registerExtensionCommands({
         if (targetName === undefined || targetName.length === 0 || targetName === target) {
           return undefined;
         }
-        delete targets[target];
-        targets[targetName] = updatedTarget;
-        nextTargetName = targetName;
-        if (config.defaultTarget === target) {
-          config.defaultTarget = targetName;
-        }
-        if (config.target === target) {
-          config.target = targetName;
-        }
+        edit = { kind: 'targetName', targetName };
       } else if (pick.value === 'outputDir') {
         const outputDir = (
           await vscode.window.showInputBox({
             prompt: 'Output directory',
-            value: String(updatedTarget.outputDir ?? ''),
+            value: String(config.targets?.[target]?.outputDir ?? ''),
             placeHolder: 'build',
           })
         )?.trim();
         if (outputDir === undefined || outputDir.length === 0) {
           return undefined;
         }
-        updatedTarget.outputDir = outputDir;
+        edit = { kind: 'outputDir', outputDir };
       } else if (pick.value === 'artifactBase') {
         const artifactBase = (
           await vscode.window.showInputBox({
             prompt: 'Artifact base',
-            value: String(updatedTarget.artifactBase ?? ''),
+            value: String(config.targets?.[target]?.artifactBase ?? ''),
             placeHolder: 'main',
           })
         )?.trim();
         if (artifactBase === undefined || artifactBase.length === 0) {
           return undefined;
         }
-        updatedTarget.artifactBase = artifactBase;
+        edit = { kind: 'artifactBase', artifactBase };
       }
 
-      targets[nextTargetName] = updatedTarget;
-      config.targets = targets as NonNullable<ProjectConfig['targets']>;
+      if (edit === undefined) {
+        return undefined;
+      }
+      const editResult = applyConfigureProjectTargetEdit(config, target, edit);
+      if (editResult.kind === 'missingTarget') {
+        void vscode.window.showErrorMessage(`Debug80: Target ${target} no longer exists.`);
+        return undefined;
+      }
+      if (editResult.kind === 'noChange') {
+        return undefined;
+      }
       const written = writeProjectConfig(projectConfigPath, config);
       if (!written) {
         void vscode.window.showErrorMessage('Debug80: Failed to update project config.');
         return undefined;
       }
 
-      targetSelection.rememberTarget(projectConfigPath, nextTargetName);
+      targetSelection.rememberTarget(projectConfigPath, editResult.targetName);
       platformViewProvider.refreshIdleView();
       void vscode.window.showInformationMessage(
-        `Debug80: Updated ${nextTargetName} (${pick.label}).`
+        `Debug80: Updated ${editResult.targetName} (${pick.label}).`
       );
-      return nextTargetName;
+      return editResult.targetName;
     })
   );
 

--- a/src/extension/configure-project-edit.ts
+++ b/src/extension/configure-project-edit.ts
@@ -1,0 +1,110 @@
+/**
+ * @file Pure project target edit helpers for the configure-project command.
+ */
+
+import type { Debug80PlatformId, ProjectConfig } from '../debug/session/types';
+import {
+  createSimplePlatformDefaults,
+  createTec1PlatformDefaults,
+  createTec1gPlatformDefaults,
+} from './config-panel-html';
+import { DEBUG80_PROJECT_VERSION } from './project-config';
+
+export type ConfigureProjectTargetEdit =
+  | { kind: 'targetPlatformOverride'; platform: Debug80PlatformId }
+  | { kind: 'program'; sourceFile: string }
+  | { kind: 'assembler'; assembler: string | undefined }
+  | { kind: 'targetName'; targetName: string }
+  | { kind: 'outputDir'; outputDir: string }
+  | { kind: 'artifactBase'; artifactBase: string };
+
+export type ConfigureProjectTargetEditResult =
+  | { kind: 'updated'; targetName: string }
+  | { kind: 'missingTarget' }
+  | { kind: 'noChange' };
+
+type ProjectTargetConfig = NonNullable<ProjectConfig['targets']>[string];
+
+export function applyConfigureProjectTargetEdit(
+  config: ProjectConfig,
+  targetName: string,
+  edit: ConfigureProjectTargetEdit
+): ConfigureProjectTargetEditResult {
+  const targets = config.targets ?? {};
+  const currentTarget = targets[targetName];
+  if (currentTarget === undefined) {
+    return { kind: 'missingTarget' };
+  }
+
+  const updatedTarget: ProjectTargetConfig = { ...currentTarget };
+  let nextTargetName = targetName;
+
+  if (edit.kind === 'targetPlatformOverride') {
+    applyPlatformOverride(config, targets, updatedTarget, edit.platform);
+  } else if (edit.kind === 'program') {
+    applyProgramSource(updatedTarget, edit.sourceFile);
+  } else if (edit.kind === 'assembler') {
+    applyAssembler(updatedTarget, edit.assembler);
+  } else if (edit.kind === 'targetName') {
+    if (edit.targetName === targetName) {
+      return { kind: 'noChange' };
+    }
+    delete targets[targetName];
+    nextTargetName = edit.targetName;
+    if (config.defaultTarget === targetName) {
+      config.defaultTarget = nextTargetName;
+    }
+    if (config.target === targetName) {
+      config.target = nextTargetName;
+    }
+  } else if (edit.kind === 'outputDir') {
+    updatedTarget.outputDir = edit.outputDir;
+  } else if (edit.kind === 'artifactBase') {
+    updatedTarget.artifactBase = edit.artifactBase;
+  }
+
+  targets[nextTargetName] = updatedTarget;
+  config.targets = targets;
+  return { kind: 'updated', targetName: nextTargetName };
+}
+
+function applyPlatformOverride(
+  config: ProjectConfig,
+  targets: NonNullable<ProjectConfig['targets']>,
+  target: ProjectTargetConfig,
+  platform: Debug80PlatformId
+): void {
+  target.platform = platform;
+  delete target.simple;
+  delete target.tec1;
+  delete target.tec1g;
+  if (platform === 'tec1') {
+    target.tec1 = createTec1PlatformDefaults();
+  } else if (platform === 'tec1g') {
+    target.tec1g = createTec1gPlatformDefaults();
+  } else {
+    target.simple = createSimplePlatformDefaults();
+  }
+  config.projectVersion = DEBUG80_PROJECT_VERSION;
+  if (Object.keys(targets).length <= 1) {
+    config.projectPlatform = platform;
+  }
+}
+
+function applyProgramSource(target: ProjectTargetConfig, sourceFile: string): void {
+  target.sourceFile = sourceFile;
+  target.asm = sourceFile;
+  if (sourceFile.toLowerCase().endsWith('.zax')) {
+    target.assembler = 'zax';
+  } else if (target.assembler === 'zax') {
+    delete target.assembler;
+  }
+}
+
+function applyAssembler(target: ProjectTargetConfig, assembler: string | undefined): void {
+  if (assembler === undefined) {
+    delete target.assembler;
+    return;
+  }
+  target.assembler = assembler;
+}

--- a/tests/extension/configure-project-edit.test.ts
+++ b/tests/extension/configure-project-edit.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @file Configure-project target edit helper tests.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ProjectConfig } from '../../src/debug/session/types';
+import { applyConfigureProjectTargetEdit } from '../../src/extension/configure-project-edit';
+
+describe('configure-project target edit', () => {
+  it('applies platform override and updates project platform for a single target', () => {
+    const config: ProjectConfig = {
+      targets: {
+        app: { sourceFile: 'src/main.asm', platform: 'simple', simple: {} },
+      },
+    };
+
+    const result = applyConfigureProjectTargetEdit(config, 'app', {
+      kind: 'targetPlatformOverride',
+      platform: 'tec1g',
+    });
+
+    expect(result).toEqual({ kind: 'updated', targetName: 'app' });
+    expect(config.projectVersion).toBe(2);
+    expect(config.projectPlatform).toBe('tec1g');
+    expect(config.targets?.app?.platform).toBe('tec1g');
+    expect(config.targets?.app?.simple).toBeUndefined();
+    expect(config.targets?.app?.tec1g).toBeDefined();
+  });
+
+  it('keeps project platform stable when editing one target in a multi-target config', () => {
+    const config: ProjectConfig = {
+      projectPlatform: 'tec1',
+      targets: {
+        app: { sourceFile: 'src/main.asm', platform: 'simple' },
+        other: { sourceFile: 'src/other.asm', platform: 'tec1' },
+      },
+    };
+
+    applyConfigureProjectTargetEdit(config, 'app', {
+      kind: 'targetPlatformOverride',
+      platform: 'tec1g',
+    });
+
+    expect(config.projectPlatform).toBe('tec1');
+    expect(config.targets?.app?.platform).toBe('tec1g');
+  });
+
+  it('sets zax assembler for zax source files and clears stale zax for asm files', () => {
+    const config: ProjectConfig = {
+      targets: {
+        app: { sourceFile: 'src/old.zax', asm: 'src/old.zax', assembler: 'zax' },
+      },
+    };
+
+    applyConfigureProjectTargetEdit(config, 'app', {
+      kind: 'program',
+      sourceFile: 'src/main.asm',
+    });
+    expect(config.targets?.app?.sourceFile).toBe('src/main.asm');
+    expect(config.targets?.app?.asm).toBe('src/main.asm');
+    expect(config.targets?.app?.assembler).toBeUndefined();
+
+    applyConfigureProjectTargetEdit(config, 'app', {
+      kind: 'program',
+      sourceFile: 'src/main.zax',
+    });
+    expect(config.targets?.app?.assembler).toBe('zax');
+  });
+
+  it('renames targets and updates target aliases', () => {
+    const config: ProjectConfig = {
+      target: 'app',
+      defaultTarget: 'app',
+      targets: {
+        app: { sourceFile: 'src/main.asm' },
+      },
+    };
+
+    const result = applyConfigureProjectTargetEdit(config, 'app', {
+      kind: 'targetName',
+      targetName: 'renamed',
+    });
+
+    expect(result).toEqual({ kind: 'updated', targetName: 'renamed' });
+    expect(config.target).toBe('renamed');
+    expect(config.defaultTarget).toBe('renamed');
+    expect(config.targets?.app).toBeUndefined();
+    expect(config.targets?.renamed?.sourceFile).toBe('src/main.asm');
+  });
+
+  it('reports missing and unchanged targets without mutating', () => {
+    const config: ProjectConfig = {
+      targets: {
+        app: { sourceFile: 'src/main.asm' },
+      },
+    };
+
+    expect(
+      applyConfigureProjectTargetEdit(config, 'missing', {
+        kind: 'assembler',
+        assembler: 'zax',
+      })
+    ).toEqual({ kind: 'missingTarget' });
+    expect(
+      applyConfigureProjectTargetEdit(config, 'app', {
+        kind: 'targetName',
+        targetName: 'app',
+      })
+    ).toEqual({ kind: 'noChange' });
+    expect(config.targets).toEqual({ app: { sourceFile: 'src/main.asm' } });
+  });
+});


### PR DESCRIPTION
## Summary
- move configureProject target mutation rules into a pure helper
- keep VS Code prompts and user-facing command flow in commands.ts
- add focused unit coverage for platform override, multi-target platform stability, source/assembler behavior, target rename aliases, missing/unchanged targets

## Verification
- npx vitest run tests/extension/configure-project-edit.test.ts tests/extension/commands.test.ts
- npm run typecheck
- npm run lint -- --max-warnings=0
- npm run format:check
- git diff --check