### PR TITLE
Consolidate adapter step request flow

### DIFF
--- a/src/debug/requests/adapter-request-controller.ts
+++ b/src/debug/requests/adapter-request-controller.ts
@@ -11,6 +11,7 @@ import { getShadowAlias, isBreakpointAddress } from '../mapping/debug-addressing
 import { buildStackFrames, flushDiagLog, isDiagnosticsEnabled } from '../mapping/stack-service';
 import type { SourceStateManager } from '../mapping/source-state-manager';
 import {
+  applyStepInfo,
   captureEntryCpuStateIfNeeded,
   runUntilReturnAsync,
   runUntilStopAsync,
@@ -124,83 +125,25 @@ export class AdapterRequestController {
     response: DebugProtocol.NextResponse,
     _args: DebugProtocol.NextArguments
   ): void {
-    if (this.deps.sessionState.runtime === undefined) {
-      this.deps.sendErrorResponse(response, 1, 'No program loaded');
-      return;
-    }
-
-    const trace: StepInfo = { taken: false };
-    const result = this.deps.sessionState.runtime.step({ trace });
-    this.applyStepInfo(trace);
-    this.deps.sessionState.platformRuntime?.recordCycles(result.cycles ?? 0);
-    captureEntryCpuStateIfNeeded(this.deps.getRuntimeControlContext());
-    this.deps.sessionState.runState.pauseRequested = false;
-    this.deps.sendResponse(response);
-
-    if (result.halted) {
-      this.handleHaltStop();
-    } else {
-      if (trace.kind && trace.taken && trace.returnAddress !== undefined) {
-        this.deps.sessionState.runState.haltNotified = false;
-        this.deps.sessionState.runState.isRunning = true;
-        this.deps.sessionState.runState.lastStopReason = 'step';
-        this.deps.sessionState.runState.lastBreakpointAddress = null;
-        this.runUntilStop(
-          new Set([trace.returnAddress]),
-          this.deps.sessionState.runState.stepOverMaxInstructions,
-          'step over'
-        );
-        return;
-      }
-      this.deps.sessionState.runState.haltNotified = false;
-      this.deps.sessionState.runState.isRunning = false;
-      this.deps.sessionState.runState.lastStopReason = 'step';
-      this.deps.sessionState.runState.lastBreakpointAddress = null;
-      this.deps.sendEvent(new StoppedEvent('step', this.deps.threadId));
-    }
+    this.handleSingleStepRequest(response, {
+      getStepOverReturnAddress: (trace) =>
+        trace.kind && trace.taken ? trace.returnAddress : undefined,
+      stepOverPrecedesHalt: false,
+    });
   }
 
   public stepInRequest(
     response: DebugProtocol.StepInResponse,
     _args: DebugProtocol.StepInArguments
   ): void {
-    if (this.deps.sessionState.runtime === undefined) {
-      this.deps.sendErrorResponse(response, 1, 'No program loaded');
-      return;
-    }
-
     const unmappedReturn = this.resolveUnmappedCall();
-    const trace: StepInfo = { taken: false };
-    const result = this.deps.sessionState.runtime.step({ trace });
-    this.applyStepInfo(trace);
-    this.deps.sessionState.platformRuntime?.recordCycles(result.cycles ?? 0);
-    captureEntryCpuStateIfNeeded(this.deps.getRuntimeControlContext());
-    this.deps.sessionState.runState.pauseRequested = false;
-    this.deps.sendResponse(response);
-
-    if (unmappedReturn !== null && trace.kind && trace.taken) {
-      const returnAddress = trace.returnAddress ?? unmappedReturn;
-      this.deps.sessionState.runState.haltNotified = false;
-      this.deps.sessionState.runState.isRunning = true;
-      this.deps.sessionState.runState.lastStopReason = 'step';
-      this.deps.sessionState.runState.lastBreakpointAddress = null;
-      this.runUntilStop(
-        new Set([returnAddress]),
-        this.deps.sessionState.runState.stepOverMaxInstructions,
-        'step over'
-      );
-      return;
-    }
-
-    if (result.halted) {
-      this.handleHaltStop();
-    } else {
-      this.deps.sessionState.runState.haltNotified = false;
-      this.deps.sessionState.runState.isRunning = false;
-      this.deps.sessionState.runState.lastStopReason = 'step';
-      this.deps.sessionState.runState.lastBreakpointAddress = null;
-      this.deps.sendEvent(new StoppedEvent('step', this.deps.threadId));
-    }
+    this.handleSingleStepRequest(response, {
+      getStepOverReturnAddress: (trace) =>
+        unmappedReturn !== null && trace.kind && trace.taken
+          ? (trace.returnAddress ?? unmappedReturn)
+          : undefined,
+      stepOverPrecedesHalt: true,
+    });
   }
 
   public stepOutRequest(
@@ -451,6 +394,79 @@ export class AdapterRequestController {
     });
   }
 
+  private handleSingleStepRequest(
+    response: DebugProtocol.Response,
+    options: {
+      getStepOverReturnAddress: (trace: StepInfo) => number | undefined;
+      stepOverPrecedesHalt: boolean;
+    }
+  ): void {
+    const runtime = this.deps.sessionState.runtime;
+    if (runtime === undefined) {
+      this.deps.sendErrorResponse(response, 1, 'No program loaded');
+      return;
+    }
+
+    const trace: StepInfo = { taken: false };
+    const result = runtime.step({ trace });
+    const context = this.deps.getRuntimeControlContext();
+    applyStepInfo(context, trace);
+    this.deps.sessionState.platformRuntime?.recordCycles(result.cycles ?? 0);
+    captureEntryCpuStateIfNeeded(context);
+    this.deps.sessionState.runState.pauseRequested = false;
+    this.deps.sendResponse(response);
+
+    if (options.stepOverPrecedesHalt && this.continueStepOverIfNeeded(options, trace)) {
+      return;
+    }
+
+    if (result.halted) {
+      this.handleHaltStop();
+      return;
+    }
+
+    if (!options.stepOverPrecedesHalt && this.continueStepOverIfNeeded(options, trace)) {
+      return;
+    }
+
+    this.markStepStopped();
+    this.deps.sendEvent(new StoppedEvent('step', this.deps.threadId));
+  }
+
+  private continueStepOverIfNeeded(
+    options: {
+      getStepOverReturnAddress: (trace: StepInfo) => number | undefined;
+    },
+    trace: StepInfo
+  ): boolean {
+    const returnAddress = options.getStepOverReturnAddress(trace);
+    if (returnAddress === undefined) {
+      return false;
+    }
+
+    this.markStepRunning();
+    this.runUntilStop(
+      new Set([returnAddress]),
+      this.deps.sessionState.runState.stepOverMaxInstructions,
+      'step over'
+    );
+    return true;
+  }
+
+  private markStepRunning(): void {
+    this.deps.sessionState.runState.haltNotified = false;
+    this.deps.sessionState.runState.isRunning = true;
+    this.deps.sessionState.runState.lastStopReason = 'step';
+    this.deps.sessionState.runState.lastBreakpointAddress = null;
+  }
+
+  private markStepStopped(): void {
+    this.deps.sessionState.runState.haltNotified = false;
+    this.deps.sessionState.runState.isRunning = false;
+    this.deps.sessionState.runState.lastStopReason = 'step';
+    this.deps.sessionState.runState.lastBreakpointAddress = null;
+  }
+
   private resolveUnmappedCall(): number | null {
     const { runtime, mappingIndex } = this.deps.sessionState;
     if (runtime === undefined || mappingIndex === undefined) {
@@ -468,21 +484,5 @@ export class AdapterRequestController {
       activePlatform: this.deps.platformState.active,
       tec1gRuntime: this.deps.sessionState.tec1gRuntime,
     });
-  }
-
-  private applyStepInfo(trace: StepInfo): void {
-    if (!trace.kind || !trace.taken) {
-      return;
-    }
-    if (trace.kind === 'call' || trace.kind === 'rst') {
-      this.deps.sessionState.runState.callDepth += 1;
-      return;
-    }
-    if (trace.kind === 'ret') {
-      this.deps.sessionState.runState.callDepth = Math.max(
-        0,
-        this.deps.sessionState.runState.callDepth - 1
-      );
-    }
   }
 }

--- a/tests/debug/adapter-request-controller.test.ts
+++ b/tests/debug/adapter-request-controller.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('vscode', () => ({}));
 
@@ -8,6 +8,10 @@ import { createSessionState } from '../../src/debug/session/session-state';
 import * as runtimeControl from '../../src/debug/session/runtime-control';
 import { VariableService } from '../../src/debug/requests/variable-service';
 import { createZ80Runtime } from '../../src/z80/runtime';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function createController() {
   const sessionState = createSessionState();
@@ -40,18 +44,32 @@ function createController() {
       getRuntime: () => sessionState.runtime,
       getRuntimeCapabilities: () => undefined,
       getActivePlatform: () => 'simple',
-      getCallDepth: () => 0,
-      setCallDepth: () => undefined,
+      getCallDepth: () => sessionState.runState.callDepth,
+      setCallDepth: (depth: number) => {
+        sessionState.runState.callDepth = depth;
+      },
       getPauseRequested: () => false,
-      setPauseRequested: () => undefined,
-      getRunning: () => false,
-      setRunning: () => undefined,
-      getSkipBreakpointOnce: () => null,
-      setSkipBreakpointOnce: () => undefined,
-      getHaltNotified: () => false,
-      setHaltNotified: () => undefined,
-      setLastStopReason: () => undefined,
-      setLastBreakpointAddress: () => undefined,
+      setPauseRequested: (value: boolean) => {
+        sessionState.runState.pauseRequested = value;
+      },
+      getRunning: () => sessionState.runState.isRunning,
+      setRunning: (value: boolean) => {
+        sessionState.runState.isRunning = value;
+      },
+      getSkipBreakpointOnce: () => sessionState.runState.skipBreakpointOnce,
+      setSkipBreakpointOnce: (address: number | null) => {
+        sessionState.runState.skipBreakpointOnce = address;
+      },
+      getHaltNotified: () => sessionState.runState.haltNotified,
+      setHaltNotified: (value: boolean) => {
+        sessionState.runState.haltNotified = value;
+      },
+      setLastStopReason: (reason: string) => {
+        sessionState.runState.lastStopReason = reason;
+      },
+      setLastBreakpointAddress: (address: number | null) => {
+        sessionState.runState.lastBreakpointAddress = address;
+      },
       isBreakpointAddress: () => false,
       handleHaltStop: () => undefined,
       sendEvent: () => undefined,
@@ -97,6 +115,82 @@ describe('adapter-request-controller startup sequencing', () => {
     controller.startConfiguredExecutionIfReady();
 
     expect(runUntilStopSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('AdapterRequestController single-step flow', () => {
+  it('sends the next response before the stopped event for a plain step', () => {
+    const { controller, deps, sessionState } = createController();
+    sessionState.runtime = {
+      getPC: () => 0,
+      step: ({ trace }: { trace: { taken: boolean } }) => {
+        trace.taken = false;
+        return { halted: false, cycles: 1 };
+      },
+    } as never;
+
+    controller.nextRequest({} as never, {} as never);
+
+    expect(deps.sendResponse).toHaveBeenCalledTimes(1);
+    expect(deps.sendEvent).toHaveBeenCalledTimes(1);
+    expect(deps.sendResponse.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.sendEvent.mock.invocationCallOrder[0] ?? 0
+    );
+    expect(sessionState.runState.isRunning).toBe(false);
+    expect(sessionState.runState.lastStopReason).toBe('step');
+  });
+
+  it('sends the next response before starting step-over continuation', () => {
+    const runUntilStopSpy = vi
+      .spyOn(runtimeControl, 'runUntilStopAsync')
+      .mockResolvedValue(undefined);
+    const { controller, deps, sessionState } = createController();
+    sessionState.runState.stepOverMaxInstructions = 123;
+    sessionState.runtime = {
+      getPC: () => 0,
+      step: ({ trace }: { trace: { kind?: string; taken: boolean; returnAddress?: number } }) => {
+        trace.kind = 'call';
+        trace.taken = true;
+        trace.returnAddress = 0x3456;
+        return { halted: false, cycles: 1 };
+      },
+    } as never;
+
+    controller.nextRequest({} as never, {} as never);
+
+    expect(deps.sendResponse).toHaveBeenCalledTimes(1);
+    expect(runUntilStopSpy).toHaveBeenCalledWith(expect.anything(), {
+      extraBreakpoints: new Set([0x3456]),
+      maxInstructions: 123,
+      limitLabel: 'step over',
+    });
+    expect(deps.sendResponse.mock.invocationCallOrder[0]).toBeLessThan(
+      runUntilStopSpy.mock.invocationCallOrder[0] ?? 0
+    );
+    expect(deps.sendEvent).not.toHaveBeenCalled();
+    expect(sessionState.runState.isRunning).toBe(true);
+    expect(sessionState.runState.callDepth).toBe(1);
+  });
+
+  it('sends the step-in response before the stopped event for a plain step', () => {
+    const { controller, deps, sessionState } = createController();
+    sessionState.runtime = {
+      getPC: () => 0,
+      step: ({ trace }: { trace: { taken: boolean } }) => {
+        trace.taken = false;
+        return { halted: false, cycles: 1 };
+      },
+    } as never;
+
+    controller.stepInRequest({} as never, {} as never);
+
+    expect(deps.sendResponse).toHaveBeenCalledTimes(1);
+    expect(deps.sendEvent).toHaveBeenCalledTimes(1);
+    expect(deps.sendResponse.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.sendEvent.mock.invocationCallOrder[0] ?? 0
+    );
+    expect(sessionState.runState.isRunning).toBe(false);
+    expect(sessionState.runState.lastStopReason).toBe('step');
   });
 });
 


### PR DESCRIPTION
## Summary
- centralize next/step-in single-step request handling
- reuse runtime-control applyStepInfo through the runtime control context
- preserve response-before-event ordering and step-over continuation behavior
- add focused adapter request-controller coverage

## Verification
- npx vitest run tests/debug/adapter-request-controller.test.ts tests/debug/runtime-control.test.ts
- npm run typecheck
- npm run lint -- --max-warnings=0
- npm run format:check
- git diff --check