### PR TITLE
Refactor command project folder resolution

### DIFF
--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -78,6 +78,66 @@ type ConfigureFieldId =
   | 'outputDir'
   | 'artifactBase';
 
+const DEBUG_PROJECT_FOLDER_PROMPT = {
+  prompt: true,
+  requireProject: true,
+  placeHolder: 'Select the Debug80 project folder to debug',
+} as const;
+
+const TARGET_PROJECT_FOLDER_PROMPT = {
+  prompt: true,
+  requireProject: true,
+  placeHolder: 'Select the Debug80 project folder',
+} as const;
+
+type TargetProjectFolderResolution =
+  | { kind: 'found'; folder: vscode.WorkspaceFolder }
+  | { kind: 'missing-explicit-root'; rootPath: string }
+  | { kind: 'none' };
+
+async function resolveDebugProjectFolder(
+  rootPath: string | undefined,
+  workspaceSelection: WorkspaceSelectionController
+): Promise<vscode.WorkspaceFolder | undefined> {
+  const directFolder = findWorkspaceFolder(rootPath);
+  if (directFolder !== undefined && findProjectConfigPath(directFolder) !== undefined) {
+    return directFolder;
+  }
+  return workspaceSelection.resolveWorkspaceFolder(DEBUG_PROJECT_FOLDER_PROMPT);
+}
+
+async function resolveRestartProjectFolder(
+  activeSession: vscode.DebugSession | undefined,
+  workspaceSelection: WorkspaceSelectionController
+): Promise<vscode.WorkspaceFolder | undefined> {
+  if (activeSession?.type === 'z80') {
+    const sessionFolder = resolveSessionWorkspaceFolder(activeSession);
+    if (sessionFolder !== undefined) {
+      return sessionFolder;
+    }
+  }
+  return workspaceSelection.resolveWorkspaceFolder(DEBUG_PROJECT_FOLDER_PROMPT);
+}
+
+async function resolveTargetProjectFolder(
+  args: SelectTargetArgs | undefined,
+  workspaceSelection: WorkspaceSelectionController
+): Promise<TargetProjectFolderResolution> {
+  const folder = findWorkspaceFolder(args?.rootPath);
+  if (folder !== undefined) {
+    return { kind: 'found', folder };
+  }
+  if (args?.rootPath !== undefined) {
+    return { kind: 'missing-explicit-root', rootPath: args.rootPath };
+  }
+  const promptedFolder = await workspaceSelection.resolveWorkspaceFolder(
+    TARGET_PROJECT_FOLDER_PROMPT
+  );
+  return promptedFolder !== undefined
+    ? { kind: 'found', folder: promptedFolder }
+    : { kind: 'none' };
+}
+
 export function registerExtensionCommands({
   context,
   platformViewProvider,
@@ -239,15 +299,7 @@ export function registerExtensionCommands({
 
   context.subscriptions.push(
     vscode.commands.registerCommand('debug80.startDebug', async (args?: StartDebugArgs) => {
-      const directFolder = findWorkspaceFolder(args?.rootPath);
-      const folder =
-        directFolder && findProjectConfigPath(directFolder) !== undefined
-          ? directFolder
-          : await workspaceSelection.resolveWorkspaceFolder({
-              prompt: true,
-              requireProject: true,
-              placeHolder: 'Select the Debug80 project folder to debug',
-            });
+      const folder = await resolveDebugProjectFolder(args?.rootPath, workspaceSelection);
       if (!folder) {
         const workspaceFolderCount = vscode.workspace.workspaceFolders?.length ?? 0;
         void vscode.window.showInformationMessage(
@@ -268,19 +320,7 @@ export function registerExtensionCommands({
   context.subscriptions.push(
     vscode.commands.registerCommand('debug80.restartDebug', async () => {
       const activeSession = vscode.debug.activeDebugSession;
-      const folder =
-        activeSession?.type === 'z80'
-          ? (resolveSessionWorkspaceFolder(activeSession) ??
-            (await workspaceSelection.resolveWorkspaceFolder({
-              prompt: true,
-              requireProject: true,
-              placeHolder: 'Select the Debug80 project folder to debug',
-            })))
-          : await workspaceSelection.resolveWorkspaceFolder({
-              prompt: true,
-              requireProject: true,
-              placeHolder: 'Select the Debug80 project folder to debug',
-            });
+      const folder = await resolveRestartProjectFolder(activeSession, workspaceSelection);
       if (!folder) {
         void vscode.window.showInformationMessage('Debug80: No configured Debug80 project found.');
         return false;
@@ -368,25 +408,18 @@ export function registerExtensionCommands({
 
   context.subscriptions.push(
     vscode.commands.registerCommand('debug80.selectTarget', async (args?: SelectTargetArgs) => {
-      const folder =
-        findWorkspaceFolder(args?.rootPath) ??
-        (args?.rootPath === undefined
-          ? await workspaceSelection.resolveWorkspaceFolder({
-              requireProject: true,
-              prompt: true,
-              placeHolder: 'Select the Debug80 project folder',
-            })
-          : undefined);
-      if (!folder) {
-        if (args?.rootPath !== undefined) {
-          void vscode.window.showInformationMessage(
-            `Debug80: The workspace root ${args.rootPath} is not open in this window.`
-          );
-          return undefined;
-        }
+      const folderResolution = await resolveTargetProjectFolder(args, workspaceSelection);
+      if (folderResolution.kind === 'missing-explicit-root') {
+        void vscode.window.showInformationMessage(
+          `Debug80: The workspace root ${folderResolution.rootPath} is not open in this window.`
+        );
+        return undefined;
+      }
+      if (folderResolution.kind === 'none') {
         void vscode.window.showInformationMessage('Debug80: No configured Debug80 project found.');
         return undefined;
       }
+      const { folder } = folderResolution;
 
       const projectConfig = findProjectConfigPath(folder);
       if (projectConfig === undefined) {

--- a/tests/extension/commands.test.ts
+++ b/tests/extension/commands.test.ts
@@ -228,6 +228,45 @@ describe('registerExtensionCommands', () => {
     );
   });
 
+  it('prompts for a configured project when a provided debug root is not a project', async () => {
+    workspaceFolders = [
+      { name: 'empty-root', uri: { fsPath: '/workspace/empty-root' }, index: 0 },
+      { name: 'tec1g-mon3', uri: { fsPath: '/workspace/tec1g-mon3' }, index: 1 },
+    ];
+    const resolveWorkspaceFolder = vi.fn().mockResolvedValue(workspaceFolders[1]);
+    existsSync.mockImplementation((candidate: string) => {
+      const normalized = path.normalize(candidate);
+      return normalized === projectConfigPath || /\.(asm|zax)$/i.test(normalized);
+    });
+
+    await registerCommands({
+      workspaceSelection: {
+        resolveWorkspaceFolder,
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+    });
+
+    const startDebug = registeredCommands.get('debug80.startDebug');
+    expect(startDebug).toBeTypeOf('function');
+
+    startDebugging.mockResolvedValueOnce(true);
+    const result = await startDebug?.({ rootPath: '/workspace/empty-root' });
+
+    expect(result).toBe(true);
+    expect(resolveWorkspaceFolder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: true,
+        requireProject: true,
+        placeHolder: 'Select the Debug80 project folder to debug',
+      })
+    );
+    expect(startDebugging).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: { fsPath: '/workspace/tec1g-mon3' } }),
+      expect.objectContaining({ projectConfig: projectConfigPath })
+    );
+  });
+
   it('creates a project directly in an already-open empty workspace root', async () => {
     workspaceFolders = [{ name: 'empty-root', uri: { fsPath: '/workspace/empty-root' }, index: 0 }];
     const folder = {
@@ -793,6 +832,33 @@ describe('registerExtensionCommands', () => {
     });
 
     expect(result).toBe('serial');
+  });
+
+  it('reports an explicit target root that is not open without prompting', async () => {
+    const resolveWorkspaceFolder = vi.fn();
+
+    await registerCommands({
+      workspaceSelection: {
+        resolveWorkspaceFolder,
+        rememberWorkspace: vi.fn(),
+        selectWorkspaceFolder: vi.fn(),
+      } as never,
+      targetSelection: {
+        resolveTarget: vi.fn(),
+        rememberTarget: vi.fn(),
+      } as never,
+    });
+
+    const selectTarget = registeredCommands.get('debug80.selectTarget');
+    expect(selectTarget).toBeTypeOf('function');
+
+    const result = await selectTarget?.({ rootPath: '/workspace/missing' });
+
+    expect(result).toBeUndefined();
+    expect(resolveWorkspaceFolder).not.toHaveBeenCalled();
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      'Debug80: The workspace root /workspace/missing is not open in this window.'
+    );
   });
 
   it('configures target platform through debug80.configureProject', async () => {


### PR DESCRIPTION
## Summary
- extract shared project-folder resolution for start, restart, and target selection commands
- preserve existing prompt and explicit-root behaviours
- add command tests for non-project debug roots and missing explicit target roots

## Verification
- npx vitest run tests/extension/commands.test.ts
- npm run typecheck
- npm run lint -- --max-warnings=0
- npm run format:check
- git diff --check