### PR TITLE
Add Z80 assembly syntax highlighting

### DIFF
--- a/language-configuration/z80-asm.json
+++ b/language-configuration/z80-asm.json
@@ -1,0 +1,27 @@
+{
+  "comments": {
+    "lineComment": ";"
+  },
+  "brackets": [
+    ["(", ")"],
+    ["[", "]"]
+  ],
+  "autoClosingPairs": [
+    ["(", ")"],
+    ["[", "]"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  "surroundingPairs": [
+    ["(", ")"],
+    ["[", "]"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  "folding": {
+    "markers": {
+      "start": "^\\s*;\\s*#?region\\b",
+      "end": "^\\s*;\\s*#?endregion\\b"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
           ".z80",
           ".a80",
           ".s"
-        ]
+        ],
+        "configuration": "./language-configuration/z80-asm.json"
       },
       {
         "id": "z80-lst",
@@ -91,6 +92,11 @@
       }
     ],
     "grammars": [
+      {
+        "language": "z80-asm",
+        "scopeName": "source.z80.asm",
+        "path": "./syntaxes/z80-asm.tmLanguage.json"
+      },
       {
         "language": "z80-lst",
         "scopeName": "source.z80.lst",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "onLanguage:z80-asm",
     "onLanguage:z80-macroasm"
   ],
-  "extensionPack": [
-    "imanolea.z80-asm"
-  ],
   "main": "./out/extension/extension.js",
   "contributes": {
     "views": {

--- a/scripts/check-vsix-contents.cjs
+++ b/scripts/check-vsix-contents.cjs
@@ -17,6 +17,7 @@ const REQUIRED_ENTRIES = [
   { label: 'resources/', matches: hasTopLevelDirectory('resources') },
   { label: 'roms/', matches: hasTopLevelDirectory('roms') },
   { label: 'schemas/', matches: hasTopLevelDirectory('schemas') },
+  { label: 'language-configuration/', matches: hasTopLevelDirectory('language-configuration') },
   { label: 'syntaxes/', matches: hasTopLevelDirectory('syntaxes') },
   { label: 'README.md', matches: (entry) => entry === 'README.md' },
   {

--- a/syntaxes/z80-asm.tmLanguage.json
+++ b/syntaxes/z80-asm.tmLanguage.json
@@ -1,0 +1,141 @@
+{
+  "name": "Z80 Assembly",
+  "scopeName": "source.z80.asm",
+  "fileTypes": ["asm", "z80", "a80", "s"],
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#labels"
+    },
+    {
+      "include": "#directives"
+    },
+    {
+      "include": "#instructions"
+    },
+    {
+      "include": "#registers"
+    },
+    {
+      "include": "#numbers"
+    },
+    {
+      "include": "#operators"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.semicolon.z80-asm",
+          "match": ";.*$"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.z80-asm",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.z80-asm",
+              "match": "\\\\."
+            }
+          ]
+        },
+        {
+          "name": "string.quoted.single.z80-asm",
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            {
+              "name": "constant.character.escape.z80-asm",
+              "match": "\\\\."
+            }
+          ]
+        }
+      ]
+    },
+    "labels": {
+      "patterns": [
+        {
+          "name": "entity.name.label.z80-asm",
+          "match": "^\\s*([A-Za-z_.$?@][A-Za-z0-9_.$?@]*)(?=\\s*:)",
+          "captures": {
+            "1": {
+              "name": "entity.name.label.z80-asm"
+            }
+          }
+        },
+        {
+          "name": "entity.name.label.local.z80-asm",
+          "match": "^\\s*(@[A-Za-z0-9_.$?@]+)(?=\\s*:?)",
+          "captures": {
+            "1": {
+              "name": "entity.name.label.local.z80-asm"
+            }
+          }
+        }
+      ]
+    },
+    "directives": {
+      "patterns": [
+        {
+          "name": "keyword.control.directive.z80-asm",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])\\.?(?:ALIGN|AREA|ASSERT|BINCLUDE|BLOCK|BYTE|CODE|CPU|DATA|DB|DC|DEFB|DEFS|DEFW|DM|DS|DW|ELSE|END|ENDIF|ENDM|ENDR|EQU|EXPORT|EXTERN|GLOBAL|IF|IFDEF|IFNDEF|INCBIN|INCLUDE|LIST|MACRO|MODULE|ORG|PHASE|PUBLIC|REPT|SECTION|SET|TEXT|WORD|XDEF|XREF)(?![A-Za-z0-9_.$?@])"
+        }
+      ]
+    },
+    "instructions": {
+      "patterns": [
+        {
+          "name": "keyword.instruction.z80-asm",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:ADC|ADD|AND|BIT|CALL|CCF|CP|CPD|CPDR|CPI|CPIR|CPL|DAA|DEC|DI|DJNZ|EI|EX|EXX|HALT|IM|IN|INC|IND|INDR|INI|INIR|JP|JR|LD|LDD|LDDR|LDI|LDIR|NEG|NOP|OR|OTDR|OTIR|OUT|OUTD|OUTI|POP|PUSH|RES|RET|RETI|RETN|RL|RLA|RLC|RLCA|RLD|RR|RRA|RRC|RRCA|RRD|RST|SBC|SCF|SET|SLA|SLL|SRA|SRL|SUB|XOR)(?![A-Za-z0-9_.$?@])"
+        }
+      ]
+    },
+    "registers": {
+      "patterns": [
+        {
+          "name": "variable.language.register.z80-asm",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:A|B|C|D|E|H|L|AF|BC|DE|HL|IX|IY|SP|PC|I|R|IXH|IXL|IYH|IYL|AF')(?![A-Za-z0-9_.$?@])"
+        },
+        {
+          "name": "variable.language.condition.z80-asm",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:NZ|Z|NC|C|PO|PE|P|M)(?![A-Za-z0-9_.$?@])"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.hex.z80-asm",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:0x[0-9A-F]+|\\$[0-9A-F]+|#[0-9A-F]+|[0-9][0-9A-F]*H)(?![A-Za-z0-9_.$?@])"
+        },
+        {
+          "name": "constant.numeric.binary.z80-asm",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:%[01]+|[01]+B)(?![A-Za-z0-9_.$?@])"
+        },
+        {
+          "name": "constant.numeric.decimal.z80-asm",
+          "match": "(?<![A-Za-z0-9_.$?@])\\d+(?![A-Za-z0-9_.$?@])"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.z80-asm",
+          "match": "\\+|-|\\*|/|=|<|>|\\||&|\\^|~|:"
+        }
+      ]
+    }
+  }
+}

--- a/tests/webview/language-contracts.test.ts
+++ b/tests/webview/language-contracts.test.ts
@@ -4,7 +4,7 @@
  * Validates that:
  * 1. The language IDs used in the extension language-association module are contributed.
  * 2. Every contributed language has a breakpoint entry.
- * 3. .asm files are associated with the contributed language.
+ * 3. ASM-family files are associated with the contributed language.
  * 4. The debugger languages list includes every breakpoint language.
  */
 
@@ -68,15 +68,19 @@ describe('package.json language contracts', () => {
     expect(bpLangs).toContain(asmLanguageId);
   });
 
-  it('.asm files are associated with ASM_LANGUAGE_ID', () => {
+  it('ASM-family files are associated with ASM_LANGUAGE_ID', () => {
     const assoc = contributes.configurationDefaults['files.associations'];
-    expect(assoc['*.asm']).toBe(asmLanguageId);
+    for (const extension of ['asm', 'z80', 'a80', 's']) {
+      expect(assoc[`*.${extension}`]).toBe(asmLanguageId);
+    }
   });
 
-  it('contributed language claims .asm extension', () => {
+  it('contributed language claims ASM-family extensions', () => {
     const lang = contributes.languages.find((l) => l.id === asmLanguageId);
     expect(lang).toBeDefined();
-    expect(lang!.extensions).toContain('.asm');
+    for (const extension of ['.asm', '.z80', '.a80', '.s']) {
+      expect(lang!.extensions).toContain(extension);
+    }
   });
 
   it('ASM_LANGUAGE_ID has a TextMate grammar contribution', () => {

--- a/tests/webview/language-contracts.test.ts
+++ b/tests/webview/language-contracts.test.ts
@@ -24,6 +24,7 @@ interface PackageJson {
       'files.associations': Record<string, string>;
     };
     languages: Array<{ id: string; extensions?: string[] }>;
+    grammars: Array<{ language: string; scopeName: string; path: string }>;
     breakpoints: Array<{ language: string }>;
     debuggers: Array<{ type: string; languages: string[] }>;
   };
@@ -76,6 +77,14 @@ describe('package.json language contracts', () => {
     const lang = contributes.languages.find((l) => l.id === asmLanguageId);
     expect(lang).toBeDefined();
     expect(lang!.extensions).toContain('.asm');
+  });
+
+  it('ASM_LANGUAGE_ID has a TextMate grammar contribution', () => {
+    const grammar = contributes.grammars.find((g) => g.language === asmLanguageId);
+    expect(grammar).toBeDefined();
+    expect(grammar!.scopeName).toBe('source.z80.asm');
+    expect(grammar!.path).toBe('./syntaxes/z80-asm.tmLanguage.json');
+    expect(fs.existsSync(path.resolve(__dirname, '../..', grammar!.path))).toBe(true);
   });
 
   it('ZAX_LANGUAGE_ID is a contributed language', () => {


### PR DESCRIPTION
## Summary
- add TextMate grammar for the existing z80-asm language used by .asm/.z80/.a80/.s files
- add language configuration for semicolon comments, brackets, quotes, and region folding
- extend language contract tests to cover the grammar contribution

## Verification
- npm run typecheck
- npm run lint -- --max-warnings=0
- npm run format:check
- git diff --check
- npx vitest run -c vitest.webview.config.ts tests/webview/language-contracts.test.ts