### PR TITLE
Improve Z80 assembly grammar and document LSP direction

### DIFF
--- a/docs/design-z80-language-server.md
+++ b/docs/design-z80-language-server.md
@@ -1,0 +1,291 @@
+# Design: Z80 Assembly Language Server
+
+**Status:** Draft  
+**Type:** Additive editor tooling  
+**Scope:** `.asm`, `.z80`, `.a80`, `.s`, and later `.zax` where the dialect overlap is safe
+
+---
+
+## Motivation
+
+Debug80 now owns the Z80 assembly language contribution and TextMate grammar for common
+assembly source files. Syntax highlighting is useful, but it is still regex-based and has no
+project understanding. A language server would let Debug80 provide structured editing support
+for assembly source without coupling those features directly to the debug adapter or webview.
+
+The goal is not to build a full replacement assembler inside the extension. The goal is to
+provide a tolerant language service that understands enough source structure to make old and
+new Z80 projects easier to navigate, edit, and debug.
+
+---
+
+## What An LSP Could Offer
+
+### Diagnostics
+
+Initial diagnostics should be lightweight and conservative:
+
+- duplicate label definitions in the same resolved source set
+- undefined label references where the reference is unambiguous
+- unknown Z80 mnemonic
+- unknown register or condition code in obvious instruction positions
+- malformed numeric literals
+- missing include files
+- out-of-range `JR` / `DJNZ` targets once expressions can be resolved
+- optional warning when a source file is outside the selected Debug80 project target graph
+
+Diagnostics should avoid pretending to be the assembler. Any dialect-sensitive or macro-heavy
+line that cannot be parsed confidently should be skipped rather than marked wrong.
+
+### Navigation
+
+High-value navigation features:
+
+- **Go to Definition** for labels, constants, macro names, and include files.
+- **Find References** for labels/constants/macros across the active project target.
+- **Document Symbols** for labels, constants, macros, sections, and routine comment headers.
+- **Workspace Symbols** for fast label search across Debug80 projects.
+
+These features would be valuable even before deeper semantic diagnostics exist.
+
+### Completion
+
+Useful completions:
+
+- Z80 mnemonics
+- registers and condition codes
+- known labels and constants
+- include paths relative to the current source and project source roots
+- assembler directives for the selected backend
+- optional platform symbols, ports, or monitor routines where Debug80 has platform metadata
+
+Completion should be project-aware. For example, the active `debug80.json` target should
+determine which files and labels are visible by default.
+
+### Hover
+
+Hover can add value without being intrusive:
+
+- opcode summary and legal operand forms
+- register/flag descriptions
+- label definition location
+- resolved numeric values in decimal/hex/binary
+- assembled address from the latest map/debug data where available
+- include target path
+- routine comment header summary, e.g. `Input`, `Output`, `Clobbers`
+
+Address-aware hover should be best-effort and clearly dependent on the latest successful
+build/map. It should not imply that stale maps are authoritative.
+
+### Rename And Code Actions
+
+Rename is valuable but should be delayed until symbol resolution is reliable. A wrong rename in
+assembly is costly.
+
+Possible later code actions:
+
+- rename label
+- create missing label
+- convert numeric literal between decimal/hex/binary
+- add missing include
+- set current source as Debug80 target
+- open or refresh project configuration
+
+---
+
+## Proposed Architecture
+
+### Extension Host Client
+
+Debug80 would register an LSP client from the extension host for the assembly language IDs it
+owns:
+
+- `z80-asm`
+- possibly `zax` later, if the server has explicit ZAX dialect support
+
+The client should pass workspace/project context to the server:
+
+- workspace folders
+- active Debug80 project folder, if selected
+- active target name and source file
+- `debug80.json` path
+- assembler backend (`asm80`, `zax`, future backends)
+- source roots and include roots
+- latest known map/debug-map path, if available
+
+This keeps the server editor-focused while still letting it use Debug80 project knowledge.
+
+### Server Process
+
+Use the standard `vscode-languageclient` / `vscode-languageserver` split:
+
+- `src/lsp/client.ts` in the extension host
+- `src/lsp/server.ts` for the language server entry point
+- shared parser/index modules under `src/lsp/assembly/` or `src/language/`
+
+The server should be a separate Node process, not run inside the debug adapter. That keeps
+LSP latency, crashes, and parser state independent of active debug sessions.
+
+### Parser And Index
+
+The first parser should be tolerant and line-oriented:
+
+- strip comments and strings safely
+- recognize labels at line start
+- recognize constants/directives
+- recognize include directives
+- recognize mnemonics and operands enough to find symbol-like tokens
+- preserve source ranges for all extracted symbols/references
+
+The index should track:
+
+- documents currently open in VS Code
+- parsed files discovered through include/source roots
+- symbol definitions
+- references
+- include edges
+- simple expression values where safely resolvable
+- parse version per document
+
+The parser should not expand complex macros in the first version. Macro definitions and macro
+invocations can be indexed as symbols, but semantic expansion should wait.
+
+---
+
+## Dialect Strategy
+
+Debug80 currently supports multiple assembler realities:
+
+- asm80-style sources
+- ZAX sources
+- inherited TEC monitor sources and older Z80 style
+
+The LSP should model dialects explicitly instead of assuming one universal grammar:
+
+- **Core Z80 dialect:** mnemonics, registers, conditions, common number formats, labels.
+- **asm80 profile:** asm80 directives and include rules.
+- **ZAX profile:** ZAX directives and any stricter syntax rules.
+- **Legacy/common profile:** permissive handling for old source files.
+
+The selected Debug80 target should choose the active profile. Standalone files without a
+project can use the common permissive profile.
+
+---
+
+## Relationship To TextMate Grammar
+
+TextMate remains responsible for immediate lexical colouring. The LSP can add semantic tokens
+later, but that should not be the first milestone.
+
+Short-term relationship:
+
+- TextMate handles syntax highlighting.
+- LSP handles structure, navigation, diagnostics, completion, and hover.
+
+Later, LSP semantic tokens could distinguish:
+
+- definition vs reference labels
+- constants vs labels
+- macros vs routines
+- unresolved symbols
+- platform symbols
+- addresses known from maps
+
+Semantic tokens should be additive and must not make files look worse when the server is still
+indexing.
+
+---
+
+## Debug80 Integration Opportunities
+
+The language server becomes more useful when it can use Debug80’s existing project data:
+
+- use `debug80.json` targets to define the source graph
+- use source roots to resolve includes and sibling files
+- use the latest `.d8.json` debug map to show addresses
+- warn when a breakpoint is on a line with no mapped executable code
+- expose code lenses for routine addresses or target entry points
+- complete platform-specific constants from platform metadata
+- add actions for “Select Active Target” or “Set Program File”
+
+These should be layered on top of the core language service. The server should still work
+without a configured Debug80 project.
+
+---
+
+## Milestone Plan
+
+### Milestone 1: Project-Aware Symbol Index
+
+Deliver:
+
+- language server/client wiring
+- parser for labels, constants, includes, routine headers, and simple references
+- document symbols
+- go to definition
+- workspace symbols
+- include-file resolution diagnostics
+
+This milestone proves the architecture without committing to hard semantic validation.
+
+### Milestone 2: References And Completion
+
+Deliver:
+
+- find references for labels/constants
+- label/constant completion
+- mnemonic/register/directive completion
+- include path completion
+- duplicate label diagnostics
+- undefined symbol diagnostics for confident references
+
+### Milestone 3: Assembler-Aware Diagnostics
+
+Deliver:
+
+- backend profiles for asm80 and ZAX
+- better directive validation
+- simple expression evaluator
+- range checks for `JR` / `DJNZ`
+- map-aware hover for labels and addresses
+
+### Milestone 4: Refactoring And Semantic Tokens
+
+Deliver:
+
+- safe rename symbol
+- semantic token support
+- routine/header-aware outline polish
+- optional code actions
+
+---
+
+## Risks And Constraints
+
+- **False diagnostics are worse than missing diagnostics.** Assembly projects often use macros,
+  generated includes, non-standard directives, and historical style. Be conservative.
+- **`.asm` is not always Z80.** Debug80 currently claims `.asm`; the LSP should be tolerant and
+  avoid noisy validation until a Debug80 project target confirms the file is Z80.
+- **Macro expansion can become expensive.** Do not block initial LSP value on macro expansion.
+- **Stale build artifacts can mislead.** Any map-derived address must be marked as coming from
+  the latest known build/map.
+- **Performance matters.** Large ROM sources should parse incrementally and index lazily.
+- **Windows path handling must stay first-class.** Include and project resolution must use
+  normalized URI/path handling, not string-only POSIX assumptions.
+
+---
+
+## Recommended Direction
+
+Start with a tolerant project-aware symbol index, not a full assembler parser.
+
+The first useful version should focus on:
+
+1. document symbols and outline
+2. go to definition for labels/includes
+3. workspace symbol search
+4. label completion
+5. duplicate/undefined label diagnostics only where confident
+
+That gives Debug80 a clear IDE improvement while keeping risk low. Once the parser/index is
+trusted, add backend-specific diagnostics and map-aware debug integration.

--- a/docs/design-z80-language-server.md
+++ b/docs/design-z80-language-server.md
@@ -1,7 +1,7 @@
 # Design: Z80 Assembly Language Server
 
-**Status:** Draft  
-**Type:** Additive editor tooling  
+**Status:** Draft
+**Type:** Additive editor tooling
 **Scope:** `.asm`, `.z80`, `.a80`, `.s`, and later `.zax` where the dialect overlap is safe
 
 ---

--- a/syntaxes/z80-asm.tmLanguage.json
+++ b/syntaxes/z80-asm.tmLanguage.json
@@ -180,7 +180,7 @@
               "name": "variable.language.condition.z80-asm"
             }
           },
-          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:CALL|JP|JR|RET)\\s+(Z|NZ|C|NC|PE|PO|M|P)(?![A-Za-z0-9_.$?@])"
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(CALL|JP|JR|RET)\\s+(Z|NZ|C|NC|PE|PO|M|P)(?![A-Za-z0-9_.$?@])"
         }
       ]
     },
@@ -220,7 +220,7 @@
         },
         {
           "name": "constant.language.current-location.z80-asm",
-          "match": "(?<![A-Za-z0-9_.$?@])\\$(?![0-9A-Fa-f])"
+          "match": "(?<![A-Za-z0-9_.$?@])\\$(?![A-Za-z0-9_.$?@])"
         }
       ]
     },

--- a/syntaxes/z80-asm.tmLanguage.json
+++ b/syntaxes/z80-asm.tmLanguage.json
@@ -133,15 +133,6 @@
     "labels": {
       "patterns": [
         {
-          "name": "entity.name.label.z80-asm",
-          "match": "^\\s*([A-Za-z_.$?@][A-Za-z0-9_.$?@]*)(?=\\s*:)",
-          "captures": {
-            "1": {
-              "name": "entity.name.label.z80-asm"
-            }
-          }
-        },
-        {
           "name": "entity.name.label.local.z80-asm",
           "match": "^\\s*(@[A-Za-z0-9_.$?@]+)(?=\\s*:?)",
           "captures": {
@@ -156,6 +147,15 @@
           "captures": {
             "1": {
               "name": "entity.name.label.local.z80-asm"
+            }
+          }
+        },
+        {
+          "name": "entity.name.label.z80-asm",
+          "match": "^\\s*([A-Za-z_.$?@][A-Za-z0-9_.$?@]*)(?=\\s*:)",
+          "captures": {
+            "1": {
+              "name": "entity.name.label.z80-asm"
             }
           }
         }

--- a/syntaxes/z80-asm.tmLanguage.json
+++ b/syntaxes/z80-asm.tmLanguage.json
@@ -32,8 +32,72 @@
     "comments": {
       "patterns": [
         {
+          "begin": ";",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.z80-asm"
+            }
+          },
+          "end": "$",
           "name": "comment.line.semicolon.z80-asm",
-          "match": ";.*$"
+          "patterns": [
+            {
+              "include": "#routine-comments"
+            }
+          ]
+        }
+      ]
+    },
+    "routine-comments": {
+      "patterns": [
+        {
+          "name": "meta.comment.separator.z80-asm",
+          "match": "[-=]{3,}"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "storage.type.annotation.z80-asm"
+            },
+            "2": {
+              "name": "entity.name.function.z80-asm"
+            }
+          },
+          "match": "(@(?:routine|proc|extern)\\b)\\s+([A-Za-z_.$?@][A-Za-z0-9_.$?@]*)"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "storage.type.annotation.z80-asm"
+            },
+            "2": {
+              "name": "meta.annotation.parameters.z80-asm"
+            }
+          },
+          "match": "(@(?:in|out|clobbers|preserves|expect-out)\\b)\\s+(\\{?\\b(?:AF|BC|DE|HL|IX|IY|SP|PC|A|B|C|D|E|F|H|L|IXH|IXL|IYH|IYL|I|R|carry|zero|sign|parity|halfCarry|negative|Z|NZ|NC|PE|PO|M|P)(?:\\s*,\\s*(?:AF|BC|DE|HL|IX|IY|SP|PC|A|B|C|D|E|F|H|L|IXH|IXL|IYH|IYL|I|R|carry|zero|sign|parity|halfCarry|negative|Z|NZ|NC|PE|PO|M|P))*\\b\\}?)"
+        },
+        {
+          "name": "storage.type.annotation.z80-asm",
+          "match": "@end\\b"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "storage.type.comment-header.z80-asm"
+            },
+            "2": {
+              "name": "punctuation.separator.key-value.z80-asm"
+            }
+          },
+          "match": "\\b(Inputs?|Outputs?|Returns?|Entry|Exit|Clobbers|Preserves|Destroys|Uses|Requires|Note|Notes|Routine|Subroutine)\\s*(:)"
+        },
+        {
+          "name": "variable.language.register.z80-asm",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:AF'|AF|BC|DE|HL|IX|IY|SP|PC|A|B|C|D|E|F|H|L|IXH|IXL|IYH|IYL|I|R)(?![A-Za-z0-9_.$?@])"
+        },
+        {
+          "name": "variable.language.flag.z80-asm",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:carry|zero|sign|parity|halfCarry|negative|Z|NZ|NC|PE|PO|M|P)(?![A-Za-z0-9_.$?@])"
         }
       ]
     },

--- a/syntaxes/z80-asm.tmLanguage.json
+++ b/syntaxes/z80-asm.tmLanguage.json
@@ -16,6 +16,9 @@
       "include": "#directives"
     },
     {
+      "include": "#condition-instructions"
+    },
+    {
       "include": "#instructions"
     },
     {
@@ -146,6 +149,15 @@
               "name": "entity.name.label.local.z80-asm"
             }
           }
+        },
+        {
+          "name": "entity.name.label.local.z80-asm",
+          "match": "^\\s*(\\.[A-Za-z_.$?@][A-Za-z0-9_.$?@]*)(?=\\s*:)",
+          "captures": {
+            "1": {
+              "name": "entity.name.label.local.z80-asm"
+            }
+          }
         }
       ]
     },
@@ -157,11 +169,26 @@
         }
       ]
     },
+    "condition-instructions": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.instruction.z80-asm"
+            },
+            "2": {
+              "name": "variable.language.condition.z80-asm"
+            }
+          },
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:CALL|JP|JR|RET)\\s+(Z|NZ|C|NC|PE|PO|M|P)(?![A-Za-z0-9_.$?@])"
+        }
+      ]
+    },
     "instructions": {
       "patterns": [
         {
           "name": "keyword.instruction.z80-asm",
-          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:ADC|ADD|AND|BIT|CALL|CCF|CP|CPD|CPDR|CPI|CPIR|CPL|DAA|DEC|DI|DJNZ|EI|EX|EXX|HALT|IM|IN|INC|IND|INDR|INI|INIR|JP|JR|LD|LDD|LDDR|LDI|LDIR|NEG|NOP|OR|OTDR|OTIR|OUT|OUTD|OUTI|POP|PUSH|RES|RET|RETI|RETN|RL|RLA|RLC|RLCA|RLD|RR|RRA|RRC|RRCA|RRD|RST|SBC|SCF|SET|SLA|SLL|SRA|SRL|SUB|XOR)(?![A-Za-z0-9_.$?@])"
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:ADC|ADD|AND|BIT|CALL|CCF|CP|CPD|CPDR|CPI|CPIR|CPL|DAA|DEC|DI|DJNZ|EI|EX|EXX|HALT|IM|IN|INC|IND|INDR|INI|INIR|JP|JR|LD|LDD|LDDR|LDI|LDIR|NEG|NOP|OR|OTDR|OTIR|OUT|OUTD|OUTI|POP|PUSH|RES|RET|RETI|RETN|RL|RLA|RLC|RLCA|RLD|RR|RRA|RRC|RRCA|RRD|RST|SBC|SCF|SET|SLA|SLL|SLI|SRA|SRL|SUB|XOR)(?![A-Za-z0-9_.$?@])"
         }
       ]
     },
@@ -190,6 +217,10 @@
         {
           "name": "constant.numeric.decimal.z80-asm",
           "match": "(?<![A-Za-z0-9_.$?@])\\d+(?![A-Za-z0-9_.$?@])"
+        },
+        {
+          "name": "constant.language.current-location.z80-asm",
+          "match": "(?<![A-Za-z0-9_.$?@])\\$(?![0-9A-Fa-f])"
         }
       ]
     },
@@ -198,6 +229,14 @@
         {
           "name": "keyword.operator.z80-asm",
           "match": "\\+|-|\\*|/|=|<|>|\\||&|\\^|~|:"
+        },
+        {
+          "name": "punctuation.section.parens.z80-asm",
+          "match": "[()]"
+        },
+        {
+          "name": "punctuation.separator.comma.z80-asm",
+          "match": ","
         }
       ]
     }

--- a/tests/webview/language-contracts.test.ts
+++ b/tests/webview/language-contracts.test.ts
@@ -104,6 +104,16 @@ describe('package.json language contracts', () => {
     expect(serializedGrammar).toContain('storage.type.comment-header.z80-asm');
   });
 
+  it('Z80 assembly grammar includes AZM-derived punctuation and condition scopes', () => {
+    const serializedGrammar = JSON.stringify(loadZ80AsmGrammar());
+    expect(serializedGrammar).toContain('#condition-instructions');
+    expect(serializedGrammar).toContain('constant.language.current-location.z80-asm');
+    expect(serializedGrammar).toContain('punctuation.section.parens.z80-asm');
+    expect(serializedGrammar).toContain('punctuation.separator.comma.z80-asm');
+    expect(serializedGrammar).toContain('SLI');
+    expect(serializedGrammar).toContain('\\\\.[A-Za-z_.$?@]');
+  });
+
   it('ZAX_LANGUAGE_ID is a contributed language', () => {
     const ids = contributes.languages.map((l) => l.id);
     expect(ids).toContain(zaxLanguageId);

--- a/tests/webview/language-contracts.test.ts
+++ b/tests/webview/language-contracts.test.ts
@@ -17,6 +17,7 @@ const LANGUAGE_ASSOCIATION_PATH = path.resolve(
   __dirname,
   '../../src/extension/language-association.ts'
 );
+const Z80_ASM_GRAMMAR_PATH = path.resolve(__dirname, '../../syntaxes/z80-asm.tmLanguage.json');
 
 interface PackageJson {
   contributes: {
@@ -32,6 +33,10 @@ interface PackageJson {
 
 function loadPackageJson(): PackageJson {
   return JSON.parse(fs.readFileSync(PKG_PATH, 'utf8')) as PackageJson;
+}
+
+function loadZ80AsmGrammar(): unknown {
+  return JSON.parse(fs.readFileSync(Z80_ASM_GRAMMAR_PATH, 'utf8'));
 }
 
 function extractAsmLanguageId(): string {
@@ -89,6 +94,14 @@ describe('package.json language contracts', () => {
     expect(grammar!.scopeName).toBe('source.z80.asm');
     expect(grammar!.path).toBe('./syntaxes/z80-asm.tmLanguage.json');
     expect(fs.existsSync(path.resolve(__dirname, '../..', grammar!.path))).toBe(true);
+  });
+
+  it('Z80 assembly grammar highlights routine comment headers', () => {
+    const serializedGrammar = JSON.stringify(loadZ80AsmGrammar());
+    expect(serializedGrammar).toContain('#routine-comments');
+    expect(serializedGrammar).toContain('@(?:routine|proc|extern)');
+    expect(serializedGrammar).toContain('Inputs?|Outputs?');
+    expect(serializedGrammar).toContain('storage.type.comment-header.z80-asm');
   });
 
   it('ZAX_LANGUAGE_ID is a contributed language', () => {

--- a/tests/webview/language-contracts.test.ts
+++ b/tests/webview/language-contracts.test.ts
@@ -65,6 +65,21 @@ function getGrammarPatternContaining(repositoryName: string, text: string): { ma
   return { match: pattern.match };
 }
 
+function getFirstMatchingGrammarScope(repositoryName: string, source: string): string {
+  const grammar = loadZ80AsmGrammar() as {
+    repository?: Record<string, { patterns?: Array<{ name?: string; match?: string }> }>;
+  };
+  for (const pattern of grammar.repository?.[repositoryName]?.patterns ?? []) {
+    if (pattern.name === undefined || pattern.match === undefined) {
+      continue;
+    }
+    if (toJavaScriptRegex(pattern.match).test(source)) {
+      return pattern.name;
+    }
+  }
+  throw new Error(`No grammar pattern in ${repositoryName} matched ${source}`);
+}
+
 function toJavaScriptRegex(textMatePattern: string): RegExp {
   if (textMatePattern.startsWith('(?i)')) {
     return new RegExp(textMatePattern.slice(4), 'i');
@@ -167,6 +182,12 @@ describe('package.json language contracts', () => {
     expect(regex.test('$ + 2')).toBe(true);
     expect(regex.test('$SCREEN')).toBe(false);
     expect(regex.test('$label')).toBe(false);
+  });
+
+  it('Z80 assembly grammar classifies dotted local labels before global labels', () => {
+    expect(getFirstMatchingGrammarScope('labels', '.loop:')).toBe(
+      'entity.name.label.local.z80-asm'
+    );
   });
 
   it('ZAX_LANGUAGE_ID is a contributed language', () => {

--- a/tests/webview/language-contracts.test.ts
+++ b/tests/webview/language-contracts.test.ts
@@ -39,6 +39,39 @@ function loadZ80AsmGrammar(): unknown {
   return JSON.parse(fs.readFileSync(Z80_ASM_GRAMMAR_PATH, 'utf8'));
 }
 
+function getGrammarPattern(repositoryName: string, scopeName: string): { match: string } {
+  const grammar = loadZ80AsmGrammar() as {
+    repository?: Record<string, { patterns?: Array<{ name?: string; match?: string }> }>;
+  };
+  const pattern = grammar.repository?.[repositoryName]?.patterns?.find((candidate) => {
+    return candidate.name === scopeName && candidate.match !== undefined;
+  });
+  if (pattern?.match === undefined) {
+    throw new Error(`Could not find grammar pattern ${repositoryName}/${scopeName}`);
+  }
+  return { match: pattern.match };
+}
+
+function getGrammarPatternContaining(repositoryName: string, text: string): { match: string } {
+  const grammar = loadZ80AsmGrammar() as {
+    repository?: Record<string, { patterns?: Array<{ match?: string }> }>;
+  };
+  const pattern = grammar.repository?.[repositoryName]?.patterns?.find((candidate) => {
+    return candidate.match?.includes(text) === true;
+  });
+  if (pattern?.match === undefined) {
+    throw new Error(`Could not find grammar pattern ${repositoryName} containing ${text}`);
+  }
+  return { match: pattern.match };
+}
+
+function toJavaScriptRegex(textMatePattern: string): RegExp {
+  if (textMatePattern.startsWith('(?i)')) {
+    return new RegExp(textMatePattern.slice(4), 'i');
+  }
+  return new RegExp(textMatePattern);
+}
+
 function extractAsmLanguageId(): string {
   const src = fs.readFileSync(LANGUAGE_ASSOCIATION_PATH, 'utf8');
   const match = src.match(/const ASM_LANGUAGE_ID\s*=\s*'([^']+)'/);
@@ -112,6 +145,28 @@ describe('package.json language contracts', () => {
     expect(serializedGrammar).toContain('punctuation.separator.comma.z80-asm');
     expect(serializedGrammar).toContain('SLI');
     expect(serializedGrammar).toContain('\\\\.[A-Za-z_.$?@]');
+  });
+
+  it('Z80 assembly grammar condition instruction regex captures mnemonic and condition', () => {
+    const conditionPattern = getGrammarPatternContaining(
+      'condition-instructions',
+      'CALL|JP|JR|RET'
+    );
+    const regex = toJavaScriptRegex(conditionPattern.match);
+    const match = regex.exec('JR NZ,label');
+    expect(match?.[1]).toBe('JR');
+    expect(match?.[2]).toBe('NZ');
+  });
+
+  it('Z80 assembly grammar current-location regex does not match dollar labels', () => {
+    const currentLocationPattern = getGrammarPattern(
+      'numbers',
+      'constant.language.current-location.z80-asm'
+    );
+    const regex = toJavaScriptRegex(currentLocationPattern.match);
+    expect(regex.test('$ + 2')).toBe(true);
+    expect(regex.test('$SCREEN')).toBe(false);
+    expect(regex.test('$label')).toBe(false);
   });
 
   it('ZAX_LANGUAGE_ID is a contributed language', () => {


### PR DESCRIPTION
## Summary
- add nested routine-comment highlighting for Z80 assembly comments, including AZM-style tags and Input/Output headers
- add AZM-derived grammar refinements for condition operands, current-location $, punctuation, dot-local labels, and SLI
- document a possible Debug80 Z80 language server architecture and milestone direction

## Verification
- node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('syntaxes/z80-asm.tmLanguage.json','utf8')); console.log('grammar json ok')"
- npx vitest run -c vitest.webview.config.ts tests/webview/language-contracts.test.ts
- npm run typecheck
- npm run lint -- --max-warnings=0
- npm run format:check
- git diff --check