### PR TITLE
Mirror TEC-1G 8x8 matrix horizontally

### DIFF
--- a/src/platforms/tec1g/runtime-matrix.ts
+++ b/src/platforms/tec1g/runtime-matrix.ts
@@ -9,6 +9,11 @@ import type { Tec1gState } from './runtime-state';
 /** If no matrix port OUT for this long, commit partial staging (~25 fps). */
 const TEC1G_MATRIX_IDLE_FLUSH_MS = 40;
 
+/** Maps hardware column bits into left-to-right visible matrix pixels. */
+function matrixDisplayIndex(row: number, hardwareColumn: number): number {
+  return row * 8 + (7 - hardwareColumn);
+}
+
 /**
  * Matrix display: accumulate row RGB into staging; commit when all rows visited.
  */
@@ -69,13 +74,12 @@ function accumulateMatrixStagingFromRows(display: Tec1gState['display']): void {
     if ((rowMask & (1 << row)) === 0) {
       continue;
     }
-    const base = row * 8;
     const rPlane = ledMatrixRedRows[row] ?? 0;
     const gPlane = ledMatrixGreenRows[row] ?? 0;
     const bPlane = ledMatrixBlueRows[row] ?? 0;
     for (let col = 0; col < 8; col += 1) {
       const bit = 1 << col;
-      const idx = base + col;
+      const idx = matrixDisplayIndex(row, col);
       display.matrixStagingR[idx] = (rPlane & bit) !== 0 ? 255 : 0;
       display.matrixStagingG[idx] = (gPlane & bit) !== 0 ? 255 : 0;
       display.matrixStagingB[idx] = (bPlane & bit) !== 0 ? 255 : 0;

--- a/tests/platforms/tec1g/matrix.test.ts
+++ b/tests/platforms/tec1g/matrix.test.ts
@@ -47,7 +47,8 @@ describe('TEC-1G matrix keyboard', () => {
     // Brightness commits on idle (~40ms) or when all 8 row lines have been selected — not on every OUT.
     const idleCycles = millisecondsToClocks(TEC1G_FAST_HZ, 45) + 1000;
     rt.recordCycles(idleCycles);
-    expect(rt.state.display.ledMatrixBrightnessR[17]).toBe(255);
+    expect(rt.state.display.ledMatrixBrightnessR[17]).toBe(0);
+    expect(rt.state.display.ledMatrixBrightnessR[22]).toBe(255);
     expect(rt.ioHandlers.read(0x02fe) & (1 << 4)).toBe(0);
   });
 
@@ -149,9 +150,30 @@ describe('TEC-1G matrix keyboard', () => {
 
     const idleCycles = millisecondsToClocks(TEC1G_FAST_HZ, 45) + 1000;
     rt.recordCycles(idleCycles);
-    expect(rt.state.display.ledMatrixBrightnessR[0]).toBe(255);
-    expect(rt.state.display.ledMatrixBrightnessR[1]).toBe(255);
-    expect(rt.state.display.ledMatrixBrightnessR[2]).toBe(0);
+    expect(rt.state.display.ledMatrixBrightnessR[0]).toBe(0);
+    expect(rt.state.display.ledMatrixBrightnessR[5]).toBe(0);
+    expect(rt.state.display.ledMatrixBrightnessR[6]).toBe(255);
+    expect(rt.state.display.ledMatrixBrightnessR[7]).toBe(255);
+  });
+
+  it('mirrors hardware columns into visible 8x8 brightness columns', () => {
+    const rightmostRt = makeRuntime(true);
+
+    rightmostRt.ioHandlers.write(0x06, 0x01);
+    rightmostRt.ioHandlers.write(0x05, 0x01);
+    rightmostRt.recordCycles(millisecondsToClocks(TEC1G_FAST_HZ, 45) + 1000);
+
+    expect(rightmostRt.state.display.ledMatrixBrightnessR[0]).toBe(0);
+    expect(rightmostRt.state.display.ledMatrixBrightnessR[7]).toBe(255);
+
+    const leftmostRt = makeRuntime(true);
+
+    leftmostRt.ioHandlers.write(0x06, 0x80);
+    leftmostRt.ioHandlers.write(0x05, 0x01);
+    leftmostRt.recordCycles(millisecondsToClocks(TEC1G_FAST_HZ, 45) + 1000);
+
+    expect(leftmostRt.state.display.ledMatrixBrightnessR[0]).toBe(255);
+    expect(leftmostRt.state.display.ledMatrixBrightnessR[7]).toBe(0);
   });
 
   it('suppresses keypad NMI when matrix mode is enabled', () => {

--- a/tests/webview/tec1g-matrix-ui.test.ts
+++ b/tests/webview/tec1g-matrix-ui.test.ts
@@ -99,13 +99,17 @@ describe('tec1g matrix ui', () => {
   });
 
   it('falls back to latch rows before brightness data arrives', () => {
-    const firstDot = document.querySelector('.matrix-dot') as HTMLElement;
+    const dots = document.querySelectorAll('.matrix-dot');
+    const firstDot = dots[0] as HTMLElement;
+    const lastDotInFirstRow = dots[7] as HTMLElement;
 
     controller.applyMatrixRows([0x01]);
 
-    expect(firstDot.classList.contains('on')).toBe(true);
-    expect(firstDot.style.getPropertyValue('--matrix-level')).toBe('1.000');
-    expect(firstDot.style.getPropertyValue('--matrix-r')).toBe('1.000');
+    expect(firstDot.classList.contains('on')).toBe(false);
+    expect(firstDot.style.getPropertyValue('--matrix-level')).toBe('0.000');
+    expect(lastDotInFirstRow.classList.contains('on')).toBe(true);
+    expect(lastDotInFirstRow.style.getPropertyValue('--matrix-level')).toBe('1.000');
+    expect(lastDotInFirstRow.style.getPropertyValue('--matrix-r')).toBe('1.000');
   });
 
   it('preserves omitted brightness planes on partial RGB updates', () => {

--- a/webview/tec1g/matrix-ui.ts
+++ b/webview/tec1g/matrix-ui.ts
@@ -77,7 +77,8 @@ export function createMatrixUiController(
     dots.forEach((dot) => {
       const row = parseInt((dot as HTMLElement).dataset.row || '0', 10);
       const col = parseInt((dot as HTMLElement).dataset.col || '0', 10);
-      const mask = 1 << col;
+      const hardwareCol = 7 - col;
+      const mask = 1 << hardwareCol;
       const idx = row * 8 + col;
       let br: number;
       let bg: number;


### PR DESCRIPTION
## Summary
- Mirror TEC-1G 8x8 matrix hardware column bits into visible left-to-right brightness pixels.
- Apply the same horizontal mirror to the webview row-latch fallback before brightness payloads arrive.
- Update runtime and webview tests to cover the reversed left/right mapping.

## Test Plan
- `./node_modules/.bin/vitest run tests/platforms/tec1g/matrix.test.ts`
- `./node_modules/.bin/vitest run -c vitest.webview.config.ts tests/webview/tec1g-matrix-ui.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc -p webview/tsconfig.json --noEmit`
- `./node_modules/.bin/eslint src tests webview --ext .ts --max-warnings=0`
- `./node_modules/.bin/prettier --check "src/**/*.ts" "tests/**/*.ts" "webview/**/*.ts"`
- `git diff --check`