### PR TITLE
Color Z80 assembly comments green

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,20 @@
         "*.a80": "z80-asm",
         "*.s": "z80-asm",
         "*.zax": "zax"
+      },
+      "editor.tokenColorCustomizations": {
+        "textMateRules": [
+          {
+            "scope": [
+              "comment.line.semicolon.z80-asm",
+              "punctuation.definition.comment.z80-asm",
+              "comment.line.semicolon.z80-lst"
+            ],
+            "settings": {
+              "foreground": "#6A9955"
+            }
+          }
+        ]
       }
     },
     "languages": [

--- a/tests/webview/language-contracts.test.ts
+++ b/tests/webview/language-contracts.test.ts
@@ -23,6 +23,14 @@ interface PackageJson {
   contributes: {
     configurationDefaults: {
       'files.associations': Record<string, string>;
+      'editor.tokenColorCustomizations'?: {
+        textMateRules?: Array<{
+          scope?: string | string[];
+          settings?: {
+            foreground?: string;
+          };
+        }>;
+      };
     };
     languages: Array<{ id: string; extensions?: string[] }>;
     grammars: Array<{ language: string; scopeName: string; path: string }>;
@@ -150,6 +158,19 @@ describe('package.json language contracts', () => {
     expect(serializedGrammar).toContain('@(?:routine|proc|extern)');
     expect(serializedGrammar).toContain('Inputs?|Outputs?');
     expect(serializedGrammar).toContain('storage.type.comment-header.z80-asm');
+  });
+
+  it('contributes green token colors for Debug80 assembly comments', () => {
+    const rules =
+      contributes.configurationDefaults['editor.tokenColorCustomizations']?.textMateRules ?? [];
+    const commentRule = rules.find((rule) => {
+      return Array.isArray(rule.scope) && rule.scope.includes('comment.line.semicolon.z80-asm');
+    });
+
+    expect(commentRule).toBeDefined();
+    expect(commentRule!.scope).toContain('punctuation.definition.comment.z80-asm');
+    expect(commentRule!.scope).toContain('comment.line.semicolon.z80-lst');
+    expect(commentRule!.settings?.foreground).toBe('#6A9955');
   });
 
   it('Z80 assembly grammar includes AZM-derived punctuation and condition scopes', () => {


### PR DESCRIPTION
## Summary
- Add a Debug80-specific token color customization so Z80 assembly and listing comments render green.
- Scope the color rule to Debug80 TextMate scopes rather than generic `comment`, avoiding other-language impact.
- Add a package language contract regression test for the comment color contribution.

## Test Plan
- `./node_modules/.bin/vitest run -c vitest.webview.config.ts tests/webview/language-contracts.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint tests/webview/language-contracts.test.ts --ext .ts --max-warnings=0`
- `./node_modules/.bin/prettier --check package.json tests/webview/language-contracts.test.ts`
- `git diff --check`