### PR TITLE
Distinguish assembly label and constant colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,124 @@
             "settings": {
               "foreground": "#6A9955"
             }
+          },
+          {
+            "scope": [
+              "entity.name.label.z80-asm",
+              "entity.name.label.local.z80-asm",
+              "entity.name.label.z80-lst"
+            ],
+            "settings": {
+              "foreground": "#B77DFF"
+            }
+          },
+          {
+            "scope": [
+              "variable.other.symbol.z80-asm",
+              "variable.other.symbol.z80-lst"
+            ],
+            "settings": {
+              "foreground": "#FF4D6D"
+            }
+          },
+          {
+            "scope": [
+              "keyword.control.directive.z80-asm",
+              "keyword.control.directive.z80-lst"
+            ],
+            "settings": {
+              "foreground": "#FF66C4"
+            }
+          },
+          {
+            "scope": [
+              "storage.type.annotation.z80-asm",
+              "storage.type.comment-header.z80-asm"
+            ],
+            "settings": {
+              "foreground": "#00D1A7"
+            }
+          },
+          {
+            "scope": [
+              "keyword.instruction.z80-asm",
+              "keyword.instruction.z80-lst"
+            ],
+            "settings": {
+              "foreground": "#FF9D00"
+            }
+          },
+          {
+            "scope": [
+              "variable.language.register.z80-asm",
+              "variable.language.register.z80-lst"
+            ],
+            "settings": {
+              "foreground": "#00C2FF"
+            }
+          },
+          {
+            "scope": [
+              "variable.language.condition.z80-asm",
+              "variable.language.condition.z80-lst",
+              "variable.language.flag.z80-asm"
+            ],
+            "settings": {
+              "foreground": "#3B82F6"
+            }
+          },
+          {
+            "scope": [
+              "string.quoted.double.z80-asm",
+              "string.quoted.single.z80-asm",
+              "string.quoted.double.z80-lst"
+            ],
+            "settings": {
+              "foreground": "#A3E635"
+            }
+          },
+          {
+            "scope": [
+              "entity.name.function.z80-asm"
+            ],
+            "settings": {
+              "foreground": "#FDE047"
+            }
+          },
+          {
+            "scope": [
+              "keyword.operator.z80-asm",
+              "punctuation.section.parens.z80-asm",
+              "punctuation.separator.comma.z80-asm",
+              "punctuation.separator.key-value.z80-asm",
+              "keyword.operator.z80-lst",
+              "punctuation.section.parens.z80-lst",
+              "punctuation.separator.comma.z80-lst",
+              "meta.comment.separator.z80-asm",
+              "meta.annotation.parameters.z80-asm",
+              "constant.character.escape.z80-asm",
+              "constant.character.escape.z80-lst"
+            ],
+            "settings": {
+              "foreground": "#A0AEC0"
+            }
+          },
+          {
+            "scope": [
+              "constant.numeric.hex.z80-asm",
+              "constant.numeric.binary.z80-asm",
+              "constant.numeric.decimal.z80-asm",
+              "constant.language.current-location.z80-asm",
+              "constant.numeric.address.z80-lst",
+              "constant.numeric.hex.z80-lst",
+              "constant.numeric.binary.z80-lst",
+              "constant.numeric.decimal.z80-lst",
+              "constant.language.current-location.z80-lst",
+              "constant.numeric.hexbyte.z80-lst"
+            ],
+            "settings": {
+              "foreground": "#FFD166"
+            }
           }
         ]
       }

--- a/syntaxes/z80-asm.tmLanguage.json
+++ b/syntaxes/z80-asm.tmLanguage.json
@@ -28,6 +28,9 @@
       "include": "#numbers"
     },
     {
+      "include": "#symbols"
+    },
+    {
       "include": "#operators"
     }
   ],
@@ -165,7 +168,7 @@
       "patterns": [
         {
           "name": "keyword.control.directive.z80-asm",
-          "match": "(?i)(?<![A-Za-z0-9_.$?@])\\.?(?:ALIGN|AREA|ASSERT|BINCLUDE|BLOCK|BYTE|CODE|CPU|DATA|DB|DC|DEFB|DEFS|DEFW|DM|DS|DW|ELSE|END|ENDIF|ENDM|ENDR|EQU|EXPORT|EXTERN|GLOBAL|IF|IFDEF|IFNDEF|INCBIN|INCLUDE|LIST|MACRO|MODULE|ORG|PHASE|PUBLIC|REPT|SECTION|SET|TEXT|WORD|XDEF|XREF)(?![A-Za-z0-9_.$?@])"
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])\\.?(?:ALIGN|AREA|ASSERT|BINCLUDE|BLOCK|BYTE|CODE|CPU|DATA|DB|DC|DEFB|DEFS|DEFW|DM|DS|DW|ELSE|END|ENDIF|ENDM|ENDR|EQU|EXPORT|EXTERN|GLOBAL|IF|IFDEF|IFNDEF|INCBIN|INCLUDE|LIST|MACRO|MODULE|ORG|PHASE|PUBLIC|REPT|SECTION|TEXT|WORD|XDEF|XREF)(?![A-Za-z0-9_.$?@])"
         }
       ]
     },
@@ -221,6 +224,14 @@
         {
           "name": "constant.language.current-location.z80-asm",
           "match": "(?<![A-Za-z0-9_.$?@])\\$(?![A-Za-z0-9_.$?@])"
+        }
+      ]
+    },
+    "symbols": {
+      "patterns": [
+        {
+          "name": "variable.other.symbol.z80-asm",
+          "match": "(?<![A-Za-z0-9_.$?@])[A-Za-z_.$?@][A-Za-z0-9_.$?@]*(?![A-Za-z0-9_.$?@])"
         }
       ]
     },

--- a/syntaxes/z80-lst.tmLanguage.json
+++ b/syntaxes/z80-lst.tmLanguage.json
@@ -1,40 +1,182 @@
 {
   "name": "Z80 Listing",
   "scopeName": "source.z80.lst",
-  "fileTypes": [
-    "lst"
-  ],
+  "fileTypes": ["lst"],
   "patterns": [
     {
-      "name": "comment.line.semicolon.z80-lst",
-      "match": ";.*$"
+      "include": "#listing-row"
     },
     {
-      "name": "string.quoted.double.z80-lst",
-      "begin": "\"",
-      "end": "\"",
+      "include": "#comments"
+    },
+    {
+      "include": "#strings"
+    }
+  ],
+  "repository": {
+    "listing-row": {
+      "begin": "(?i)^\\s*[0-9A-F]{4,5}(?:\\s{3}(?:(?:(?:[0-9A-F]{2}|DB|DC|DM|DS|DW)\\s(?=(?:[0-9A-F]{2}|DB|DC|DM|DS|DW)(?:\\s|$)))+(?!(?:DB|DC|DM|DS|DW)\\b)[0-9A-F]{2}(?=\\s|$)|(?:(?:DB|DC|DM|DS|DW)(?=\\s*$|\\s{2,}(?=(?:DB|DC|DM|DS|DW|[0-9A-F]{2})(?:\\s|$))|\\s+(?=[0-9A-F]{2}(?:\\s|$)))|(?!(?:DB|DC|DM|DS|DW)(?:\\s{2,}|\\s*$))[0-9A-F]{2})(?:\\s+(?=[0-9A-F]{2}(?:\\s|$))|\\s{2,}|\\s*$)*)|\\s{15,})\\s*",
+      "beginCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "name": "constant.numeric.address.z80-lst",
+              "match": "^\\s*[0-9A-Fa-f]{4,5}\\b"
+            },
+            {
+              "name": "constant.numeric.hexbyte.z80-lst",
+              "match": "(?i)\\b(?:[0-9A-F]{2}|DB|DC|DM|DS|DW)\\b"
+            }
+          ]
+        }
+      },
+      "end": "$",
       "patterns": [
         {
-          "name": "constant.character.escape.z80-lst",
-          "match": "\\\\."
+          "include": "#comments"
+        },
+        {
+          "include": "#strings"
+        },
+        {
+          "include": "#labels"
+        },
+        {
+          "include": "#directives"
+        },
+        {
+          "include": "#numbers"
+        },
+        {
+          "include": "#condition-instructions"
+        },
+        {
+          "include": "#registers"
+        },
+        {
+          "include": "#instructions"
+        },
+        {
+          "include": "#symbols"
+        },
+        {
+          "include": "#operators"
         }
       ]
     },
-    {
-      "name": "constant.numeric.address.z80-lst",
-      "match": "^\\s*[0-9A-Fa-f]{4}\\b"
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.semicolon.z80-lst",
+          "match": ";.*$"
+        }
+      ]
     },
-    {
-      "name": "constant.numeric.hexbyte.z80-lst",
-      "match": "\\b[0-9A-Fa-f]{2}\\b"
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.z80-lst",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.z80-lst",
+              "match": "\\\\."
+            }
+          ]
+        }
+      ]
     },
-    {
-      "name": "entity.name.label.z80-lst",
-      "match": "\\b[A-Za-z_][A-Za-z0-9_]*:"
+    "labels": {
+      "patterns": [
+        {
+          "name": "entity.name.label.z80-lst",
+          "match": "\\b[A-Za-z_][A-Za-z0-9_]*:"
+        }
+      ]
     },
-    {
-      "name": "keyword.instruction.z80-lst",
-      "match": "\\b(?:ADC|ADD|AND|BIT|CALL|CCF|CP|CPD|CPDR|CPI|CPIR|CPL|DAA|DEC|DI|DJNZ|EI|EX|EXX|HALT|IM|IN|INC|IND|INDR|INI|INIR|JP|JR|LD|LDD|LDDR|LDI|LDIR|NEG|NOP|OR|OTDR|OTIR|OUT|OUTD|OUTI|POP|PUSH|RES|RET|RETI|RETN|RL|RLA|RLC|RLCA|RLD|RR|RRA|RRC|RRCA|RRD|RST|SBC|SCF|SET|SLA|SLL|SRA|SRL|SUB|XOR|EQU|ORG|DB|DS)\\b"
+    "directives": {
+      "patterns": [
+        {
+          "name": "keyword.control.directive.z80-lst",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])\\.?(?:ALIGN|AREA|ASSERT|BINCLUDE|BLOCK|BYTE|CODE|CPU|DATA|DB|DC|DEFB|DEFS|DEFW|DM|DS|DW|ELSE|END|ENDIF|ENDM|ENDR|EQU|EXPORT|EXTERN|GLOBAL|IF|IFDEF|IFNDEF|INCBIN|INCLUDE|LIST|MACRO|MODULE|ORG|PHASE|PUBLIC|REPT|SECTION|TEXT|WORD|XDEF|XREF)(?![A-Za-z0-9_.$?@])"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.hex.z80-lst",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:0x[0-9A-F]+|\\$[0-9A-F]+|#[0-9A-F]+|[0-9][0-9A-F]*H)(?![A-Za-z0-9_.$?@])"
+        },
+        {
+          "name": "constant.numeric.binary.z80-lst",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:%[01]+|[01]+B)(?![A-Za-z0-9_.$?@])"
+        },
+        {
+          "name": "constant.numeric.decimal.z80-lst",
+          "match": "(?<![A-Za-z0-9_.$?@])\\d+(?![A-Za-z0-9_.$?@])"
+        },
+        {
+          "name": "constant.language.current-location.z80-lst",
+          "match": "(?<![A-Za-z0-9_.$?@])\\$(?![A-Za-z0-9_.$?@])"
+        }
+      ]
+    },
+    "condition-instructions": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.instruction.z80-lst"
+            },
+            "2": {
+              "name": "variable.language.condition.z80-lst"
+            }
+          },
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(CALL|JP|JR|RET)\\s+(Z|NZ|C|NC|PE|PO|M|P)(?![A-Za-z0-9_.$?@])"
+        }
+      ]
+    },
+    "registers": {
+      "patterns": [
+        {
+          "name": "variable.language.register.z80-lst",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:A|B|C|D|E|H|L|AF|BC|DE|HL|IX|IY|SP|PC|I|R|IXH|IXL|IYH|IYL|AF')(?![A-Za-z0-9_.$?@])"
+        }
+      ]
+    },
+    "instructions": {
+      "patterns": [
+        {
+          "name": "keyword.instruction.z80-lst",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?:ADC|ADD|AND|BIT|CALL|CCF|CP|CPD|CPDR|CPI|CPIR|CPL|DAA|DEC|DI|DJNZ|EI|EX|EXX|HALT|IM|IN|INC|IND|INDR|INI|INIR|JP|JR|LD|LDD|LDDR|LDI|LDIR|NEG|NOP|OR|OTDR|OTIR|OUT|OUTD|OUTI|POP|PUSH|RES|RET|RETI|RETN|RL|RLA|RLC|RLCA|RLD|RR|RRA|RRC|RRCA|RRD|RST|SBC|SCF|SET|SLA|SLL|SLI|SRA|SRL|SUB|XOR)(?![A-Za-z0-9_.$?@])"
+        }
+      ]
+    },
+    "symbols": {
+      "patterns": [
+        {
+          "name": "variable.other.symbol.z80-lst",
+          "match": "(?i)(?<![A-Za-z0-9_.$?@])(?!(?:ADC|ADD|AND|BIT|CALL|CCF|CP|CPD|CPDR|CPI|CPIR|CPL|DAA|DEC|DI|DJNZ|EI|EX|EXX|HALT|IM|IN|INC|IND|INDR|INI|INIR|JP|JR|LD|LDD|LDDR|LDI|LDIR|NEG|NOP|OR|OTDR|OTIR|OUT|OUTD|OUTI|POP|PUSH|RES|RET|RETI|RETN|RL|RLA|RLC|RLCA|RLD|RR|RRA|RRC|RRCA|RRD|RST|SBC|SCF|SET|SLA|SLL|SLI|SRA|SRL|SUB|XOR|A|B|C|D|E|H|L|AF|BC|DE|HL|IX|IY|SP|PC|I|R|IXH|IXL|IYH|IYL|AF'|NZ|Z|NC|PO|PE|P|M)\\b)[A-Za-z_.$?@][A-Za-z0-9_.$?@]*(?![A-Za-z0-9_.$?@])"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.z80-lst",
+          "match": "\\+|-|\\*|/|=|<|>|\\||&|\\^|~|:"
+        },
+        {
+          "name": "punctuation.section.parens.z80-lst",
+          "match": "[()]"
+        },
+        {
+          "name": "punctuation.separator.comma.z80-lst",
+          "match": ","
+        }
+      ]
     }
-  ]
+  }
 }

--- a/tests/webview/language-contracts.test.ts
+++ b/tests/webview/language-contracts.test.ts
@@ -18,6 +18,7 @@ const LANGUAGE_ASSOCIATION_PATH = path.resolve(
   '../../src/extension/language-association.ts'
 );
 const Z80_ASM_GRAMMAR_PATH = path.resolve(__dirname, '../../syntaxes/z80-asm.tmLanguage.json');
+const Z80_LST_GRAMMAR_PATH = path.resolve(__dirname, '../../syntaxes/z80-lst.tmLanguage.json');
 
 interface PackageJson {
   contributes: {
@@ -45,6 +46,10 @@ function loadPackageJson(): PackageJson {
 
 function loadZ80AsmGrammar(): unknown {
   return JSON.parse(fs.readFileSync(Z80_ASM_GRAMMAR_PATH, 'utf8'));
+}
+
+function loadZ80LstGrammar(): unknown {
+  return JSON.parse(fs.readFileSync(Z80_LST_GRAMMAR_PATH, 'utf8'));
 }
 
 function getGrammarPattern(repositoryName: string, scopeName: string): { match: string } {
@@ -86,6 +91,234 @@ function getFirstMatchingGrammarScope(repositoryName: string, source: string): s
     }
   }
   throw new Error(`No grammar pattern in ${repositoryName} matched ${source}`);
+}
+
+function getFirstGrammarCaptureScope(
+  repositoryName: string,
+  source: string,
+  expectedText: string
+): string {
+  const grammar = loadZ80AsmGrammar() as {
+    repository?: Record<
+      string,
+      {
+        patterns?: Array<{
+          captures?: Record<string, { name?: string }>;
+          match?: string;
+          name?: string;
+        }>;
+      }
+    >;
+  };
+  for (const pattern of grammar.repository?.[repositoryName]?.patterns ?? []) {
+    if (pattern.match === undefined) {
+      continue;
+    }
+    const match = toJavaScriptRegex(pattern.match).exec(source);
+    if (match === null) {
+      continue;
+    }
+    for (const [captureIndex, capture] of Object.entries(pattern.captures ?? {})) {
+      if (capture.name === undefined) {
+        continue;
+      }
+      if (match[Number(captureIndex)] === expectedText) {
+        return capture.name;
+      }
+    }
+    if (pattern.name !== undefined && match[0] === expectedText) {
+      return pattern.name;
+    }
+  }
+  throw new Error(`No grammar capture matched ${expectedText} in ${source}`);
+}
+
+function getFirstMatchingListingScope(source: string): string {
+  for (const pattern of getListingSourcePatterns()) {
+    if (pattern.name === undefined || pattern.match === undefined) {
+      continue;
+    }
+    if (toJavaScriptRegex(pattern.match).test(source)) {
+      return pattern.name;
+    }
+  }
+  throw new Error(`No listing grammar pattern matched ${source}`);
+}
+
+function getFirstListingCaptureScope(source: string, expectedText: string): string {
+  const listingSource = extractListingSource(source);
+  const sourceToCheck = (listingSource ?? source).split(';')[0] ?? '';
+  for (const pattern of getListingSourcePatterns()) {
+    if (pattern.match === undefined) {
+      continue;
+    }
+    const match = toJavaScriptRegex(pattern.match).exec(sourceToCheck);
+    if (match === null) {
+      continue;
+    }
+    for (const [captureIndex, capture] of Object.entries(pattern.captures ?? {})) {
+      if (capture.name === undefined) {
+        continue;
+      }
+      if (match[Number(captureIndex)] === expectedText) {
+        return capture.name;
+      }
+    }
+    if (pattern.name !== undefined && match[0] === expectedText) {
+      return pattern.name;
+    }
+  }
+  throw new Error(`No listing grammar capture matched ${expectedText} in ${source}`);
+}
+
+function tryGetFirstListingCaptureScope(source: string, expectedText: string): string | null {
+  try {
+    return getFirstListingCaptureScope(source, expectedText);
+  } catch {
+    return null;
+  }
+}
+
+function tryGetNamedListingCaptureText(source: string, expectedScope: string): string | null {
+  const listingSource = extractListingSource(source);
+  const sourceToCheck = (listingSource ?? source).split(';')[0] ?? '';
+  for (const pattern of getListingSourcePatterns()) {
+    if (pattern.match === undefined) {
+      continue;
+    }
+    const match = toJavaScriptRegex(pattern.match).exec(sourceToCheck);
+    if (match === null) {
+      continue;
+    }
+    for (const [captureIndex, capture] of Object.entries(pattern.captures ?? {})) {
+      if (capture.name === expectedScope && match[Number(captureIndex)] !== undefined) {
+        return match[Number(captureIndex)] ?? null;
+      }
+    }
+  }
+  return null;
+}
+
+function extractListingSource(line: string): string | null {
+  const grammar = loadZ80LstGrammar() as {
+    repository?: Record<string, { begin?: string }>;
+  };
+  const begin = grammar.repository?.['listing-row']?.begin;
+  if (begin === undefined) {
+    throw new Error('Missing listing-row begin pattern');
+  }
+  const match = toJavaScriptRegex(begin).exec(line);
+  if (match === null) {
+    return null;
+  }
+  return line.slice(match[0].length);
+}
+
+function getListingPrefixCaptureScope(line: string, expectedText: string): string {
+  const grammar = loadZ80LstGrammar() as {
+    repository?: Record<
+      string,
+      {
+        begin?: string;
+        beginCaptures?: Record<
+          string,
+          {
+            patterns?: Array<{
+              match?: string;
+              name?: string;
+            }>;
+          }
+        >;
+      }
+    >;
+  };
+  const listingRow = grammar.repository?.['listing-row'];
+  const begin = listingRow?.begin;
+  if (begin === undefined) {
+    throw new Error('Missing listing-row begin pattern');
+  }
+  const rowMatch = toJavaScriptRegex(begin).exec(line);
+  if (rowMatch === null) {
+    throw new Error(`No listing row matched ${line}`);
+  }
+  const prefix = rowMatch[0];
+  for (const capture of Object.values(listingRow.beginCaptures ?? {})) {
+    for (const pattern of capture.patterns ?? []) {
+      if (pattern.name === undefined || pattern.match === undefined) {
+        continue;
+      }
+      const regex = toJavaScriptRegex(pattern.match);
+      const matches = prefix.matchAll(new RegExp(regex.source, `${regex.flags}g`));
+      for (const match of matches) {
+        if (match[0] === expectedText) {
+          return pattern.name;
+        }
+      }
+    }
+  }
+  throw new Error(`No listing prefix capture matched ${expectedText} in ${line}`);
+}
+
+function getListingSourcePatterns(): Array<{
+  captures?: Record<string, { name?: string }>;
+  match?: string;
+  name?: string;
+}> {
+  const grammar = loadZ80LstGrammar() as {
+    repository?: Record<
+      string,
+      {
+        patterns?: Array<{
+          include?: string;
+          captures?: Record<string, { name?: string }>;
+          match?: string;
+          name?: string;
+        }>;
+      }
+    >;
+  };
+  const patterns: Array<{
+    captures?: Record<string, { name?: string }>;
+    match?: string;
+    name?: string;
+  }> = [];
+  for (const entry of grammar.repository?.['listing-row']?.patterns ?? []) {
+    if (entry.include?.startsWith('#') === true) {
+      patterns.push(...(grammar.repository?.[entry.include.slice(1)]?.patterns ?? []));
+    } else {
+      patterns.push(entry);
+    }
+  }
+  return patterns;
+}
+
+function findTokenColorRule(scope: string): {
+  scope?: string | string[];
+  settings?: {
+    foreground?: string;
+  };
+} {
+  const rules =
+    loadPackageJson().contributes.configurationDefaults['editor.tokenColorCustomizations']
+      ?.textMateRules ?? [];
+  const rule = rules.find((candidate) => {
+    if (Array.isArray(candidate.scope)) {
+      return candidate.scope.includes(scope);
+    }
+    return candidate.scope === scope;
+  });
+  if (rule === undefined) {
+    throw new Error(`Could not find token color rule for ${scope}`);
+  }
+  return rule;
+}
+
+function findTokenColor(scope: string): string {
+  const foreground = findTokenColorRule(scope).settings?.foreground;
+  if (foreground === undefined) {
+    throw new Error(`Could not find foreground for ${scope}`);
+  }
+  return foreground;
 }
 
 function toJavaScriptRegex(textMatePattern: string): RegExp {
@@ -161,26 +394,176 @@ describe('package.json language contracts', () => {
   });
 
   it('contributes green token colors for Debug80 assembly comments', () => {
-    const rules =
-      contributes.configurationDefaults['editor.tokenColorCustomizations']?.textMateRules ?? [];
-    const commentRule = rules.find((rule) => {
-      return Array.isArray(rule.scope) && rule.scope.includes('comment.line.semicolon.z80-asm');
-    });
+    const commentRule = findTokenColorRule('comment.line.semicolon.z80-asm');
 
-    expect(commentRule).toBeDefined();
-    expect(commentRule!.scope).toContain('punctuation.definition.comment.z80-asm');
-    expect(commentRule!.scope).toContain('comment.line.semicolon.z80-lst');
-    expect(commentRule!.settings?.foreground).toBe('#6A9955');
+    expect(commentRule.scope).toContain('punctuation.definition.comment.z80-asm');
+    expect(commentRule.scope).toContain('comment.line.semicolon.z80-lst');
+    expect(commentRule.settings?.foreground).toBe('#6A9955');
+  });
+
+  it('contributes a balanced token color palette for Z80 assembly scopes', () => {
+    const labelRule = findTokenColorRule('entity.name.label.z80-asm');
+    const symbolRule = findTokenColorRule('variable.other.symbol.z80-asm');
+    const directiveRule = findTokenColorRule('keyword.control.directive.z80-asm');
+    const annotationRule = findTokenColorRule('storage.type.annotation.z80-asm');
+    const instructionRule = findTokenColorRule('keyword.instruction.z80-asm');
+    const registerRule = findTokenColorRule('variable.language.register.z80-asm');
+    const conditionRule = findTokenColorRule('variable.language.condition.z80-asm');
+    const stringRule = findTokenColorRule('string.quoted.double.z80-asm');
+    const functionRule = findTokenColorRule('entity.name.function.z80-asm');
+    const operatorRule = findTokenColorRule('keyword.operator.z80-asm');
+    const constantRule = findTokenColorRule('constant.numeric.hex.z80-asm');
+
+    expect(labelRule.scope).toContain('entity.name.label.local.z80-asm');
+    expect(labelRule.scope).toContain('entity.name.label.z80-lst');
+    expect(labelRule.settings?.foreground).toBe('#B77DFF');
+    expect(symbolRule.scope).toContain('variable.other.symbol.z80-lst');
+    expect(symbolRule.settings?.foreground).toBe('#FF4D6D');
+    expect(directiveRule.scope).toContain('keyword.control.directive.z80-lst');
+    expect(directiveRule.settings?.foreground).toBe('#FF66C4');
+    expect(annotationRule.scope).toContain('storage.type.comment-header.z80-asm');
+    expect(annotationRule.settings?.foreground).toBe('#00D1A7');
+    expect(instructionRule.scope).toContain('keyword.instruction.z80-lst');
+    expect(instructionRule.settings?.foreground).toBe('#FF9D00');
+    expect(registerRule.scope).toContain('variable.language.register.z80-lst');
+    expect(registerRule.settings?.foreground).toBe('#00C2FF');
+    expect(conditionRule.scope).toContain('variable.language.flag.z80-asm');
+    expect(conditionRule.settings?.foreground).toBe('#3B82F6');
+    expect(stringRule.scope).toContain('string.quoted.single.z80-asm');
+    expect(stringRule.scope).toContain('string.quoted.double.z80-lst');
+    expect(stringRule.settings?.foreground).toBe('#A3E635');
+    expect(functionRule.settings?.foreground).toBe('#FDE047');
+    expect(operatorRule.scope).toContain('punctuation.section.parens.z80-asm');
+    expect(operatorRule.scope).toContain('punctuation.section.parens.z80-lst');
+    expect(operatorRule.settings?.foreground).toBe('#A0AEC0');
+    expect(constantRule.scope).toContain('constant.numeric.binary.z80-asm');
+    expect(constantRule.scope).toContain('constant.numeric.decimal.z80-asm');
+    expect(constantRule.scope).toContain('constant.language.current-location.z80-asm');
+    expect(constantRule.scope).toContain('constant.numeric.address.z80-lst');
+    expect(constantRule.scope).toContain('constant.numeric.hex.z80-lst');
+    expect(constantRule.scope).toContain('constant.numeric.binary.z80-lst');
+    expect(constantRule.scope).toContain('constant.numeric.decimal.z80-lst');
+    expect(constantRule.scope).toContain('constant.language.current-location.z80-lst');
+    expect(constantRule.scope).toContain('constant.numeric.hexbyte.z80-lst');
+    expect(constantRule.settings?.foreground).toBe('#FFD166');
+  });
+
+  it('keeps primary token families on unique foreground colors', () => {
+    const primaryScopes = [
+      'comment.line.semicolon.z80-asm',
+      'entity.name.label.z80-asm',
+      'variable.other.symbol.z80-asm',
+      'keyword.control.directive.z80-asm',
+      'storage.type.annotation.z80-asm',
+      'keyword.instruction.z80-asm',
+      'variable.language.register.z80-asm',
+      'variable.language.condition.z80-asm',
+      'constant.numeric.hex.z80-asm',
+    ];
+    const colors = primaryScopes.map(findTokenColor);
+    expect(new Set(colors).size).toBe(colors.length);
+  });
+
+  it('Z80 listing grammar classifies non-byte directives distinctly from opcodes', () => {
+    expect(getFirstListingCaptureScope('C7DE   C0 08                  DW   DATA_FROM', 'DW')).toBe(
+      'keyword.control.directive.z80-lst'
+    );
+    expect(
+      getFirstListingCaptureScope('FFEC                          .ORG   BASE_ADDR', '.ORG')
+    ).toBe('keyword.control.directive.z80-lst');
+    expect(getFirstListingCaptureScope('10000                         .END', '.END')).toBe(
+      'keyword.control.directive.z80-lst'
+    );
+    expect(getFirstMatchingListingScope('SET')).toBe('keyword.instruction.z80-lst');
+  });
+
+  it('Z80 listing grammar keeps branch conditions and register operands distinct', () => {
+    expect(getFirstListingCaptureScope('1000   38 01        JR   C,DONE', 'C')).toBe(
+      'variable.language.condition.z80-lst'
+    );
+    expect(getFirstMatchingListingScope('C')).toBe('variable.language.register.z80-lst');
+    expect(getFirstMatchingListingScope('af')).toBe('variable.language.register.z80-lst');
+    expect(getFirstMatchingListingScope('bc')).toBe('variable.language.register.z80-lst');
+  });
+
+  it('Z80 listing grammar gives punctuation neutral operator scopes', () => {
+    expect(getFirstMatchingListingScope(',')).toBe('punctuation.separator.comma.z80-lst');
+    expect(getFirstMatchingListingScope('(')).toBe('punctuation.section.parens.z80-lst');
+    expect(getFirstMatchingListingScope(')')).toBe('punctuation.section.parens.z80-lst');
+  });
+
+  it('Z80 listing grammar keeps object-code byte columns as constants', () => {
+    expect(
+      tryGetNamedListingCaptureText(
+        '0001   DB 02        IN   A,(TERM_STATUS)',
+        'keyword.control.directive.z80-lst'
+      )
+    ).toBe(null);
+    expect(extractListingSource('0001   DB 02        IN   A,(TERM_STATUS)')).toContain(
+      'IN   A,(TERM_STATUS)'
+    );
+    expect(extractListingSource('C7B4   DM                     DM   2')).toBe('DM   2');
+    expect(extractListingSource('C7B4   DS                     DS   2')).toBe('DS   2');
+    expect(extractListingSource('C7B4   DW                     DW   DATA')).toBe('DW   DATA');
+    expect(extractListingSource('0000   DB')).toBe('');
+    expect(
+      extractListingSource('FF48   A7 C7 C6 4B C6 C3 SEGDISP:   DB   0A7H,0C7H,0C6H,4BH,0C6H,0C3H')
+    ).toContain('SEGDISP:   DB');
+    expect(
+      extractListingSource(
+        'FF87   48 3A 4D 3A 53 20 50 4D 3A 30 2D 33 2C 20 50 52 41 4D 3A 38 00 HELPLIST:   DB   "H:M:S PM:0-3, PRAM:8",0'
+      )
+    ).toContain('HELPLIST:   DB');
+    expect(extractListingSource('FF48                RTC_PORT:   EQU   0FCH')).toBe(
+      'RTC_PORT:   EQU   0FCH'
+    );
+    expect(extractListingSource('10000               REL_TXT:   EQU   "2025.16"')).toBe(
+      'REL_TXT:   EQU   "2025.16"'
+    );
+    expect(extractListingSource('FF55   54 75 65 73 64 61 79 00 DB   "Tuesday",0')).toBe(
+      'DB   "Tuesday",0'
+    );
+    expect(getListingPrefixCaptureScope('C7B4   DM                     DM   2', 'DM')).toBe(
+      'constant.numeric.hexbyte.z80-lst'
+    );
+    expect(getFirstListingCaptureScope('C7B4   02                     DB   2', 'DB')).toBe(
+      'keyword.control.directive.z80-lst'
+    );
+    expect(getFirstListingCaptureScope('C7B4                          DB   2', 'DB')).toBe(
+      'keyword.control.directive.z80-lst'
+    );
+    expect(getFirstListingCaptureScope('C7B4                          DB', 'DB')).toBe(
+      'keyword.control.directive.z80-lst'
+    );
+    expect(getFirstListingCaptureScope('C7B4                          DW', 'DW')).toBe(
+      'keyword.control.directive.z80-lst'
+    );
+    expect(
+      getFirstListingCaptureScope(
+        'F011   53 74 61 72 74 20 41 64 64 72 65 73 73 3A 00 DB   "Start Address:",0',
+        'DB'
+      )
+    ).toBe('keyword.control.directive.z80-lst');
+  });
+
+  it('Z80 listing grammar classifies source operands as numeric constants', () => {
+    expect(getFirstMatchingListingScope('$0000')).toBe('constant.numeric.hex.z80-lst');
+    expect(getFirstMatchingListingScope('4000H')).toBe('constant.numeric.hex.z80-lst');
+    expect(getFirstMatchingListingScope('%1010')).toBe('constant.numeric.binary.z80-lst');
+    expect(getFirstMatchingListingScope('123')).toBe('constant.numeric.decimal.z80-lst');
   });
 
   it('Z80 assembly grammar includes AZM-derived punctuation and condition scopes', () => {
     const serializedGrammar = JSON.stringify(loadZ80AsmGrammar());
+    const serializedListingGrammar = JSON.stringify(loadZ80LstGrammar());
     expect(serializedGrammar).toContain('#condition-instructions');
     expect(serializedGrammar).toContain('constant.language.current-location.z80-asm');
     expect(serializedGrammar).toContain('punctuation.section.parens.z80-asm');
     expect(serializedGrammar).toContain('punctuation.separator.comma.z80-asm');
     expect(serializedGrammar).toContain('SLI');
     expect(serializedGrammar).toContain('\\\\.[A-Za-z_.$?@]');
+    expect(serializedListingGrammar).toContain('keyword.control.directive.z80-lst');
+    expect(serializedListingGrammar).toContain('SLI');
   });
 
   it('Z80 assembly grammar condition instruction regex captures mnemonic and condition', () => {
@@ -209,6 +592,59 @@ describe('package.json language contracts', () => {
     expect(getFirstMatchingGrammarScope('labels', '.loop:')).toBe(
       'entity.name.label.local.z80-asm'
     );
+  });
+
+  it('Z80 assembly grammar classifies symbol references separately from constants', () => {
+    expect(getFirstMatchingGrammarScope('symbols', 'PACMO_SPLASH_ACTIVE')).toBe(
+      'variable.other.symbol.z80-asm'
+    );
+  });
+
+  it('Z80 assembly examples keep definitions, references, and registers separate', () => {
+    expect(getFirstMatchingGrammarScope('labels', 'POLL_INPUT_AND_UPDATE:')).toBe(
+      'entity.name.label.z80-asm'
+    );
+    expect(getFirstMatchingGrammarScope('instructions', 'LD')).toBe('keyword.instruction.z80-asm');
+    expect(getFirstMatchingGrammarScope('symbols', 'PACMO_SPLASH_ACTIVE')).toBe(
+      'variable.other.symbol.z80-asm'
+    );
+    expect(getFirstMatchingGrammarScope('symbols', 'PACMO_PAUSED')).toBe(
+      'variable.other.symbol.z80-asm'
+    );
+    expect(getFirstMatchingGrammarScope('registers', 'A')).toBe(
+      'variable.language.register.z80-asm'
+    );
+  });
+
+  it('Z80 assembly comment header annotations use annotation scopes', () => {
+    expect(getFirstGrammarCaptureScope('routine-comments', '@clobbers AF, BC', '@clobbers')).toBe(
+      'storage.type.annotation.z80-asm'
+    );
+  });
+
+  it('Z80 listing grammar classifies symbol references separately from constants', () => {
+    expect(getFirstListingCaptureScope('0003   C3 00 00     JP START', 'START')).toBe(
+      'variable.other.symbol.z80-lst'
+    );
+    expect(
+      getFirstListingCaptureScope('0001   DB 02        IN   A,(TERM_STATUS)', 'TERM_STATUS')
+    ).toBe('variable.other.symbol.z80-lst');
+    expect(getFirstMatchingListingScope('A')).toBe('variable.language.register.z80-lst');
+  });
+
+  it('Z80 listing grammar does not color comment or footer prose as operands', () => {
+    expect(
+      tryGetFirstListingCaptureScope('0001   00           ; CALL SOMEWHERE', 'SOMEWHERE')
+    ).toBe(null);
+    expect(
+      tryGetFirstListingCaptureScope(
+        'Footer generated from source path /tmp/LD A,(TERM_STATUS)',
+        'TERM_STATUS'
+      )
+    ).toBe(null);
+    expect(
+      tryGetFirstListingCaptureScope('START: 0000 DEFINED AT LINE 1 IN PACMO.ASM', 'PACMO.ASM')
+    ).toBe(null);
   });
 
   it('ZAX_LANGUAGE_ID is a contributed language', () => {


### PR DESCRIPTION
## Summary
- Add narrow Debug80 token color defaults for Z80 assembly labels and listing labels.
- Add a separate warm constant color for numeric/current-location scopes in assembly and listing files.
- Extend language contract coverage for the label and constant token color rules.

## Test Plan
- `./node_modules/.bin/vitest run -c vitest.webview.config.ts tests/webview/language-contracts.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint tests/webview/language-contracts.test.ts --ext .ts --max-warnings=0`
- `./node_modules/.bin/prettier --check package.json tests/webview/language-contracts.test.ts`
- `git diff --check HEAD~1 HEAD`