### PR TITLE
Document hardware serial link design

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Platform-focused repos ship their own `.vscode` configs; use those for full demo
 ## Project config (recommended)
 
 Add `.vscode/debug80.json` so F5 doesn’t depend on the active editor (`debug80.json` at the repo root also works). Example:
+
 ```json
 {
   "defaultTarget": "app",
@@ -122,7 +123,9 @@ Add `.vscode/debug80.json` so F5 doesn’t depend on the active editor (`debug80
   }
 }
 ```
+
 Fields per target:
+
 - `sourceFile`: root asm file to assemble
 - `outputDir`: where artifacts go
 - `artifactBase`: basename for artifacts
@@ -138,7 +141,15 @@ Fields per target:
 - `terminal`: optional terminal port map for the `simple` platform
 - You can define multiple targets (e.g., `app`, `unit`, `integration`) and set `defaultTarget`.
 
+Platform ROM fields such as `tec1.romHex`, `tec1.extraListings`,
+`tec1g.romHex`, and `tec1g.extraListings` may point at stable
+workspace-relative override paths. Scaffolded TEC-1 and TEC-1G projects use
+those paths for configuration, but Debug80 resolves the bundled extension copy
+when the workspace file is absent. Put files under `roms/` only when you want a
+local override or an inspection copy.
+
 Launch config (`.vscode/launch.json`) option:
+
 - `openRomSourcesOnLaunch`: opens ROM listing/source files automatically when a session starts (default true).
 - `openMainSourceOnLaunch`: opens the primary source file automatically when a session starts.
 - `sourceColumn`: editor column (1-9) for source files opened on launch (default 1).
@@ -148,10 +159,11 @@ Launch config (`.vscode/launch.json`) option:
 
 To make a folder debuggable quickly in VS Code:
 
-1) Press `Cmd-Shift-P` (macOS) or `Ctrl-Shift-P` (Windows/Linux) to open the Command Palette.
-2) Type “Debug80: Create Project (config + launch)” and press Enter.
+1. Press `Cmd-Shift-P` (macOS) or `Ctrl-Shift-P` (Windows/Linux) to open the Command Palette.
+2. Type “Debug80: Create Project (config + launch)” and press Enter.
 
 This command scaffolds a built-in profile kit:
+
 - Creates `debug80.json` (or you may place it at `.vscode/debug80.json`) with a default target (tries `src/main.asm`, or the first `.asm` it finds).
 - Creates `.vscode/launch.json` with a Debug80 launch configuration when you choose a launch-enabled scaffold.
 - Merges a small **Debug80** block into `.gitignore` if missing: `.debug80/` cache, the default `outputDir`, `.vscode/launch.json` (local-only; the extension also contributes a default launch), and common OS junk. It does not ignore the whole `.vscode/` folder, because project config can live at `.vscode/debug80.json`.
@@ -160,30 +172,33 @@ This command scaffolds a built-in profile kit:
 
 After scaffolding, adjust the `sourceFile`, `outputDir`, and `artifactBase` as needed, then press F5.
 
-To target a different platform (e.g., `tec1`):
-- Set `platform: "tec1"` in `.vscode/debug80.json`.
-- Copy relevant fields from the dedicated `debug80-tec1` repo’s `.vscode/debug80.json` (e.g., memory regions, ROM, `ramInitHex`).
-- Update `sourceFile` to your program and build outputs.
+For TEC-1 and TEC-1G kits, the generated config records bundled ROM/listing
+references. Day-to-day debugging does not require copying stock monitor ROMs
+into the workspace. Use **Debug80: Copy Bundled Assets into Workspace** only
+when you want local files to inspect or replace.
 
 ## Z80 workflow
 
-1) Run “Debug80: Create Project (config + launch)” to scaffold `debug80.json` (defaults to `targets.app` with `src/main.asm`) and, if requested, `.vscode/launch.json`. The profile picker lets you choose the built-in kit before scaffolding.
-2) Start debugging with the generated debug80 launch; the adapter reads `debug80.json` (or `.vscode/debug80.json` if you use that layout), runs `asm80` automatically using the target’s `sourceFile`/`asm`, and writes HEX/LST into `outputDir` (install `asm80` locally first). Set `assemble: false` to use pre-built artifacts instead.
-3) Set breakpoints in `.asm` files (preferred). Listing breakpoints in `.lst` still work as a fallback.
-4) Start debugging (F5). `stopOnEntry` halts on entry; Step/Continue as usual. Registers show in the Variables view.
+1. Run “Debug80: Create Project (config + launch)” to scaffold `debug80.json` (defaults to `targets.app` with `src/main.asm`) and, if requested, `.vscode/launch.json`. The profile picker lets you choose the built-in kit before scaffolding.
+2. Start debugging with the generated debug80 launch; the adapter reads `debug80.json` (or `.vscode/debug80.json` if you use that layout), runs `asm80` automatically using the target’s `sourceFile`/`asm`, and writes HEX/LST into `outputDir` (install `asm80` locally first). Set `assemble: false` to use pre-built artifacts instead.
+3. Set breakpoints in `.asm` files (preferred). Listing breakpoints in `.lst` still work as a fallback.
+4. Start debugging (F5). `stopOnEntry` halts on entry; Step/Continue as usual. Registers show in the Variables view.
 
 Notes:
+
 - HALT stops execution; Continue again to terminate.
 - Listing/HEX are required; ensure asm80 completes successfully or provide existing artifacts.
+- ROM source/listing files can be opened with **Debug80: Open ROM Listing/Source** during a debug session.
 - Step Over/Step Out can run for a long time in tight loops; use Pause to interrupt if needed.
 
 ## External projects (e.g., caverns80)
 
 For external repos:
-1) Open the external project as your workspace (e.g., `caverns80`).
-2) Run “Debug80: Create Project (config + launch)” to scaffold `.vscode`.
-3) Update the selected profile kit and `sourceFile` to match the project and platform (Simple/TEC-1).
-4) Press F5.
+
+1. Open the external project as your workspace (e.g., `caverns80`).
+2. Run “Debug80: Create Project (config + launch)” to scaffold `.vscode`.
+3. Update the selected profile kit and `sourceFile` to match the project and platform (Simple/TEC-1).
+4. Press F5.
 
 This keeps example configs inside Debug80 while letting external projects own their debug setup.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ These are still useful for product and implementation decisions:
 - [Project workflow](design-project-workflow.md)
 - [Platform UI runtime behavior](design-platform-ui-runtime-behaviors.md)
 - [Production readiness](design-production-readiness.md)
+- [Hardware serial link](design-hardware-serial-link.md)
 
 ## Platform Notes
 

--- a/docs/design-hardware-serial-link.md
+++ b/docs/design-hardware-serial-link.md
@@ -1,0 +1,424 @@
+# Design: Hardware Serial Link
+
+**Status:** Draft
+**Type:** Additive hardware workflow
+**Scope:** Send built artifacts from VS Code to real TEC-1/TEC-1G hardware over a host serial port
+
+---
+
+## Summary
+
+Debug80 should support a real hardware serial link that runs in the VS Code extension host and
+talks to physical serial ports on the computer. This is separate from the current emulated serial
+terminal, which injects bytes into the running Z80 emulator.
+
+The first useful workflow is sending the active target's Intel HEX file to a real board, using
+project-configured serial settings such as `4800, 8, none, 2`.
+
+---
+
+## Goals
+
+- Let a user send the active target's built HEX file to real hardware from the Debug80 UI.
+- Support serial settings needed by TEC monitor workflows:
+  - baud rate, default `4800`
+  - data bits, default `8`
+  - parity, default `none`
+  - stop bits, default `2`
+  - optional inter-character and inter-line pacing
+- Infer the file to send from the active project/target whenever possible.
+- Keep serial configuration in `debug80.json`, with target overrides and sensible defaults.
+- Keep the real-hardware path visibly distinct from emulator serial.
+- Provide progress, cancellation, clear error messages, and enough logging to diagnose dropped
+  transfers.
+
+---
+
+## Non-Goals
+
+- Do not make the debug adapter own the host serial port.
+- Do not replace the emulated serial terminal.
+- Do not require a debug session just to send a HEX file to hardware.
+- Do not implement binary upload/download or memory dump workflows in the first milestone.
+- Do not assume every `.hex` transfer protocol is identical. Start with plain Intel HEX text
+  pacing, then add monitor-specific handshakes if needed.
+
+---
+
+## Existing Debug80 Context
+
+Debug80 already has:
+
+- emulator serial UI in the TEC-1 and TEC-1G platform panels
+- `Debug80: Open ROM Listing/Source`
+- target-aware project selection and active target persistence
+- target config fields for `sourceFile`, `outputDir`, `artifactBase`, `hex`, and assembler backend
+- existing send-file logic for emulator serial in `src/extension/platform-view-serial-actions.ts`
+
+The new hardware link should reuse project/target resolution, progress UI, and file inference ideas,
+but it should not reuse DAP custom requests. Real serial I/O belongs in the extension host.
+
+---
+
+## PlatformIO Findings
+
+PlatformIO is a useful reference because it solves a similar class of problem: a VS Code extension
+coordinates project state, UI commands, build/upload tasks, and serial access across Windows, macOS,
+and Linux.
+
+The main lessons for Debug80 are architectural:
+
+- **Separate VS Code UI from hardware/tooling complexity.** PlatformIO IDE for VS Code is a front
+  end over PlatformIO Core rather than one monolithic extension implementation. Its documentation
+  describes PlatformIO Core as the built-in CLI/tooling layer used by the extension.
+- **Make serial configuration project-owned.** PlatformIO's `platformio.ini` supports monitor
+  settings such as `monitor_port`, `monitor_speed`, `monitor_parity`, `monitor_eol`,
+  `monitor_rts`, and `monitor_dtr`. Debug80 should mirror that idea in `debug80.json` instead of
+  hiding important serial behavior in extension-global state.
+- **Use explicit commands for common embedded workflows.** PlatformIO exposes build, upload, upload
+  and monitor, and serial monitor actions from toolbar/command surfaces. Debug80's equivalent should
+  be target-aware actions such as **Send HEX to Hardware** and **Open Hardware Serial Monitor**.
+- **Serial ports are exclusive resources.** PlatformIO includes settings such as automatically
+  closing the serial monitor before upload. Debug80 should avoid opening the same port from multiple
+  places and should close or reuse the port deliberately before transfers.
+- **A CLI/provider boundary can reduce VSIX native-module risk.** Rather than putting all serial
+  implementation details directly in the main Debug80 extension, a small Debug80-controlled provider
+  or helper can own native serial access. That follows the same broad pattern as PlatformIO without
+  depending on PlatformIO itself.
+
+References:
+
+- PlatformIO IDE for VS Code: <https://docs.platformio.org/en/latest/integration/ide/vscode.html>
+- PlatformIO serial monitor options:
+  <https://docs.platformio.org/en/latest/projectconf/sections/env/options/monitor/index.html>
+- `pio device monitor` CLI:
+  <https://docs.platformio.org/en/latest/core/userguide/device/cmd_monitor.html>
+- `pio device list` CLI:
+  <https://docs.platformio.org/en/latest/core/userguide/device/cmd_list.html>
+
+Debug80 should study PlatformIO's source for command/task organization and packaging decisions, but
+should not depend on PlatformIO as the serial backend. PlatformIO is a broad embedded ecosystem built
+around `platformio.ini`, boards, environments, upload protocols, and PlatformIO Core. Debug80 needs a
+small Z80-focused transfer path for known build artifacts and monitor workflows.
+
+---
+
+## Transport Dependency
+
+Node does not provide serial ports in its standard library. The likely dependency is the `serialport`
+npm package:
+
+- `SerialPort.list()` discovers ports.
+- `new SerialPort({ path, baudRate, dataBits, parity, stopBits })` opens a port.
+- It supports Node/Electron environments through native bindings.
+
+Risks to verify before shipping:
+
+- VSIX includes the native serialport runtime files.
+- macOS, Windows, and Linux install paths work from a clean extension install.
+- Remote VS Code workspaces behave correctly or fail clearly.
+- Packaging does not require build tools for normal users.
+
+---
+
+## Provider Strategy
+
+The preferred design is a provider boundary:
+
+```ts
+export interface HardwareSerialProvider {
+  listPorts(): Promise<HardwareSerialPortInfo[]>;
+  sendHex(request: HardwareSerialSendHexRequest): Promise<HardwareSerialTransferResult>;
+  openMonitor?(config: HardwareSerialConfig): Promise<void>;
+}
+```
+
+Debug80 core should own:
+
+- active project and target resolution
+- build artifact inference
+- UI commands and panel messages
+- config editing and validation
+- user-facing progress/error handling
+
+The provider should own:
+
+- serial port discovery
+- open/write/read/close lifecycle
+- native dependencies or helper process details
+- OS-specific serial errors and permission diagnostics
+
+Provider implementation options:
+
+1. **Internal provider using `serialport`.** Simple to call, but puts native dependency and
+   packaging risk inside the main Debug80 VSIX.
+2. **Debug80 hardware-serial companion extension.** Keeps the main extension free of native serial
+   dependencies and allows hardware users to opt in. The companion can prefer the local UI extension
+   host if remote workspace behavior becomes important.
+3. **Debug80 CLI/helper process.** Similar to PlatformIO Core at a much smaller scale. This can be
+   implemented with Node + `serialport`, Python + `pyserial`, or another proven serial stack, while
+   Debug80 talks to it through process execution or a small JSON protocol.
+
+The current recommendation is to design Debug80 core around the provider interface first. The first
+implementation can be an internal provider or a companion extension, but the call site should not
+care which one is active.
+
+---
+
+## Extension Host And Remote Workspaces
+
+This feature talks to the serial ports visible to the VS Code extension host process.
+
+For normal local VS Code windows, that is the user's machine, which is what we want. For Remote SSH,
+WSL, dev containers, or Codespaces, the extension host may run on another machine or inside a
+container. In that case `/dev/ttyUSB0` or `COM3` may refer to the remote/container environment, not
+the user's desktop USB adapter.
+
+The first implementation should:
+
+- detect and report available ports from the actual extension host
+- document that hardware serial requires the extension host to have access to the device
+- avoid silently implying that local desktop hardware is available in remote workspaces
+
+Future work could explore a UI-extension companion if local desktop serial support is needed while
+the workspace extension host runs remotely.
+
+---
+
+## Project Configuration
+
+Add an optional `hardwareSerial` block. It should be allowed at the root, inside a profile, and
+inside a target. Precedence should follow Debug80's project model:
+
+```text
+defaults < root hardwareSerial < profiles.<profile>.hardwareSerial < targets.<target>.hardwareSerial
+```
+
+The active target's `profile` field chooses the profile layer. Machine-specific fields such as
+`port` may be better stored in VS Code workspace state later, but if they are present in
+`debug80.json` they should use the same precedence.
+
+```json
+{
+  "hardwareSerial": {
+    "baudRate": 4800,
+    "dataBits": 8,
+    "parity": "none",
+    "stopBits": 2,
+    "lineEnding": "cr",
+    "charDelayMs": 2,
+    "lineDelayMs": 20
+  },
+  "targets": {
+    "app": {
+      "sourceFile": "src/main.asm",
+      "outputDir": "build",
+      "artifactBase": "main",
+      "hardwareSerial": {
+        "port": "/dev/tty.usbserial-0001"
+      }
+    }
+  }
+}
+```
+
+Windows example:
+
+```json
+{
+  "targets": {
+    "app": {
+      "hardwareSerial": {
+        "port": "COM3"
+      }
+    }
+  }
+}
+```
+
+Recommended config fields:
+
+| Field           | Type                               | Default | Notes                               |
+| --------------- | ---------------------------------- | ------- | ----------------------------------- |
+| `port`          | string                             | none    | Required to send without prompting. |
+| `baudRate`      | number                             | `4800`  | TEC-1G monitor contract.            |
+| `dataBits`      | `5`/`6`/`7`/`8`                    | `8`     | SerialPort-compatible.              |
+| `parity`        | `none`/`even`/`odd`/`mark`/`space` | `none`  | Display as `N` in compact labels.   |
+| `stopBits`      | `1`/`1.5`/`2`                      | `2`     | TEC-1G monitor contract.            |
+| `flowControl`   | `none`/`rtscts`                    | `none`  | Start without flow control.         |
+| `lineEnding`    | `none`/`cr`/`lf`/`crlf`            | `cr`    | Intel HEX monitors usually want CR. |
+| `charDelayMs`   | number                             | `2`     | Conservative initial pacing.        |
+| `lineDelayMs`   | number                             | `20`    | Conservative initial pacing.        |
+| `openTimeoutMs` | number                             | `3000`  | User-facing timeout.                |
+
+Compact UI label example:
+
+```text
+COM3 - 4800 8N2
+```
+
+---
+
+## File Selection And Build Artifact Inference
+
+For a selected project and target, the default file should be obvious:
+
+1. If `target.hex` is configured, send that path.
+2. Otherwise if root `hex` is configured, send that path.
+3. Otherwise resolve `outputDir` and `artifactBase` for the active target and use:
+
+```text
+<outputDir>/<artifactBase>.hex
+```
+
+4. If the HEX file does not exist, offer to build first where the target is buildable.
+5. If the file still cannot be inferred, open a file picker filtered to `.hex`.
+
+This matches the user's mental model: "send the current target's build output to the board."
+
+---
+
+## UI Integration
+
+The Debug80 sidebar should expose this as a real-hardware workflow, not as emulator serial.
+
+Suggested controls:
+
+- **Port** selector: current port label, click to choose from detected ports.
+- **Serial settings** button: edit baud/data/parity/stop/pacing.
+- **Send HEX to Hardware** button: sends the inferred active target HEX.
+- Optional output/status area: transfer log and received serial text.
+
+Avoid naming collisions:
+
+- Existing `SEND FILE` in the serial terminal means "send to emulator".
+- New hardware action should say `SEND HEX TO HARDWARE` or `SEND TO BOARD`.
+
+The hardware controls should be shown only when a Debug80 project/target is selected. They do not
+need an active debug session.
+
+---
+
+## Command Surface
+
+Add extension commands:
+
+- `debug80.selectHardwareSerialPort`
+- `debug80.configureHardwareSerial`
+- `debug80.sendHexToHardware`
+- `debug80.openHardwareSerialMonitor` later, if receive/display becomes first-class
+
+The webview should send messages such as:
+
+```ts
+{ type: 'hardwareSerialSelectPort' }
+{ type: 'hardwareSerialConfigure' }
+{ type: 'hardwareSerialSendHex', rootPath?: string, targetName?: string }
+```
+
+The extension host should own all serial-port state and file access.
+
+---
+
+## Transfer Flow
+
+Initial send flow:
+
+1. Resolve active project and target.
+2. Resolve hardware serial config with this precedence:
+   `defaults < root < active profile < active target`.
+3. If port is missing, prompt with `SerialPort.list()`.
+4. Resolve the HEX path.
+5. If the HEX does not exist, offer build or file picker.
+6. Open the serial port.
+7. Send Intel HEX text line by line:
+   - normalize source line endings
+   - append configured line ending
+   - apply `charDelayMs` and `lineDelayMs`
+   - report progress by line count and byte count
+8. Close the port unless a monitor session is explicitly open.
+9. Report success, cancellation, or the first serial error.
+
+Potential later refinement:
+
+- monitor prompt detection
+- ACK/NAK handling if a ROM monitor exposes it
+- automatic reset/control-line sequencing through DTR/RTS if the board supports it
+
+---
+
+## Module Sketch
+
+```text
+src/extension/hardware-serial/
+  config.ts              # config shape, defaults, merge, validation
+  artifact.ts            # active target HEX inference
+  port-service.ts        # serialport wrapper and lazy import
+  send-hex.ts            # transfer workflow, pacing, progress
+  commands.ts            # command registration
+```
+
+Tests:
+
+```text
+tests/extension/hardware-serial-config.test.ts
+tests/extension/hardware-serial-artifact.test.ts
+tests/extension/hardware-serial-send.test.ts
+```
+
+The serial transport should be injected behind a small interface in tests so unit tests do not
+require real serial hardware.
+
+---
+
+## Suggested Milestones
+
+### Milestone 1: Design And Config
+
+- Add `hardwareSerial` config schema.
+- Add config merge/default helpers.
+- Add artifact inference helper for `<outputDir>/<artifactBase>.hex`.
+- Add the provider interface, with a stub provider that reports "not installed" or "not available."
+- Add docs and tests for config/artifact resolution.
+
+### Milestone 2: Provider Spike
+
+- Decide whether the first provider lives inside Debug80, in a companion extension, or behind a
+  helper CLI.
+- If using `serialport`, add it only to the provider package/surface chosen above.
+- Implement port listing and open/write/close behind the provider boundary.
+- Verify packaging on macOS, Windows, and Linux.
+- Ensure errors are clear when no serial binding is available.
+
+### Milestone 3: Send HEX From Commands
+
+- Add `Debug80: Select Hardware Serial Port`.
+- Add `Debug80: Configure Hardware Serial`.
+- Add `Debug80: Send HEX to Hardware`.
+- Send with progress, cancellation, pacing, and clear error handling.
+
+### Milestone 4: Debug80 UI Integration
+
+- Add panel messages and controls.
+- Show active port/settings and inferred HEX path.
+- Trigger send from the current project/target.
+
+### Milestone 5: Receive/Monitor And Protocol Polish
+
+- Add optional receive monitor.
+- Add transcript save.
+- Add monitor-specific handshakes if required.
+- Add DTR/RTS reset sequencing if useful for supported boards.
+
+---
+
+## Open Questions
+
+- Should hardware serial config live only in `debug80.json`, or should the selected port be stored
+  in VS Code workspace state to avoid committing machine-specific `COM3`/`/dev/tty.*` values?
+- Should the send workflow build automatically, prompt to build, or only send existing artifacts?
+- Does the TEC-1G monitor need a specific start command before HEX transfer, or is raw Intel HEX
+  input enough once the monitor is in receive mode?
+- What pacing is reliable on the slowest supported monitor? The current emulator send-file path uses
+  short character and line delays, but real hardware should be validated separately.
+- How should remote workspaces be handled in user-facing UI?

--- a/docs/plans/platform-rom-bundles.md
+++ b/docs/plans/platform-rom-bundles.md
@@ -1,8 +1,13 @@
-# Plan: Platform ROM bundles, profile resolution, and overrides
+# Platform ROM bundles, profile resolution, and overrides
 
-This document captures the agreed product direction: the extension is the default vendor of ROM,
-listing, and read-only source assets; project workspaces reference those assets by profile and
-only materialize local copies when the user explicitly asks for them.
+This document captures the current bundled-ROM model. The extension is the
+default vendor of ROM, listing, and read-only source assets; project workspaces
+reference those assets by profile and only materialize local copies when the
+user explicitly asks for them.
+
+**Current status:** the single-profile bundled ROM flow is implemented for
+TEC-1 MON-1B and TEC-1G MON3. Treat the original ticket list below as historical
+design context unless a future task explicitly reopens multi-ROM schema work.
 
 ## Goals
 
@@ -16,12 +21,12 @@ only materialize local copies when the user explicitly asks for them.
 
 ## Design principles
 
-| Principle | Implication |
-|-----------|-------------|
-| **Extension = distribution** | Versioned payloads + manifest (checksums, profile id, compatible Debug80 version range). |
-| **Project = source** | `debug80.json` and user source files are committed; stock ROM assets are not copied by default. |
-| **Config is the contract** | Override = edit JSON and/or explicitly materialize/replace files under those paths. |
-| **No mandatory wizard** | Wizard only accelerates layout; same behavior if user hand-authors config. |
+| Principle                    | Implication                                                                                     |
+| ---------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Extension = distribution** | Versioned payloads + manifest (checksums, profile id, compatible Debug80 version range).        |
+| **Project = source**         | `debug80.json` and user source files are committed; stock ROM assets are not copied by default. |
+| **Config is the contract**   | Override = edit JSON and/or explicitly materialize/replace files under those paths.             |
+| **No mandatory wizard**      | Wizard only accelerates layout; same behavior if user hand-authors config.                      |
 
 ## Workspace layout policy
 
@@ -41,7 +46,24 @@ New scaffolded projects should be small:
 or for deliberate user overrides. If a user is authoring a monitor ROM, that should be a separate
 advanced project profile and the user can remove the ignore rule intentionally.
 
-## Phases (high level)
+## Current behavior
+
+- Bundled assets live under `resources/bundles/<platform>/<profile>/<version>/`
+  with a `bundle.json` manifest and checksum metadata.
+- Scaffolded projects record stable workspace-relative ROM/listing/source paths
+  in `debug80.json`, plus `profiles.<name>.bundledAssets` references that map
+  those paths to the extension bundle.
+- Launch smart-resolves configured ROM/listing paths: if the workspace file
+  exists, it wins; if it is absent and a bundled asset reference exists, Debug80
+  uses the extension copy.
+- `roms/` is ignored by default because it is for explicit local copies or user
+  overrides, not required project source.
+- **Debug80: Open ROM Listing/Source** opens ROM listing/source files available
+  to the active session.
+- **Debug80: Copy Bundled Assets into Workspace** materializes bundled assets
+  only when the user asks for local inspection or replacement files.
+
+## Original phases (historical)
 
 ```mermaid
 flowchart LR
@@ -54,7 +76,7 @@ flowchart LR
 - **P0**: Manifest format, extension resource layout, read-only access from extension code.
 - **P1**: Resolve MON3/MON-1B bundle references at launch without copying into scaffolded workspaces.
 - **P2**: Override UX, upgrade/repair command, documentation for manual projects.
-- **P3**: Generalize program loader + `debug80.json` schema for **N** ROM regions on TEC-1G (backward compatible).
+- **P3**: Generalize program loader + `debug80.json` schema for **N** ROM regions on TEC-1G (backward compatible). This is not currently required for the shipped MON-1B/MON3 flow.
 - **P4**: Additional bundled profiles, CI for bundle checksums, size budgets.
 
 ---
@@ -128,7 +150,7 @@ Tickets are ordered by **recommended implementation sequence**. Dependencies are
 
 #### TICKET-05 — Wire default `debug80.json` for TEC-1G to materialized paths
 
-**Summary**: Project scaffolding templates (`project-scaffolding.ts` / templates) should set `tec1g.romHex`, `tec1g.extraListings`, `tec1g.sourceRoots` (as needed) to **workspace-relative** paths after TICKET-04.
+**Summary**: Project scaffolding templates (`project-scaffolding.ts` / templates) should set `tec1g.romHex`, `tec1g.extraListings`, and root/target `sourceRoots` (as needed) to **workspace-relative** paths after TICKET-04.
 
 **Acceptance criteria**
 
@@ -271,13 +293,13 @@ Tickets are ordered by **recommended implementation sequence**. Dependencies are
 
 ## Recommended sequencing (milestones)
 
-| Milestone | Tickets | Outcome |
-|-----------|---------|---------|
-| **M1** | 01–03 | Can ship bytes in VSIX and read them reliably. |
-| **M2** | 04–06 | New TEC-1G project references bundled MON3 and debugs ROM listing/source without project-local copies. |
-| **M3** | 07–09 | Overrides and refresh story documented / optional. |
-| **M4** | 10–12 | Multi-ROM TEC-1G config + tests. |
-| **M5** | 13–14 | Repeatable process + size strategy. |
+| Milestone | Tickets | Outcome                                                                                                |
+| --------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| **M1**    | 01–03   | Can ship bytes in VSIX and read them reliably.                                                         |
+| **M2**    | 04–06   | New TEC-1G project references bundled MON3 and debugs ROM listing/source without project-local copies. |
+| **M3**    | 07–09   | Overrides and refresh story documented / optional.                                                     |
+| **M4**    | 10–12   | Multi-ROM TEC-1G config + tests.                                                                       |
+| **M5**    | 13–14   | Repeatable process + size strategy.                                                                    |
 
 ---
 
@@ -295,10 +317,10 @@ Copy ticket IDs into your issue tracker (GitHub Issues, Jira, etc.) and link thi
 
 ### Implementation status (Debug80 repo)
 
-| Milestone | Status | Notes |
-|-----------|--------|--------|
-| **M1** (TICKET-01–03) | **Done** | `src/extension/bundle-manifest.ts` (schema v1 + `isBundleManifestV1`), `resources/bundles/tec1g/mon3/v1/` and `resources/bundles/tec1/mon1b/v1/` layouts, `src/extension/bundle-materialize.ts` (`materializeBundledRom`, explicit lazy copy). Unit tests: `tests/extension/bundle-materialize.test.ts`. |
-| **M2** (TICKET-04–06) | **Done** | Bundled MON3/MON-1B assets are referenced from project profiles and resolved from extension resources when workspace copies are absent. Scaffold no longer copies stock ROM assets by default; `.gitignore` ignores `roms/` for explicit materialized local copies. |
-| **M3+** | Not started | Overrides docs, refresh command, multi-ROM (P3), etc. |
+| Milestone             | Status              | Notes                                                                                                                                                                                                                                                                                                    |
+| --------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **M1** (TICKET-01–03) | **Done**            | `src/extension/bundle-manifest.ts` (schema v1 + `isBundleManifestV1`), `resources/bundles/tec1g/mon3/v1/` and `resources/bundles/tec1/mon1b/v1/` layouts, `src/extension/bundle-materialize.ts` (`materializeBundledRom`, explicit lazy copy). Unit tests: `tests/extension/bundle-materialize.test.ts`. |
+| **M2** (TICKET-04–06) | **Done**            | Bundled MON3/MON-1B assets are referenced from project profiles and resolved from extension resources when workspace copies are absent. Scaffold no longer copies stock ROM assets by default; `.gitignore` ignores `roms/` for explicit materialized local copies.                                      |
+| **M3+**               | Optional / deferred | Multi-ROM schema, bundle refresh/repair, and size-strategy work are future enhancements, not current blockers. The present shipped flow uses smart bundle resolution plus explicit materialization/override.                                                                                             |
 
 VSIX packaging: `.vscodeignore` excludes `src/**`, `tests/**`, and `test/**` but **not** `resources/`, so `resources/bundles/**` is included in the packaged extension.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -76,8 +76,9 @@ src/
 Each platform can have its own dependencies. Shared serial helpers and TEC
 constants live alongside the platform code. TEC-1 and TEC-1G now have their
 runtime, controller, and webview panel modules under `src/platforms/`, while
-the adapter and extension still orchestrate wiring. Bundled ROM assets live
-under `resources/bundles/`; project-local `roms/` files are optional overrides.
+the adapter and extension still orchestrate wiring. Bundled ROM, listing, and
+source assets live under `resources/bundles/`; project-local `roms/` files are
+optional overrides or explicit inspection copies.
 
 ## Core interfaces
 
@@ -123,7 +124,7 @@ export interface MemoryRegion {
   name: string;
   start: number;
   end: number; // exclusive
-  kind: "rom" | "ram" | "io" | "banked" | "unknown";
+  kind: 'rom' | 'ram' | 'io' | 'banked' | 'unknown';
   bank?: number;
   readOnly?: boolean;
 }
@@ -176,6 +177,7 @@ export interface PlatformContext {
 ### Simple platform
 
 The current environment becomes the `simple` platform:
+
 - ROM region `0x0000`–`0x07ff` (`0`–`2047`) (system layer).
 - RAM region `0x0800`–`0xffff` (`2048`–`65535`) (program + data).
 - CPU starts at `0x0000` (`0`), system init runs, then jumps to `0x0900` (`2304`).
@@ -209,6 +211,7 @@ Terminal I/O is still configurable via the `terminal` block.
 ```
 
 Notes:
+
 - `newline` defines what the terminal sends for Enter.
 - `echo` controls local echo in the webview terminal.
 - `statusBits` allows different bit conventions per platform.
@@ -226,6 +229,7 @@ this spec.
 ### TEC-1 (v0.1)
 
 TEC-1 is a small ROM+RAM machine with keypad and 7-segment display:
+
 - ROM: 0x0000 - 0x07ff (0 - 2047)
 - RAM: 0x0800 - 0x0fff (2048 - 4095, 2 KB)
 - Entry: 0x0000 (0), user programs start at 0x0800 (2048)
@@ -240,30 +244,35 @@ TEC-1 is a small ROM+RAM machine with keypad and 7-segment display:
     ],
     "appStart": 2048,
     "entry": 0,
-    "romHex": "roms/tec1/mon-1b/mon-1b.hex"
+    "romHex": "roms/tec1/mon1b/mon-1b.bin"
   }
 }
 ```
 
-`romHex` points at an Intel HEX file for the monitor ROM. If omitted, Debug80
-uses the bundled `roms/tec1/mon-1b/mon-1b.hex`. Debug80 also bundles
-`roms/tec1/mon-2/mon-2.hex` and `roms/tec1/jmon/jmon.hex` (both use RAM @ 0x0900). If you
-already have a TypeScript module like
+`romHex` points at an Intel HEX/BIN file for the monitor ROM. Scaffolded MON-1B
+projects point at the stable override path `roms/tec1/mon1b/mon-1b.bin`, but
+Debug80 resolves the bundled extension copy when that workspace file is absent.
+If you already have a TypeScript module like
 `MON-1B.ts` that exports a template string, Debug80 will accept that file and
 extract the embedded HEX string.
 
 Optional tuning fields:
+
 - `updateMs` (default 16): min milliseconds between TEC-1 panel updates.
 - `yieldMs` (default 0): extra yield delay when the emulator is ahead of real time.
 - `ramInitHex`: optional Intel HEX file to preload RAM (e.g. a starter program).
 - `extraListings`: optional list of additional `.lst` files to load for ROM/debug mapping.
 
 Extra ROM listings:
-- Use `extraListings` to load ROM listings that live outside the project (for example, in a
-  platform repo). Paths are resolved relative to the `debug80.json` base directory; absolute
-  paths also work.
-- If a listing sits next to a matching `.asm`, `.zax`, or `.z80` source file, Debug80 will offer that source in the
-  ROM source picker and use it for line-based breakpoints.
+
+- Use `extraListings` to load ROM listings for monitor/debug ROMs. Paths are
+  resolved relative to the `debug80.json` base directory; absolute paths also
+  work. For scaffolded bundled profiles, a missing workspace-relative listing
+  is smart-resolved to the copy shipped inside the extension.
+- If a listing sits next to a matching `.asm`, `.zax`, or `.z80` source file,
+  Debug80 will offer that source in the ROM source picker and use it for
+  line-based breakpoints. Bundled profiles provide source snapshots for this
+  where available; local files with the same configured paths take precedence.
 - Debug80 caches a D8 debug map under `<workspace>/.debug80/cache` as
   `<listing-base>.<hash>.d8.json` (hash from the listing path). If the workspace cache
   directory cannot be used, it falls back to the listing directory.
@@ -275,23 +284,26 @@ Extra ROM listings:
 {
   "platform": "tec1",
   "tec1": {
-    "romHex": "roms/tec1/mon-1b/mon-1b.hex",
-    "extraListings": ["../platform/roms/tec1/mon-1b/mon-1b.lst"]
+    "romHex": "roms/tec1/mon1b/mon-1b.bin",
+    "extraListings": ["roms/tec1/mon1b/mon-1b.lst"]
   }
 }
 ```
 
 ROM-specific RAM usage:
+
 - MON-1 user programs start at 0x0800.
 - MON-2 user programs start at 0x0900 (0x0800–0x08ff reserved for variables).
 
 I/O map:
+
 - IN 0x00: keycode (0x00–0x0f hex digits, 0x10 UP, 0x11 DOWN, 0x12 GO, 0x13 ADDRESS; ROMs may use K_PLUS/K_MINUS for UP/DOWN)
 - OUT 0x01: digit select (bits 0–5, one-hot) + serial TX on bit 6 + speaker on bit 7 (latched)
 - OUT 0x02: segment bits (latched)
 - NMI at 0x0066 on keypress
 
 Serial (bitbang):
+
 - TX on bit 6 of OUT 0x01 (idle high).
 - RX on bit 7 of IN 0x00 (idle high).
 - Debug80 decodes TX at 9600 baud assuming FAST = 4.0 MHz.
@@ -301,6 +313,7 @@ Serial (bitbang):
   first receive or perform a one-byte flush at startup.
 
 Segment bit mapping (PORTSEGS):
+
 - 0x01 = a (top)
 - 0x02 = f (upper-left)
 - 0x04 = g (middle)
@@ -345,10 +358,9 @@ Mon-2 example (RAM reserved 0x0800–0x08ff, user programs at 0x0900):
 
 ### TEC-1G: bundled MON3 (wizard and manual projects)
 
-For **TEC-1G**, Debug80 can ship a **MON3** ROM snapshot inside the VSIX and
-resolve it directly at launch, with an explicit command available if you want
-to materialize local inspection/override files under stable paths (see
-`docs/plans/platform-rom-bundles.md`).
+For **TEC-1G**, Debug80 ships a **MON3** ROM snapshot inside the VSIX and
+resolves it directly at launch. Local files are optional: use the explicit copy
+command only when you want inspection/override files under stable paths.
 
 **After “Create Project” (TEC-1G)** the extension records the MON-3 bundle
 reference in `debug80.json` and resolves the shipped bundle on launch when no
@@ -356,15 +368,26 @@ workspace copy is present:
 
 - `roms/tec1g/mon3/mon3.bin` — monitor ROM image (`tec1g.romHex`; `.bin` or `.hex` per program loader rules).
 - `roms/tec1g/mon3/mon3.lst` — ASM80 listing for ROM source mapping (`tec1g.extraListings`).
-- `tec1g.sourceRoots` includes `src` and `roms/tec1g/mon3` so monitor sources resolve cleanly when a listing is present.
+- root or target `sourceRoots` includes `src` and `roms/tec1g/mon3` so monitor sources resolve cleanly when a listing is present.
 
 These `roms/` paths are stable project override paths. If the files are absent,
 Debug80 resolves the bundled extension copies. If the files are present, local
 workspace files take precedence.
 
-**Command:** **Debug80: Copy Bundled Assets into Workspace** (`debug80.materializeBundledRom`) — pick a bundled asset set, folder, and optional overwrite; copies bundled ROM/listing/source assets such as TEC-1G MON3 and TEC-1 MON-1B on demand for local inspection or override.
+**Commands:**
 
-**Manual project (no wizard):** point `tec1g.romHex` and `tec1g.extraListings` at workspace-relative paths (or absolute paths). Example:
+- **Debug80: Open ROM Listing/Source** (`debug80.openRomSource`) opens the
+  ROM listing/source files available to the active debug session.
+- **Debug80: Copy Bundled Assets into Workspace**
+  (`debug80.materializeBundledRom`) copies bundled ROM/listing/source assets
+  such as TEC-1G MON3 and TEC-1 MON-1B on demand for local inspection or
+  override.
+
+**Manual project (no wizard):** either point `tec1g.romHex` and
+`tec1g.extraListings` at your own workspace-relative/absolute files, or use a
+scaffolded project as a template so the `profiles.<name>.bundledAssets`
+references can smart-resolve missing local ROM files to the extension bundle.
+Example with explicit local files:
 
 ```json
 {
@@ -375,6 +398,7 @@ workspace files take precedence.
       "outputDir": "build",
       "artifactBase": "main",
       "platform": "tec1g",
+      "sourceRoots": ["src", "roms/tec1g/mon3"],
       "tec1g": {
         "regions": [
           { "start": 0, "end": 2047, "kind": "rom" },
@@ -384,8 +408,7 @@ workspace files take precedence.
         "appStart": 16384,
         "entry": 0,
         "romHex": "roms/tec1g/mon3/mon3.bin",
-        "extraListings": ["roms/tec1g/mon3/mon3.lst"],
-        "sourceRoots": ["src", "roms/tec1g/mon3"]
+        "extraListings": ["roms/tec1g/mon3/mon3.lst"]
       }
     }
   }
@@ -400,13 +423,14 @@ More hardware and I/O detail: `docs/platforms/tec1g/README.md`.
 
 ## Build and launch flow
 
-1) User selects a target in the debug config (via `projectConfig` + `target`).
-2) Debug80 reads `platform`, resolves the matching manifest entry, and lazy-loads
-  the platform provider.
-3) Platform sets up memory and devices, then the CPU runs normally.
-4) Mapping, breakpoints, and stepping are unchanged.
+1. User selects a target in the debug config (via `projectConfig` + `target`).
+2. Debug80 reads `platform`, resolves the matching manifest entry, and lazy-loads
+   the platform provider.
+3. Platform sets up memory and devices, then the CPU runs normally.
+4. Mapping, breakpoints, and stepping are unchanged.
 
 Reset behavior:
+
 - A reset clears CPU and device state.
 - Debug80 reloads the HEX into memory after reset.
 - Platform `onReset` should reset device state and bank selection.

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -7,6 +7,7 @@ interested in the assembler pipeline, source mapping, and stepping behavior.
 ## 1. What Debug80 is
 
 Debug80 is a VS Code extension that embeds a Z80 debug adapter. It:
+
 - Loads Intel HEX for runtime memory.
 - Reads an asm80 .lst listing for address-to-source mapping.
 - Optionally runs asm80 before each launch.
@@ -17,13 +18,14 @@ Debug80 is a VS Code extension that embeds a Z80 debug adapter. It:
 Text diagram (left -> right = flow of control):
 
 VS Code UI
-  -> Extension activation (src/extension/extension.ts)
-  -> Debug Adapter Factory (src/debug/adapter.ts)
-  -> Z80DebugSession (DAP server)
-  -> Z80 runtime + memory (src/z80/*)
-  -> Mapping pipeline (src/mapping/*)
+-> Extension activation (src/extension/extension.ts)
+-> Debug Adapter Factory (src/debug/adapter.ts)
+-> Z80DebugSession (DAP server)
+-> Z80 runtime + memory (src/z80/_)
+-> Mapping pipeline (src/mapping/_)
 
 Key concepts:
+
 - The extension registers a debug adapter type named `z80`.
 - The debug adapter runs in-process (inline implementation), not as a separate server.
 - The runtime executes Z80 instructions directly in JS/TS.
@@ -46,7 +48,7 @@ Key concepts:
   - Routes `debug80/terminalOutput` to the sidebar (simple) or terminal panel (others).
 - src/extension/platform-ui-entries.ts
   - Factory functions for built-in platform UI module bundles (Simple, TEC-1, TEC-1G).
-- src/platforms/*/ui-panel-*.ts
+- src/platforms/_/ui-panel-_.ts
   - Per-platform UI modules: HTML generation, state management, message handling, memory views.
 - webview/
   - Browser-side source for all three platform panels (simple/, tec1/, tec1g/).
@@ -73,10 +75,10 @@ Key concepts:
   - Session types and stateful helpers: session state shape, runtime control, adapter UI helpers,
     platform host/registry, error classes, and message/type definitions.
   - Key files: types.ts, session-state.ts, runtime-control.ts, platform-host.ts,
-    platform-registry.ts, adapter-ui.ts, errors.ts, message-types.ts, memory-*.ts.
-- src/mapping/*
+    platform-registry.ts, adapter-ui.ts, errors.ts, message-types.ts, memory-\*.ts.
+- src/mapping/\*
   - Listing -> segments/anchors, layer 2 matching, and index building.
-- src/z80/*
+- src/z80/\*
   - CPU, runtime, and instruction execution.
   - HEX and listing loaders.
 
@@ -85,30 +87,33 @@ Key concepts:
 Entry point: src/extension/extension.ts
 
 Activation does four important things:
-1) Registers the three built-in platform UIs (Simple, TEC-1, TEC-1G) via `registerBuiltInPlatformUis()`.
-2) Registers the debug adapter for type `z80`.
-3) Registers the `PlatformViewProvider` sidebar WebviewView (`debug80.platformView`).
-4) Registers commands and debug session event handlers.
+
+1. Registers the three built-in platform UIs (Simple, TEC-1, TEC-1G) via `registerBuiltInPlatformUis()`.
+2. Registers the debug adapter for type `z80`.
+3. Registers the `PlatformViewProvider` sidebar WebviewView (`debug80.platformView`).
+4. Registers commands and debug session event handlers.
 
 Registered commands (src/extension/commands.ts):
-- debug80.createProject       — scaffold a debug80.json in the workspace
-- debug80.startDebug          — launch a debug session for the selected target
-- debug80.restartDebug        — restart the active debug session
+
+- debug80.createProject — scaffold a debug80.json in the workspace
+- debug80.startDebug — launch a debug session for the selected target
+- debug80.restartDebug — restart the active debug session
 - debug80.selectWorkspaceFolder — change the active workspace root
-- debug80.selectTarget        — change the active launch target
-- debug80.configureProject    — open project config (currently a no-op; config is via project header)
+- debug80.selectTarget — change the active launch target
+- debug80.configureProject — open project config (currently a no-op; config is via project header)
 - debug80.openProjectConfigPanel — open the project config JSON in an editor
-- debug80.setEntrySource      — set the main source file for the active target
-- debug80.openTerminal        — open the terminal panel (non-platform sessions)
-- debug80.terminalInput       — send text input to the active debug session terminal
-- debug80.openTec1            — reveal the TEC-1 sidebar panel
-- debug80.openTec1Memory      — switch the TEC-1 panel to the CPU tab
-- debug80.openRomSource       — open ROM source files for the active session
-- debug80.openDebug80View     — reveal and focus the Debug80 sidebar panel
-- debug80.addWorkspaceFolder  — open a folder picker and add the chosen folder to the workspace
+- debug80.setEntrySource — set the main source file for the active target
+- debug80.openTerminal — open the terminal panel (non-platform sessions)
+- debug80.terminalInput — send text input to the active debug session terminal
+- debug80.openTec1 — reveal the TEC-1 sidebar panel
+- debug80.openTec1Memory — switch the TEC-1 panel to the CPU tab
+- debug80.openRomSource — open ROM source files for the active session
+- debug80.openDebug80View — reveal and focus the Debug80 sidebar panel
+- debug80.addWorkspaceFolder — open a folder picker and add the chosen folder to the workspace
 - debug80.materializeBundledRom — manually install bundled ROM assets into the active workspace
 
 Important behavior for new VS Code extension developers:
+
 - The debug adapter is created with vscode.DebugAdapterInlineImplementation.
 - Terminal output is sent from the adapter via custom DAP events (see section 13).
 - Platform UI is served from the sidebar WebviewView, not from a WebviewPanel.
@@ -118,29 +123,32 @@ Important behavior for new VS Code extension developers:
 Class: Z80DebugSession in src/debug/adapter.ts
 
 DAP lifecycle (simplified):
-1) initializeRequest
+
+1. initializeRequest
    - Announces adapter capabilities.
-2) launchRequest
+2. launchRequest
    - Merges launch args with debug80.json.
    - Resolves artifacts (HEX, LST) and runs asm80 if enabled.
    - Parses HEX and LST.
    - Builds source mapping and indexes.
    - Creates the runtime and applies breakpoints.
-3) configurationDoneRequest (implicit behavior)
-4) continue / step / pause / disconnect
+3. configurationDoneRequest (implicit behavior)
+4. continue / step / pause / disconnect
 
 ## 6. Project configuration
 
 ### 6.1 Config file discovery
 
 Sources are searched in this order:
-1) launch args.projectConfig
-2) debug80.json          ← checked first among file candidates (PROJECT_CONFIG_CANDIDATES)
-3) .vscode/debug80.json
-4) .debug80.json
-5) package.json (debug80 block)
+
+1. launch args.projectConfig
+2. debug80.json ← checked first among file candidates (PROJECT_CONFIG_CANDIDATES)
+3. .vscode/debug80.json
+4. .debug80.json
+5. package.json (debug80 block)
 
 Search origin:
+
 - args.asm -> args.sourceFile -> process.cwd()
 - Walk upward to filesystem root, first match wins.
 
@@ -151,6 +159,7 @@ so root-based discovery may miss the user workspace unless debug80.json is prese
 
 Launch args are merged with config targets in populateFromConfig().
 Common fields:
+
 - sourceFile (aka asm)
 - outputDir
 - artifactBase
@@ -161,14 +170,24 @@ Common fields:
 - stepOverMaxInstructions / stepOutMaxInstructions
 - terminal (I/O bridge config)
 
+Bundled profile assets are resolved during this merge step. Scaffolded TEC-1
+and TEC-1G projects keep stable workspace-relative paths such as
+`roms/tec1/mon1b/mon-1b.bin` or `roms/tec1g/mon3/mon3.bin` in the platform
+config. If the file exists in the workspace it is used as an override; if it is
+absent and `profiles.<name>.bundledAssets` maps that logical path to a shipped
+bundle, Debug80 uses the copy under `resources/bundles/`.
+
 Debug80 always writes a D8 debug map to `<artifactBase>.d8.json` in outputDir.
 
 ### 6.3 Scaffold command
 
 Command: debug80.createProject
-- Writes .vscode/debug80.json using inferDefaultTarget().
+
+- Writes debug80.json using the selected project kit and target source.
 - Writes .vscode/launch.json if missing.
 - Creates directories (outputDir, .vscode, etc).
+- For bundled TEC-1/TEC-1G kits, writes profile-level `bundledAssets`
+  references instead of copying stock ROM files into the workspace.
 
 ## 7. Assembler integration
 
@@ -177,6 +196,7 @@ The current default backend is `asm80`, implemented in `src/debug/launch/asm80-b
 `zax` is also available, implemented in `src/debug/launch/zax-backend.ts`.
 
 If `assemble !== false` and `sourceFile`/`asm` is provided:
+
 - The selected backend assembles the program to HEX and LST artifacts.
 - For `asm80`, Debug80 links the `asm80` package directly in-process and writes HEX, compact BIN,
   and LST artifacts from the compiled output.
@@ -187,10 +207,12 @@ If `assemble !== false` and `sourceFile`/`asm` is provided:
 - Errors are printed to the Debug Console and returned as structured assembly diagnostics when possible.
 
 The backend also optionally supports:
+
 - A binary output pass for `simple.binFrom` / `simple.binTo`.
 - In-process mapping compilation for extra ROM listings.
 
 Expected tools:
+
 - `asm80` and `@jhlagado/zax` are normal extension dependencies and must be included in the VSIX.
 - Debug80 should not depend on globally installed assembler CLIs for published-extension behavior.
 - Module-system compatibility is contained inside backend adapters: asm80 is CommonJS-compatible,
@@ -201,11 +223,13 @@ Expected tools:
 Runtime entry point: src/z80/runtime.ts
 
 Key ideas:
+
 - The runtime loads a 64K memory image from HEX.
 - Each step executes a single instruction via execute() (src/z80/cpu.ts).
 - runUntilStop loops instruction execution until a breakpoint, HALT, or pause.
 
 Register display:
+
 - The adapter exposes standard Z80 registers (AF, BC, DE, HL, IX, IY, etc).
 
 ## 9. Source mapping pipeline
@@ -228,10 +252,12 @@ File: src/mapping/parser.ts
   "DEFINED AT LINE <n> IN <file>"
 
 Outputs:
+
 - segments[]: address ranges with lst text and optional source location.
 - anchors[]: address -> file/line symbols.
 
 Confidence:
+
 - HIGH: exact anchor hit.
 - MEDIUM: duplicate address or inferred between anchors.
 - LOW: no anchors yet.
@@ -252,6 +278,7 @@ Missing source files are reported to the Debug Console but are non-fatal.
 File: src/mapping/source-map.ts
 
 Indexes built at launch:
+
 - segmentsByAddress (sorted, for PC -> location)
 - segmentsByFileLine (for breakpoint resolution)
 - anchorsByFile (for fallback when no exact line match exists)
@@ -317,6 +344,7 @@ Stepping combines runtime instruction execution and adapter logic.
 - Otherwise, step a single instruction.
 
 Return address rules:
+
 - CALL nn or conditional CALL: pc + 3
 - RST n: pc + 1
 
@@ -328,10 +356,12 @@ Return address rules:
 ### 11.4 Step limits
 
 Optional caps:
+
 - stepOverMaxInstructions
 - stepOutMaxInstructions
 
 When a cap is hit:
+
 - Execution stops and logs a console message.
 - The session remains active.
 
@@ -344,12 +374,14 @@ When a cap is hit:
 ## 13. Terminal and I/O bridge
 
 Launch args.terminal configures a basic port-based terminal:
+
 - txPort: output port
 - rxPort: input port
 - statusPort: ready/available flags
 - interrupt: optional break-to-NMI behavior
 
 Custom requests:
+
 - debug80/terminalInput (send text to rx buffer)
 - debug80/terminalBreak (trigger interrupt on next tick)
 
@@ -373,11 +405,11 @@ share this one sidebar location.
 
 Built-in platforms and their sidebar behavior:
 
-| Platform | UI tab content           | CPU tab content |
-|----------|--------------------------|-----------------|
-| Simple   | Terminal output (TERMINAL area + CLEAR button) | Z80 memory viewer (4 sections) |
-| TEC-1    | Hardware display, keypad, LCD, 8×8 LED matrix, serial terminal | Z80 memory viewer |
-| TEC-1G   | Hardware display, keypad, GLCD, RGB LED matrix, serial terminal | Z80 memory viewer |
+| Platform | UI tab content                                                  | CPU tab content                |
+| -------- | --------------------------------------------------------------- | ------------------------------ |
+| Simple   | Terminal output (TERMINAL area + CLEAR button)                  | Z80 memory viewer (4 sections) |
+| TEC-1    | Hardware display, keypad, LCD, 8×8 LED matrix, serial terminal  | Z80 memory viewer              |
+| TEC-1G   | Hardware display, keypad, GLCD, RGB LED matrix, serial terminal | Z80 memory viewer              |
 
 ### 14.2 Platform registration
 
@@ -472,42 +504,43 @@ host replays state in this order:
 
 **Extension → webview:**
 
-| type          | Description |
-|---------------|-------------|
-| `projectStatus` | Workspace roots, targets, selected target name, active platform ID |
-| `sessionStatus` | Debug session state: `starting`, `running`, `paused`, `not running` |
-| `update`      | Full platform UI state snapshot (carries `uiRevision` monotonic guard) |
-| `uiVisibility` | TEC-1G component show/hide flags |
-| `serial`      | Incremental text appended to the serial/terminal output |
-| `serialInit`  | Full serial/terminal buffer on rehydration |
-| `serialClear` | Clear the serial/terminal display |
-| `selectTab`   | Restore the active tab (`ui` or `memory`) |
-| `snapshot`    | Memory dump for the CPU tab (register strip + hex sections) |
-| `snapshotError` | Error message when snapshot fails |
+| type            | Description                                                            |
+| --------------- | ---------------------------------------------------------------------- |
+| `projectStatus` | Workspace roots, targets, selected target name, active platform ID     |
+| `sessionStatus` | Debug session state: `starting`, `running`, `paused`, `not running`    |
+| `update`        | Full platform UI state snapshot (carries `uiRevision` monotonic guard) |
+| `uiVisibility`  | TEC-1G component show/hide flags                                       |
+| `serial`        | Incremental text appended to the serial/terminal output                |
+| `serialInit`    | Full serial/terminal buffer on rehydration                             |
+| `serialClear`   | Clear the serial/terminal display                                      |
+| `selectTab`     | Restore the active tab (`ui` or `memory`)                              |
+| `snapshot`      | Memory dump for the CPU tab (register strip + hex sections)            |
+| `snapshotError` | Error message when snapshot fails                                      |
 
 **Webview → extension:**
 
-| type             | Description |
-|------------------|-------------|
-| `tab`            | User switched to `ui` or `memory` tab |
-| `saveProjectConfig` | User changed Platform dropdown; payload: `{ platform: string }` |
-| `selectTarget`   | User changed Target dropdown |
-| `openWorkspaceFolder` | User clicked the workspace folder button |
-| `createProject`  | User clicked Create Project in the setup card |
-| `refresh`        | Memory panel requests a snapshot with updated view configuration |
-| `registerEdit`   | User edited a register value in the CPU tab |
-| `memoryEdit`     | User edited a memory byte in the CPU tab |
-| `serialSend`     | User sent text via the serial input field |
-| `serialSendFile` | User triggered a file send via serial |
-| `serialSave`     | User saved serial output to a file |
-| `serialClear`    | User cleared the serial/terminal display |
-| `key`            | Keypad key press (TEC-1/TEC-1G) |
-| `reset`          | Reset button (TEC-1/TEC-1G) |
-| `speed`          | Speed toggle slow/fast (TEC-1/TEC-1G) |
+| type                  | Description                                                      |
+| --------------------- | ---------------------------------------------------------------- |
+| `tab`                 | User switched to `ui` or `memory` tab                            |
+| `saveProjectConfig`   | User changed Platform dropdown; payload: `{ platform: string }`  |
+| `selectTarget`        | User changed Target dropdown                                     |
+| `openWorkspaceFolder` | User clicked the workspace folder button                         |
+| `createProject`       | User clicked Create Project in the setup card                    |
+| `refresh`             | Memory panel requests a snapshot with updated view configuration |
+| `registerEdit`        | User edited a register value in the CPU tab                      |
+| `memoryEdit`          | User edited a memory byte in the CPU tab                         |
+| `serialSend`          | User sent text via the serial input field                        |
+| `serialSendFile`      | User triggered a file send via serial                            |
+| `serialSave`          | User saved serial output to a file                               |
+| `serialClear`         | User cleared the serial/terminal display                         |
+| `key`                 | Keypad key press (TEC-1/TEC-1G)                                  |
+| `reset`               | Reset button (TEC-1/TEC-1G)                                      |
+| `speed`               | Speed toggle slow/fast (TEC-1/TEC-1G)                            |
 
 ## 15. For developers new to VS Code extensions
 
 Key VS Code concepts used here:
+
 - Extension activation: register commands and debug adapter factory.
 - Debug Adapter Protocol: the adapter responds to DAP requests.
 - Inline debug adapter: adapter runs in the extension host process.
@@ -515,9 +548,10 @@ Key VS Code concepts used here:
   that swaps HTML on platform change; see section 14.
 
 If you want to add features, start here:
+
 - New launch args: update LaunchRequestArguments in src/debug/adapter.ts.
 - New terminal behavior: update buildIoHandlers() in src/debug/adapter.ts.
-- New mapping logic: update src/mapping/* and the index builder.
+- New mapping logic: update src/mapping/\* and the index builder.
 - New platform UI: see docs/platform-development-guide.md and docs/platform-extension-api.md.
 
 ## 16. Known limitations

--- a/src/extension/project-scaffolding.ts
+++ b/src/extension/project-scaffolding.ts
@@ -145,6 +145,9 @@ export function createDefaultProjectConfig(plan: ScaffoldPlan): {
     artifactBase: plan.artifactBase,
     platform: plan.kit.platform,
     profile: plan.kit.profileName,
+    ...(plan.kit.bundledProfile !== undefined
+      ? { sourceRoots: plan.kit.bundledProfile.sourceRoots }
+      : {}),
   };
 
   if (plan.kit.platform === 'tec1') {
@@ -157,7 +160,6 @@ export function createDefaultProjectConfig(plan: ScaffoldPlan): {
             ...(plan.kit.bundledProfile.listingPath !== undefined
               ? { extraListings: [plan.kit.bundledProfile.listingPath] }
               : {}),
-            sourceRoots: plan.kit.bundledProfile.sourceRoots,
           }
         : base;
   } else if (plan.kit.platform === 'tec1g') {
@@ -170,7 +172,6 @@ export function createDefaultProjectConfig(plan: ScaffoldPlan): {
             ...(plan.kit.bundledProfile.listingPath !== undefined
               ? { extraListings: [plan.kit.bundledProfile.listingPath] }
               : {}),
-            sourceRoots: plan.kit.bundledProfile.sourceRoots,
           }
         : base;
   } else {

--- a/src/platforms/tec1/README.md
+++ b/src/platforms/tec1/README.md
@@ -14,6 +14,7 @@ display, speaker, and bitbanged serial.
 ## Clock speeds
 
 Debug80 exposes two modes:
+
 - Slow: 400 kHz (default for MON-1 style timing)
 - Fast: 4 MHz
 
@@ -22,6 +23,7 @@ The TEC-1 panel has a toggle for slow/fast.
 ## Ports
 
 ### Input
+
 - `IN 0x00` (KEYBUF): keycode in lower bits, serial RX on bit 7.
   - Keycode values:
     - 0x00–0x0f: hex digits 0–F
@@ -36,6 +38,7 @@ The TEC-1 panel has a toggle for slow/fast.
   - Bit 7 (0x80) is serial RX (DIN).
 
 ### Output
+
 - `OUT 0x01` (SCAN): digit select + speaker + serial TX.
   - Bits 0–5: digit select (one-hot). Bit 0 is rightmost digit, bit 5 is leftmost.
   - Bit 6 (0x40): serial TX (DOUT), idle high.
@@ -43,6 +46,7 @@ The TEC-1 panel has a toggle for slow/fast.
 - `OUT 0x02` (DISPLY): segment bits (latched).
 
 ### NMI
+
 - NMI vector at 0x0066 on keypress.
 
 ## 7-seg display
@@ -51,6 +55,7 @@ The TEC-1 panel has a toggle for slow/fast.
 `OUT 0x01` selects which digit is active; `OUT 0x02` provides the segment pattern.
 
 Segment bit mapping (PORTSEGS):
+
 - 0x01 = a (top)
 - 0x02 = f (upper-left)
 - 0x04 = g (middle)
@@ -65,6 +70,7 @@ Decimal points are used to indicate whether the address or data field is active.
 ## Keypad
 
 The TEC-1 keypad is 20 keys:
+
 - Hex digits 0–F
 - ADDRESS, GO, and two direction keys (◀/▶ on the emulated panel; many boards label them UP/DOWN)
 
@@ -78,6 +84,7 @@ Shift is a normal momentary push-button in hardware (not a latch). Debug80’s U
 uses a latch for convenience; it clears after the next key press.
 
 Shift affects bit 5 in the keycode:
+
 - Bit 5 (0x20) is **high** when unshifted.
 - Bit 5 is **low** when shift is held.
 
@@ -97,6 +104,7 @@ TEC-1 uses a simple async serial bitbang on the keypad/display ports:
 Debug80 only models the bitbang line for TEC-1 (no ACIA support).
 
 Protocol details (from MINT1.2 ROM):
+
 - Idle = high.
 - Start bit = low.
 - 8 data bits, LSB first.
@@ -114,6 +122,7 @@ activity.
 ## ROM-specific RAM usage
 
 Not every ROM uses RAM the same way:
+
 - MON-1: user programs typically start at 0x0800.
 - Later ROMs (e.g. MON-2): user programs typically start at 0x0900 to leave
   0x0800–0x08ff for variables/workspace.
@@ -131,22 +140,22 @@ focus ring appears around the keypad while it is active.
 
 ### Hex / control keys
 
-| Key(s) | Keypad button | Code sent |
-|--------|--------------|-----------|
-| `0`–`9`, `A`–`F` | Hex digit | 0x00–0x0F |
-| `Space` | `0` | 0x00 |
-| `Tab` | ADDRESS | 0x13 |
-| `Enter` | GO | 0x12 |
-| `←` | ◀ (left) | 0x11 |
-| `→` | ▶ (right) | 0x10 |
-| `↑` | ADDRESS | 0x13 |
-| `↓` | GO | 0x12 |
+| Key(s)           | Keypad button | Code sent |
+| ---------------- | ------------- | --------- |
+| `0`–`9`, `A`–`F` | Hex digit     | 0x00–0x0F |
+| `Space`          | `0`           | 0x00      |
+| `Tab`            | ADDRESS       | 0x13      |
+| `Enter`          | GO            | 0x12      |
+| `←`              | ◀ (left)      | 0x11      |
+| `→`              | ▶ (right)     | 0x10      |
+| `↑`              | ADDRESS       | 0x13      |
+| `↓`              | GO            | 0x12      |
 
 ### Special keys
 
-| Key | Action |
-|-----|--------|
-| `Escape` | Reset (clears SHIFT latch first) |
+| Key            | Action                                                                                                                                       |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Escape`       | Reset (clears SHIFT latch first)                                                                                                             |
 | `Shift` (hold) | SHIFT modifier — hold while pressing another key to send that key with the shift bit cleared; releasing Shift without pressing a key cancels |
 
 ### SHIFT key behaviour
@@ -184,7 +193,8 @@ You can override with `romHex` in the platform config.
     ],
     "appStart": 2048,
     "entry": 0,
-    "romHex": "roms/tec1/mon-1b/mon-1b.hex",
+    "romHex": "roms/tec1/mon1b/mon-1b.bin",
+    "extraListings": ["roms/tec1/mon1b/mon-1b.lst"],
     "ramInitHex": "build/main.hex",
     "updateMs": 16,
     "yieldMs": 0
@@ -197,4 +207,5 @@ You can override with `romHex` in the platform config.
 - Emulator and I/O: `src/platforms/tec1/runtime.ts`
 - Debug adapter wiring and TEC-1 custom requests: `src/platforms/tec1/provider.ts`
 - Memory panel HTML/browser helpers: `src/platforms/tec1/memory-panel-html.ts` and `src/platforms/tec1/memory-panel-browser.ts`
-- Bundled ROM: `roms/tec1/mon-1b/mon-1b.hex`
+- Bundled ROM override path: `roms/tec1/mon1b/mon-1b.bin`
+- Bundled listing override path: `roms/tec1/mon1b/mon-1b.lst`

--- a/src/platforms/tec1g/README.md
+++ b/src/platforms/tec1g/README.md
@@ -5,6 +5,7 @@ workflow and hardware contract. For full MON-3 behavior notes, see
 `docs/platforms/tec1g/README.md`.
 
 ## Current support
+
 - Keypad + NMI on keypress, seven-seg display, speaker.
 - LCD write/read emulation (HD44780-style), including busy-flag status.
 - Serial bit-bang TX/RX at 4800-8-N-2 (MON-3 timing).
@@ -13,12 +14,14 @@ workflow and hardware contract. For full MON-3 behavior notes, see
 - RTC (DS1302) and SD SPI (0xFC/0xFD) when enabled in config.
 
 ## Not yet emulated
+
 - Cartridge boot entry uses CART flag (MON-3 style) and maps payload into expansion banks.
 - SYS_CTRL bits 3-7: latched and decoded but bank switching not yet wired to memory.
 - SYS_INPUT bits 0 (SKEY), 4 (RKEY), 5 (GIMP): state exposed but no hardware trigger wired.
 - LCD entry mode, display on/off, cursor shift, function set, CGRAM.
 
 ## Memory map (MON-3 view)
+
 - 0x0000-0x00FF: RAM (RST vectors).
 - 0x0100-0x07FF: RAM.
 - 0x0800-0x0FFF: monitor RAM.
@@ -30,6 +33,7 @@ workflow and hardware contract. For full MON-3 behavior notes, see
 Shadow mode maps ROM 0xC000-0xC7FF into 0x0000-0x07FF for legacy monitors.
 
 ## Clock speeds
+
 - Slow: 400 kHz
 - Fast: 4 MHz
 
@@ -38,6 +42,7 @@ The TEC-1G panel can switch speed modes; the serial timing assumes FAST mode.
 ## Ports
 
 ### Input
+
 - `IN 0x00` (KEYBUF): keycode in lower bits, serial RX on bit 7 (idle high).
   - Keycodes: 0x00-0x0f (hex), 0x10 (▶ right), 0x11 (◀ left), 0x12 (GO), 0x13 (AD), 0x02 (FN). (ROMs may use K_PLUS/K_MINUS; keycaps are chevrons.)
 - `IN 0x03` (SYS_INPUT): system flags (U18 74HCT373).
@@ -54,6 +59,7 @@ The TEC-1G panel can switch speed modes; the serial timing assumes FAST mode.
 - `IN 0xFE`: matrix keyboard rows (returns 0xFF when matrix mode is disabled).
 
 ### Output
+
 - `OUT 0x01` (SCAN): digit select + speaker + serial TX.
   - Bits 0-5: digit select (one-hot).
   - Bit 6 (0x40): serial TX (idle high).
@@ -77,12 +83,15 @@ The TEC-1G panel can switch speed modes; the serial timing assumes FAST mode.
 - `OUT 0xFD`: SD card SPI (bit-banged emulation, SPI mode; read + write single block).
 
 ## Serial (bitbang)
+
 - TX uses bit 6 on `OUT 0x01`; RX uses bit 7 on `IN 0x00` (mirrored on `IN 0x03`).
 - 4800 baud, 8 data bits, no parity, 2 stop bits.
 - Debug80 decodes TX into the panel serial view and can inject RX bytes.
 
 ## DIAG ROM expectations
+
 The TEC-1G DIAG ROM exercises several device behaviors directly:
+
 - LCD busy-flag polling: `IN 0x04` bit 7 is polled before each LCD write.
 - LCD data read: after init, the DIAG checks for a space (0x20) from `IN 0x84`.
 - FTDI loopback test: toggles TX on `OUT 0x01` bit 6 and expects RX state on `IN 0x03` bit 7.
@@ -94,29 +103,33 @@ The TEC-1G DIAG ROM exercises several device behaviors directly:
   and read back on the data line (see `Diags_RTC.asm`).
 
 ## Shadow / Protect / Expand
+
 - Shadow mirrors ROM into 0x0000-0x07FF for legacy monitors; writes go to RAM.
 - Protect makes 0x4000-0x7FFF read-only.
 - Expand exposes a banked 16K window at 0x8000-0xBFFF.
 
 ## ROMs and config
+
 Debug80 ships a bundled MON-3 profile for scaffolded projects. New projects
 record bundled asset references in `debug80.json`; launch resolves the extension
 bundle directly when no workspace copy exists. You can still provide `romHex` in
 the platform config (and optionally ROM listings via `extraListings`) to override
 the bundled profile or debug a custom ROM.
 
-**Shared MON-3 settings (recommended):** Put `romHex`, `entry`, and any other
-fields that are the same for every build under **`debug80.json` root** `tec1g`,
-not only under each `targets.<name>` entry. That way every target (ASM, ZAX,
-different demos) loads the same monitor ROM without duplicating paths or
-depending on merge order. Use per-target `tec1g` only for overrides (for example
-`appStart`, `matrixMode`, or `extraListings`).
+**Shared MON-3 settings (recommended):** Scaffolded projects record MON-3 under
+a shared profile and point `tec1g.romHex` / `tec1g.extraListings` at stable
+workspace-relative override paths. When those local files are absent, launch
+uses the bundled extension copies. Put per-target `tec1g` fields only where a
+target actually differs, for example `appStart`, `matrixMode`, or
+`extraListings`.
 
 ```json
 {
   "platform": "tec1g",
+  "sourceRoots": ["src", "roms/tec1g/mon3"],
   "tec1g": {
-    "romHex": "../roms/tec1g/mon-3/mon-3.hex",
+    "romHex": "roms/tec1g/mon3/mon3.bin",
+    "extraListings": ["roms/tec1g/mon3/mon3.lst"],
     "appStart": 16384,
     "entry": 0,
     "matrixMode": false,
@@ -140,22 +153,22 @@ focus ring appears around the keypad while it is active.
 
 ### Hex / control keys
 
-| Key(s) | Keypad button | Code sent |
-|--------|--------------|-----------|
-| `0`–`9`, `A`–`F` | Hex digit | 0x00–0x0F |
-| `Space` | `0` | 0x00 |
-| `Tab` | AD | 0x13 |
-| `Enter` | GO | 0x12 |
-| `←` | ◀ (left) | 0x11 |
-| `→` | ▶ (right) | 0x10 |
-| `↑` | AD | 0x13 |
-| `↓` | GO | 0x12 |
+| Key(s)           | Keypad button | Code sent |
+| ---------------- | ------------- | --------- |
+| `0`–`9`, `A`–`F` | Hex digit     | 0x00–0x0F |
+| `Space`          | `0`           | 0x00      |
+| `Tab`            | AD            | 0x13      |
+| `Enter`          | GO            | 0x12      |
+| `←`              | ◀ (left)      | 0x11      |
+| `→`              | ▶ (right)     | 0x10      |
+| `↑`              | AD            | 0x13      |
+| `↓`              | GO            | 0x12      |
 
 ### Special keys
 
-| Key | Action |
-|-----|--------|
-| `Escape` | Reset (clears FN latch first) |
+| Key            | Action                                                                                                                          |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `Escape`       | Reset (clears FN latch first)                                                                                                   |
 | `Shift` (hold) | FN modifier — hold while pressing another key to send that key in function mode; releasing Shift without pressing a key cancels |
 
 ### FN key behaviour
@@ -172,4 +185,5 @@ physical `Shift` key is equivalent: hold `Shift` + press a key.
 - Native controls (`input`, `select`, `button`) keep their own focus normally.
 
 ## Examples
+
 - See the separate `debug80-tec1g` repo for MON-3 example workspaces and demos.

--- a/tests/extension/project-scaffolding.test.ts
+++ b/tests/extension/project-scaffolding.test.ts
@@ -230,6 +230,7 @@ describe('project-scaffolding helpers', () => {
           artifactBase: 'main',
           platform: 'tec1',
           profile: 'mon1b',
+          sourceRoots: ['src', 'roms/tec1/mon1b'],
           tec1: {
             regions: [
               { start: 0, end: 2047, kind: 'rom' },
@@ -239,7 +240,6 @@ describe('project-scaffolding helpers', () => {
             entry: 0,
             romHex: 'roms/tec1/mon1b/mon-1b.bin',
             extraListings: ['roms/tec1/mon1b/mon-1b.lst'],
-            sourceRoots: ['src', 'roms/tec1/mon1b'],
           },
         },
       },
@@ -325,6 +325,7 @@ describe('project-scaffolding helpers', () => {
           artifactBase: 'main',
           platform: 'tec1g',
           profile: 'mon3',
+          sourceRoots: ['src', 'roms/tec1g/mon3'],
           tec1g: {
             regions: [
               { start: 0, end: 2047, kind: 'rom' },
@@ -335,7 +336,6 @@ describe('project-scaffolding helpers', () => {
             entry: 0,
             romHex: 'roms/tec1g/mon3/mon3.bin',
             extraListings: ['roms/tec1g/mon3/mon3.lst'],
-            sourceRoots: ['src', 'roms/tec1g/mon3'],
           },
         },
       },


### PR DESCRIPTION
## Summary
- add a hardware serial link design for sending built HEX files to real boards from Debug80
- capture PlatformIO findings: project-owned serial settings, UI/core separation, exclusive serial port handling, and provider/helper boundary
- refresh ROM bundle docs to reflect current smart bundled asset resolution and user override behavior

## Verification
- `git diff --check`

## Notes
- docs-only PR; does not add `serialport` or implementation code
- recommends a provider boundary before choosing internal serialport, a companion extension, or a helper CLI