### PR TITLE
Stop deriving source maps from listings

### DIFF
--- a/docs/design-azm-only-source-map-deprecation.md
+++ b/docs/design-azm-only-source-map-deprecation.md
@@ -1,212 +1,120 @@
-# AZM-Only Source Map Deprecation Plan
+# AZM-Only Source Map Removal Plan
 
-## Purpose
+## Decision
 
-Debug80 originally supported an ASM80/listing-driven workflow. That made sense
-while ASM80 was the production assembler and Debug80 had to reconstruct source
-mapping from `.lst` files. AZM is now the supported assembler and emits native
-Debug80 `.d8.json` source maps. The legacy listing-derived path should therefore
-be deprecated and removed in phases.
+Debug80 should no longer reconstruct debugger source maps from assembler
+listings. AZM is now the supported assembler and emits native `.d8.json` maps.
+That file is the source of truth for source breakpoints, current source
+location, F12 navigation, hover data, Variables, Watches, call stack labels, and
+ROM source stepping.
 
-The goal is to simplify Debug80 around one clear contract:
+The old listing-derived path is not a supported fallback. If a required D8 map
+is missing or invalid, Debug80 should report that the target needs to be built
+with AZM. It should not parse `.lst` files, regenerate maps, silently use stale
+compatibility caches, or recover by guessing source paths.
 
-- AZM is the only bundled assembler.
-- A successful build produces HEX/BIN artifacts and a native `.d8.json` map.
-- Debugger source mapping, editor navigation, variables, call stack display,
-  and breakpoints read the active target's build-side `.d8.json`.
-- Debug80 does not regenerate source maps from listings for normal project code.
+## Target Contract
 
-## Current Legacy Surface
+A runnable Debug80 target has:
 
-The legacy behavior is not isolated to one switch. The main areas are:
+- a program artifact, normally Intel HEX or binary;
+- a native Debug80 source map, `<artifactBase>.d8.json`;
+- source files resolvable from the project root and configured source roots;
+- optional platform/ROM D8 maps for monitor code and bundled ROM sources.
 
-- Launch schema still documents `assembler: "asm80"` as a legacy alias.
-- Project/config validation accepts both `azm` and `asm80`.
-- Technical docs still describe listing-derived map generation.
-- `src/debug/mapping/path-resolver.ts` now resolves D8 maps beside build/listing
-  artifacts, but listing compatibility still remains in the launch path.
-- `src/debug/mapping/mapping-service.ts` can parse `.lst` listings and apply
-  Layer 2 source matching.
-- `src/mapping/parser.ts`, `src/mapping/layer2.ts`, and related tests exist to
-  reconstruct source maps from assembler listings.
-- Extra ROM mapping still uses `extraListings` and bundled `.lst` files for
-  monitor ROM source navigation.
-- The Z80 listing grammar and `.lst` language support still exist for viewing
-  listing files, which is separate from using listings as debugger metadata.
+The assembler owns map correctness. Debug80 consumes and validates D8 maps.
 
-Recent work moved runtime symbol loading and map paths toward the desired model:
-Variables prefer the build-side `.d8.json`, empty Constants are hidden, and the
-project-local `.debug80/cache` map path has been removed.
+## What Must Be Removed
 
-## What Should Stay
+The following are compatibility mechanisms, not desired architecture:
 
-Some listing-adjacent features are still useful and should not be removed just
-because ASM80 is deprecated:
+- primary source map generation from `.lst` files;
+- stale-map fallback from D8 to listing parsing;
+- Layer 2 listing/source recovery in the active launch path;
+- Debug80-generated compatibility D8 maps from listing content;
+- `.lst` breakpoint binding as a first-class debugger workflow;
+- `extraListings` as the platform ROM mapping mechanism;
+- project scaffolding that materializes or configures ROM listings as debug
+  metadata;
+- user-facing schema/docs that present listing files as normal launch inputs;
+- tests whose only purpose is proving listing-derived source maps still work.
 
-- `.lst` file syntax highlighting can remain as a viewer convenience.
-- D8 format fields such as `lstLine` and `lstText` can remain because AZM may
-  include listing context in native maps.
-- Tests for D8 parsing/validation should remain.
-- ROM/source browsing commands can remain, but they should migrate from
-  `extraListings` toward native ROM `.d8.json` maps.
+## What Can Stay
 
-## What Should Be Deprecated
+Some listing-adjacent concepts are not fallback paths and can remain:
 
-### 1. `assembler: "asm80"` Alias
+- D8 fields such as `lstLine`, `lstText`, or shared listing text tables, because
+  they are data inside the native map;
+- syntax highlighting for `.lst` files as a viewer convenience, if still useful;
+- low-level Intel HEX loading code;
+- parser tests for historical files only if they are no longer connected to the
+  debug launch path.
 
-Deprecate the config alias first. Debug80 should accept it temporarily with a
-warning, then remove it from new schemas and generated projects.
+## Staged Removal
 
-Recommended migration:
+### Stage 1: Runtime Cut To Native D8 Only
 
-1. Remove `asm80` from user-facing docs and marketplace text.
-2. Keep accepting existing `asm80` configs for one transition period.
-3. Emit a Debug Console warning:
+Goal: stop the active launch path from deriving maps from listings.
 
-   `Debug80: assembler "asm80" is deprecated; use "azm" or omit the assembler field.`
+- Replace `buildMappingFromListing` behavior with native D8 loading.
+- Keep existing function names only where changing them would balloon the first
+  patch.
+- If the primary D8 map is absent or invalid, return an empty mapping and log a
+  clear build-required message.
+- For extra ROM metadata, load native D8 maps beside configured legacy entries
+  but do not parse listing content as fallback.
+- Keep source-root handling so bundled MON3 D8 maps still bind breakpoints.
+- Update tests to prove native D8 behavior and missing-map behavior.
 
-4. Remove the alias after the deprecation window.
+Expected result: Debug80 no longer fabricates source maps from `.lst` files.
 
-### 2. Listing-Derived Source Map Cache
+### Stage 2: Rename The Model
 
-The old `.debug80/cache/*.d8.json` map cache existed because Debug80 used to
-build source maps from listings. That project-local cache path has now been
-removed: active target maps resolve to the build-side `<artifactBase>.d8.json`
-path, and new scaffolded projects no longer add `.debug80/` to `.gitignore`.
+Goal: make names match reality.
 
-Completed migration steps:
+- Introduce `debugMap`, `debugMaps`, or `romDebugMaps` config fields.
+- Migrate bundled profiles to point at `.d8.json`.
+- Keep `extraListings` only as a temporary migration alias that is translated to
+  adjacent `.d8.json` paths.
+- Rename internal `listingPath` usage where it now means artifact base or map
+  sidecar location.
 
-1. Stop using `.debug80/cache` maps for active target source mapping.
-2. Remove `resolveCacheDir` and `buildListingCacheKey`.
-3. Resolve primary and extra map paths beside their build/listing artifacts.
-4. Stop writing Debug80-generated active-target maps to a project cache.
+Expected result: new code and config no longer teach the listing mental model.
 
-This should make the build directory the single visible place for generated
-debug artifacts.
+### Stage 3: Remove Listing Breakpoint And ROM Listing Workflows
 
-### 3. Listing Parser as Source-Map Producer
+Goal: source files and D8 maps become the only debugger workflow.
 
-`parseMapping`, Layer 2 matching, and `buildMappingFromListing` currently
-reconstruct source mappings from `.lst` content. That should no longer be part
-of the normal launch path.
+- Remove breakpoint binding directly against `.lst` files.
+- Change “Open ROM Listing/Source” into “Open ROM Source” backed by D8/source
+  metadata.
+- Stop materializing bundled `.lst` files into new projects.
+- Keep bundled `.lst` files only if they are documentation/reference assets.
 
-Recommended migration:
+Expected result: users debug source, not listings.
 
-1. Introduce a native-map-first launch source path with a clear failure mode:
-   if `<artifactBase>.d8.json` is missing or invalid, report "Build the selected
-   target" instead of regenerating from `.lst`.
-2. Keep listing parsing temporarily only for explicit ROM/listing compatibility.
-3. Remove Layer 2 and ASM80 include-anchor correction from the active project
-   path.
-4. Delete listing-derived mapping tests after replacement tests cover native D8
-   behavior.
+### Stage 4: Delete Legacy Modules And Tests
 
-### 4. ROM `extraListings`
+Goal: remove cruft after all runtime callers are gone.
 
-Monitor ROM source stepping currently depends on listings in places. This is the
-most sensitive area because Debug80 still needs good MON-3/TEC-1 utility
-debugging.
+- Delete listing-to-map generation code.
+- Delete active-path Layer 2 recovery code.
+- Delete stale listing cache checks.
+- Delete tests that only validate fallback behavior.
+- Remove user-facing schema/docs for `listing` and `extraListings`.
+- Remove the `asm80` assembler alias and related docs.
 
-Recommended migration:
+Expected result: Debug80 has one source-map architecture.
 
-1. Ask AZM or the ROM build process to produce `.d8.json` maps for bundled ROMs.
-2. Add `extraMaps` or equivalent platform config that points at ROM D8 maps.
-3. Keep `extraListings` as deprecated compatibility until bundled profiles have
-   D8 maps.
-4. Remove listing-derived ROM mapping only after MON-3 stepping and symbol
-   lookup work from native ROM maps.
+## First PR Scope
 
-This keeps the important monitor utility debugging while removing the old
-listing parser dependency.
+The first PR should implement Stage 1 only:
 
-## Proposed Target Architecture
+- no listing-derived source map fallback at runtime;
+- native primary D8 required for project source mapping;
+- native extra D8 maps loaded for ROM/platform sources;
+- clear logs when a D8 map is missing or invalid;
+- regression coverage for source breakpoints and bundled MON3 breakpoints.
 
-The launch path should become:
-
-1. Resolve project and target.
-2. Run AZM through the direct library backend unless `assemble: false`.
-3. Resolve build artifacts:
-   - HEX/BIN for runtime memory.
-   - D8 map for all source mapping.
-4. Load the D8 map directly.
-5. Build runtime indexes from D8:
-   - address to source
-   - file/line to address
-   - symbols/constants/data
-   - stack display labels
-6. Load optional ROM/platform D8 maps and merge them into the same lookup layer.
-7. If any required D8 map is missing, show a clear build/configuration error.
-
-This removes the need for a "source map generation" subsystem inside Debug80.
-AZM becomes responsible for source-map correctness, while Debug80 becomes a
-consumer and validator of D8 maps.
-
-## Candidate Code Simplifications
-
-Likely removable or shrinkable after migration:
-
-- remaining listing-to-D8 compatibility branches in `buildMappingFromListing`
-- listing-to-D8 generation branches in `buildMappingFromListing`
-- Layer 2 matching from the active project launch path
-- ASM80 include remap helpers from the active project launch path
-- tests that only validate listing-derived source-map generation
-- schema/docs that present `listing` as an ordinary launch input
-- schema/docs that present `asm80` as an accepted assembler choice
-
-Some of these modules may remain temporarily for ROM compatibility until ROM D8
-maps replace `extraListings`.
-
-## Risks
-
-- Existing user projects that set `assembler: "asm80"` need a migration warning.
-- Existing projects that launch with prebuilt `hex` + `listing` but no `asm`
-  will need a native `.d8.json` map or a documented unsupported path.
-- Monitor ROM stepping must not regress. Bundled ROM profiles need D8 maps before
-  `extraListings` is removed.
-- Tests currently cover listing behavior heavily. Removing it should be paired
-  with stronger native D8 tests so coverage does not simply disappear.
-
-## Recommended Phasing
-
-### Phase 1: Deprecate and Prefer Native Maps
-
-- Keep behavior compatible.
-- Warn on `assembler: "asm80"`.
-- Make all active-target features prefer build-side D8 maps.
-- Hide or remove user-facing references to listing-derived maps.
-- Add tests proving native D8 maps provide breakpoints, F12, hover, Variables,
-  and call stack data.
-
-### Phase 2: Stop Generating Project Source Maps from Listings
-
-- Require build-side D8 for active project targets.
-- Replace in-memory listing fallback with "build target" guidance.
-- Keep listing parser only for ROM compatibility.
-- Update docs and troubleshooting.
-
-### Phase 3: Replace ROM Listings with ROM D8 Maps
-
-- Add bundled ROM D8 maps.
-- Add config support for platform/ROM source maps.
-- Deprecate `extraListings`.
-- Verify MON-3 and TEC-1 ROM stepping.
-
-### Phase 4: Remove Legacy Listing Machinery
-
-- Remove any remaining listing-derived active-target map generation.
-- Remove active-path listing parser and Layer 2 matching.
-- Remove ASM80 alias.
-- Remove stale schema/docs/tests.
-
-## Immediate Next Steps
-
-The safest next code change is small:
-
-1. Add a deprecation warning for `assembler: "asm80"`.
-2. Remove `asm80` from user-facing docs and new examples.
-3. Change source-map status wording so missing build-side D8 maps ask the user
-   to build, not rely on generated caches.
-4. Add an issue/design note for ROM D8 maps before removing `extraListings`.
-
-That gives Debug80 a clear AZM-only direction without risking MON-3 or existing
-debug sessions in one large change.
+It should not attempt the large rename from `listing` to `debugMap` yet. That is
+the next PR, after behavior is already D8-only.

--- a/src/debug/mapping/mapping-service.ts
+++ b/src/debug/mapping/mapping-service.ts
@@ -4,16 +4,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { MappingParseResult, SourceMapAnchor, SourceMapSegment } from '../../mapping/parser';
 import {
-  MappingParseResult,
-  SourceMapAnchor,
-  SourceMapSegment,
-  parseMapping,
-} from '../../mapping/parser';
-import { resolveAssemblerBackend } from '../launch/assembler-backend';
-import { resolveListingSourcePath } from './path-resolver';
-import {
-  applyLayer2,
   propagateMisassignedIncludeSegments,
   remapAsm80MisassignedIncludeAnchors,
   syncSegmentLocationsFromAnchors,
@@ -31,7 +23,7 @@ import {
   parseD8DebugMap,
 } from '../../mapping/d8-map';
 import { validateD8Segments } from '../../mapping/d8-validate';
-import { D8_DEBUG_MAP_EXT, legacyDebugMapPath } from './d8-map-paths';
+import { D8_DEBUG_MAP_EXT } from './d8-map-paths';
 import { Logger } from '../../util/logger';
 
 export interface MappingServiceOptions {
@@ -63,8 +55,7 @@ function collectDebugMapCandidates(mapPath: string, listingPath: string): string
     path.dirname(listingPath),
     `${path.basename(listingPath, path.extname(listingPath))}${D8_DEBUG_MAP_EXT}`
   );
-  const legacy = legacyDebugMapPath(mapPath);
-  const ordered = [sidecar, mapPath, legacy !== null ? legacy : undefined].filter(
+  const ordered = [sidecar, mapPath].filter(
     (p): p is string => p !== undefined && p.length > 0
   );
   return [...new Set(ordered)];
@@ -84,7 +75,11 @@ function loadFirstExistingDebugMap(
 }
 
 /**
- * Builds (or loads) a mapping for a primary listing file and any extra listings.
+ * Loads native D8 maps for a primary target and any extra ROM/platform maps.
+ *
+ * The historical name remains during the D8-only migration, but this no longer
+ * derives source maps from listing content. Missing or invalid D8 maps produce an
+ * empty mapping with a build-required warning.
  */
 export function buildMappingFromListing(options: {
   listingContent: string;
@@ -97,6 +92,8 @@ export function buildMappingFromListing(options: {
 }): MappingBuildResult {
   const { listingContent, listingPath, asmPath, sourceFile, extraListingPaths, mapArgs, service } =
     options;
+  void listingContent;
+  void sourceFile;
 
   const mapPath = service.resolveDebugMapPath(mapArgs, service.baseDir, asmPath, listingPath);
   const debugMapCandidates = collectDebugMapCandidates(mapPath, listingPath);
@@ -114,65 +111,18 @@ export function buildMappingFromListing(options: {
       service.logger.warn(`Debug80: D8 quality warning [${w.file}]: ${w.message}`);
     }
   }
-
-  // Only apply listing-vs-map mtime for Debug80-generated maps. Native assembler maps
-  // must not be invalidated when the `.lst` is newer; mtimes are
-  // not a reliable ordering signal, and the listing parser is not a substitute.
-  const mapStale = !hasNativeMap && isDebugMapStale(debugMapLoadedFrom ?? mapPath, listingPath);
-
-  let debugMap = hasNativeMap ? loadedMap : mapStale ? undefined : loadedMap;
-  let missingSources: string[] = [];
-
-  if (!debugMap) {
-    const baseMapping = parseListingMapping(listingContent);
-    applySourceFallback(baseMapping, sourceFile, service.baseDir, service.resolveMappedPath);
-    const layer2 = applyLayer2(baseMapping, {
-      resolvePath: (file) => service.resolveMappedPath(file),
-      ...(sourceFile !== undefined && sourceFile.length > 0
-        ? { candidateFiles: [sourceFile] }
-        : {}),
-    });
-    missingSources = layer2.missingSources;
-    if (missingSources.length > 0) {
-      const unique = Array.from(new Set(missingSources));
-      service.logger.warn(
-        `Debug80: Missing source files for Layer 2 mapping: ${unique.join(', ')}`
-      );
-    }
-    debugMap = buildD8DebugMap(baseMapping, {
-      arch: 'z80',
-      addressWidth: 16,
-      endianness: 'little',
-      generator: { name: 'debug80' },
-    });
-  }
-
-  if (
-    debugMap !== undefined &&
-    !hasNativeMap &&
-    sourceFile !== undefined &&
-    sourceFile.length > 0 &&
-    !debugMapContainsSource(debugMap, sourceFile, service)
-  ) {
-    service.logger.info(
-      `Debug80: Debug80-generated D8 map did not include target source "${sourceFile}". Regenerating from LST.`
+  if (loadedMap !== undefined && !hasNativeMap) {
+    service.logger.warn(
+      `Debug80: Ignoring legacy Debug80-generated source map at "${debugMapLoadedFrom ?? mapPath}". Build the selected target with AZM to generate a native D8 source map.`
     );
-    const baseMapping = parseListingMapping(listingContent);
-    applySourceFallback(baseMapping, sourceFile, service.baseDir, service.resolveMappedPath);
-    const layer2 = applyLayer2(baseMapping, {
-      resolvePath: (file) => service.resolveMappedPath(file),
-      candidateFiles: [sourceFile],
-    });
-    missingSources = layer2.missingSources;
-    debugMap = buildD8DebugMap(baseMapping, {
-      arch: 'z80',
-      addressWidth: 16,
-      endianness: 'little',
-      generator: { name: 'debug80' },
-    });
+  }
+  if (loadedMap === undefined) {
+    service.logger.warn(
+      `Debug80: Source map missing at "${mapPath}". Build the selected target with AZM to generate a native D8 source map.`
+    );
   }
 
-  let mapping = buildMappingFromD8DebugMap(debugMap);
+  let mapping = hasNativeMap && loadedMap !== undefined ? buildMappingFromD8DebugMap(loadedMap) : emptyMapping();
 
   const fileSet = new Set<string | null>();
   for (const seg of mapping.segments) {
@@ -211,60 +161,7 @@ export function buildMappingFromListing(options: {
       `${index.segmentsByFileLine.size} file entries, ${index.anchorsByFile.size} anchor files`
   );
 
-  return { mapping, index, missingSources };
-}
-
-function parseListingMapping(listingContent: string): MappingParseResult {
-  return parseMapping(listingContent);
-}
-
-function isDebugMapStale(mapPath: string, listingPath: string): boolean {
-  if (!fs.existsSync(listingPath)) {
-    return false;
-  }
-  const legacyPath = legacyDebugMapPath(mapPath);
-  const mapCandidates = [mapPath, legacyPath].filter(
-    (p): p is string => p !== null && fs.existsSync(p)
-  );
-  if (mapCandidates.length === 0) {
-    return false;
-  }
-  try {
-    const listingStat = fs.statSync(listingPath);
-    let newestMapMs = 0;
-    for (const p of mapCandidates) {
-      newestMapMs = Math.max(newestMapMs, fs.statSync(p).mtimeMs);
-    }
-    return listingStat.mtimeMs > newestMapMs;
-  } catch {
-    return false;
-  }
-}
-
-function applySourceFallback(
-  mapping: MappingParseResult,
-  sourceFile: string | undefined,
-  baseDir: string,
-  resolveMappedPath: ResolvePathFn
-): void {
-  if (sourceFile === undefined || sourceFile.length === 0) {
-    return;
-  }
-  const fallback = resolveMappedPath(sourceFile) ?? path.resolve(baseDir, sourceFile);
-  if (fallback.length === 0) {
-    return;
-  }
-  for (const segment of mapping.segments) {
-    const current = segment.loc.file;
-    if (current === null) {
-      segment.loc.file = fallback;
-      continue;
-    }
-    const resolved = resolveMappedPath(current) ?? path.resolve(baseDir, current);
-    if (!fs.existsSync(resolved)) {
-      segment.loc.file = fallback;
-    }
-  }
+  return { mapping, index, missingSources: [] };
 }
 
 function loadDebugMap(
@@ -280,7 +177,7 @@ function loadDebugMap(
     if (!map) {
       const prefix = `Debug80 [${service.platform}]`;
       service.logger.warn(
-        `${prefix}: Invalid D8 debug map at "${mapPath}". Regenerating from LST. (${error})`
+        `${prefix}: Invalid D8 debug map at "${mapPath}". Build the selected target with AZM to regenerate it. (${error})`
       );
       return undefined;
     }
@@ -288,26 +185,10 @@ function loadDebugMap(
   } catch (err) {
     const prefix = `Debug80 [${service.platform}]`;
     service.logger.error(
-      `${prefix}: Failed to read D8 debug map at "${mapPath}". Regenerating from LST. (${String(err)})`
+      `${prefix}: Failed to read D8 debug map at "${mapPath}". Build the selected target with AZM to regenerate it. (${String(err)})`
     );
     return undefined;
   }
-}
-
-function debugMapContainsSource(
-  map: D8DebugMap,
-  sourceFile: string,
-  service: MappingServiceOptions
-): boolean {
-  const sourceResolved =
-    service.resolveMappedPath(sourceFile) ?? path.resolve(service.baseDir, sourceFile);
-  for (const file of Object.keys(map.files)) {
-    const resolved = service.resolveMappedPath(file) ?? path.resolve(service.baseDir, file);
-    if (path.resolve(resolved) === path.resolve(sourceResolved)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 export function isNativeDebugMap(map: D8DebugMap): boolean {
@@ -350,19 +231,6 @@ function normalizeGeneratorIdentity(value: string | undefined): string | undefin
   return normalized.length > 0 ? normalized : undefined;
 }
 
-function shouldRebuildGeneratedMap(
-  generatedMapping: MappingParseResult,
-  hasNativeMap: boolean,
-  listingPath: string
-): boolean {
-  if (hasNativeMap) {
-    return false; // native tool map wins; always use it
-  }
-  const generatedHasSource = generatedMapping.segments.some((s) => s.loc.file !== null);
-  const sourceNowExists = resolveListingSourcePath(listingPath) !== undefined;
-  return !generatedHasSource && sourceNowExists;
-}
-
 function loadExtraListingMapping(
   listingPaths: string[],
   service: MappingServiceOptions
@@ -382,38 +250,18 @@ function loadExtraListingMapping(
         );
       }
 
-      const mapStale = !hasNativeMap && isDebugMapStale(mapPath, listingPath);
-      if (mapStale) {
-        const prefix = `Debug80 [${service.platform}]`;
+      if (loadedMap !== undefined && !hasNativeMap) {
         service.logger.warn(
-          `${prefix}: D8 debug map for extra listing is older than the LST. Regenerating (${listingPath}).`
+          `Debug80: Ignoring legacy Debug80-generated ROM source map at "${mapPath}". Rebuild the ROM metadata with AZM to generate a native D8 source map.`
         );
       }
-
-      const debugMap = hasNativeMap
-        ? loadedMap
-        : !mapStale && fs.existsSync(mapPath)
-          ? loadedMap
-          : undefined;
-      if (debugMap) {
-        const generatedMapping = buildMappingFromD8DebugMap(debugMap);
-        if (!shouldRebuildGeneratedMap(generatedMapping, hasNativeMap, listingPath)) {
-          combined.segments.push(...generatedMapping.segments);
-          combined.anchors.push(...generatedMapping.anchors);
-          continue;
-        }
-        if (!hasNativeMap) {
-          const prefix = `Debug80 [${service.platform}]`;
-          service.logger.info(
-            `${prefix}: Debug80-generated D8 map for "${listingPath}" had no source info but source now found. Rebuilding.`
-          );
-        }
-      }
-
-      const mapping = buildExtraListingMapping(listingPath, service);
-      if (!mapping) {
+      if (!hasNativeMap || loadedMap === undefined) {
+        service.logger.warn(
+          `Debug80: ROM source map missing at "${mapPath}". Rebuild the ROM metadata with AZM to generate a native D8 source map.`
+        );
         continue;
       }
+      const mapping = buildMappingFromD8DebugMap(loadedMap);
       combined.segments.push(...mapping.segments);
       combined.anchors.push(...mapping.anchors);
     } catch (err) {
@@ -429,47 +277,15 @@ function loadExtraListingMapping(
   return combined;
 }
 
-function buildExtraListingMapping(
-  listingPath: string,
-  service: MappingServiceOptions
-): MappingParseResult | undefined {
-  const fallbackSource = resolveListingSourcePath(listingPath);
-  if (typeof fallbackSource === 'string' && fallbackSource.length > 0) {
-    try {
-      const backend = resolveAssemblerBackend(undefined, fallbackSource);
-      const backendMapping = backend.compileMappingInProcess?.(
-        fallbackSource,
-        path.dirname(fallbackSource)
-      );
-      if (backendMapping) {
-        return backendMapping;
-      }
-    } catch (err) {
-      const prefix = `Debug80 [${service.platform}]`;
-      service.logger.error(
-        `${prefix}: failed to build ROM mapping for "${fallbackSource}": ${String(err)}`
-      );
-    }
-  }
-  const content = fs.readFileSync(listingPath, 'utf-8');
-  const parsed = parseMapping(content);
-  if (typeof fallbackSource === 'string' && fallbackSource.length > 0) {
-    const hasFile = parsed.segments.some((segment) => segment.loc.file !== null);
-    if (!hasFile) {
-      for (const segment of parsed.segments) {
-        segment.loc.file = fallbackSource;
-        segment.loc.line = segment.lst.line;
-      }
-    }
-  }
-  return parsed;
-}
-
 function mergeMappings(base: MappingParseResult, extra: MappingParseResult): MappingParseResult {
   return {
     segments: [...base.segments, ...extra.segments],
     anchors: [...base.anchors, ...extra.anchors],
   };
+}
+
+function emptyMapping(): MappingParseResult {
+  return { segments: [], anchors: [] };
 }
 
 function applyTec1gBootstrapAlias(mapping: MappingParseResult): void {

--- a/tests/debug/mapping-service.test.ts
+++ b/tests/debug/mapping-service.test.ts
@@ -2,29 +2,15 @@
  * @file Mapping service tests.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import type { AssemblerBackend } from '../../src/debug/launch/assembler-backend';
-import * as assemblerBackendModule from '../../src/debug/launch/assembler-backend';
-import type { Logger } from '../../src/util/logger';
-
-const resolveListingSourcePathMock = vi.hoisted(() => vi.fn(() => undefined));
-
-vi.mock('../../src/debug/mapping/path-resolver', () => ({
-  resolveListingSourcePath: resolveListingSourcePathMock,
-}));
-
 import { buildMappingFromListing, isNativeDebugMap } from '../../src/debug/mapping/mapping-service';
 import { pathsEqual } from '../../src/debug/mapping/path-utils';
-import { parseMapping } from '../../src/mapping/parser';
 import { buildD8DebugMap, D8DebugMap } from '../../src/mapping/d8-map';
 import { resolveLocation } from '../../src/mapping/source-map';
-
-const fixturesDir = path.join(process.cwd(), 'tests', 'fixtures');
-const listingContent = fs.readFileSync(path.join(fixturesDir, 'simple.lst'), 'utf-8');
-const asmContent = fs.readFileSync(path.join(fixturesDir, 'simple.asm'), 'utf-8');
+import type { Logger } from '../../src/util/logger';
 
 const writeFile = (filePath: string, content: string): void => {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -42,6 +28,53 @@ const createLogger = (logs: string[]): Logger => ({
     logs.push([message, ...args].map(String).join(' ')),
 });
 
+function makeService(dir: string, mapPath: string, logs: string[] = []) {
+  return {
+    platform: 'simple',
+    baseDir: dir,
+    resolveMappedPath: (file: string) => {
+      const candidate = path.isAbsolute(file) ? file : path.resolve(dir, file);
+      return fs.existsSync(candidate) ? candidate : undefined;
+    },
+    relativeIfPossible: (filePath: string, baseDir: string) =>
+      path.relative(baseDir, filePath) || filePath,
+    resolveExtraDebugMapPath: (p: string) =>
+      path.join(path.dirname(p), `${path.basename(p, path.extname(p))}.d8.json`),
+    resolveDebugMapPath: () => mapPath,
+    logger: createLogger(logs),
+  };
+}
+
+function nativeMapFor(filePath: string, line = 3): D8DebugMap {
+  return buildD8DebugMap(
+    {
+      segments: [
+        {
+          start: 0x2000,
+          end: 0x2001,
+          loc: { file: filePath, line },
+          lst: { line: 12, text: 'NOP' },
+          confidence: 'HIGH',
+        },
+      ],
+      anchors: [
+        {
+          symbol: 'START',
+          address: 0x2000,
+          file: filePath,
+          line,
+        },
+      ],
+    },
+    {
+      arch: 'z80',
+      addressWidth: 16,
+      endianness: 'little',
+      generator: { tool: 'azm' },
+    }
+  );
+}
+
 describe('mapping-service', () => {
   it('detects native D8 maps from missing generator metadata or tool-only producers', () => {
     const baseMap: Omit<D8DebugMap, 'generator'> = {
@@ -58,191 +91,73 @@ describe('mapping-service', () => {
     expect(isNativeDebugMap({ ...baseMap, generator: { name: 'debug80' } })).toBe(false);
   });
 
-  it('generates an in-memory debug map and index from a listing', () => {
+  it('loads a native D8 map when available', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-map-'));
     const listingPath = path.join(dir, 'simple.lst');
     const asmPath = path.join(dir, 'simple.asm');
     const mapPath = path.join(dir, 'simple.d8.json');
-
-    writeFile(listingPath, listingContent);
-    writeFile(asmPath, asmContent);
-
     const logs: string[] = [];
+
+    writeFile(listingPath, 'ignored listing content\n');
+    writeFile(asmPath, 'START:\n  NOP\n');
+    writeFile(mapPath, JSON.stringify(nativeMapFor(asmPath), null, 2));
+
     const result = buildMappingFromListing({
-      listingContent,
+      listingContent: 'ignored listing content\n',
       listingPath,
       asmPath,
       sourceFile: asmPath,
       extraListingPaths: [],
       mapArgs: {},
-      service: {
-        platform: 'simple',
-        baseDir: dir,
-        resolveMappedPath: (file) => {
-          const candidate = path.resolve(dir, file);
-          return fs.existsSync(candidate) ? candidate : undefined;
-        },
-        relativeIfPossible: (filePath, baseDir) => path.relative(baseDir, filePath) || filePath,
-        resolveExtraDebugMapPath: (p) => path.join(dir, `${path.basename(p)}.extra.json`),
-        resolveDebugMapPath: () => mapPath,
-        logger: createLogger(logs),
-      },
+      service: makeService(dir, mapPath, logs),
     });
 
-    expect(result.mapping.segments.length).toBeGreaterThan(0);
-    expect(result.index.segmentsByAddress.length).toBeGreaterThan(0);
-    expect(fs.existsSync(mapPath)).toBe(false);
+    expect(result.mapping.segments).toHaveLength(1);
+    expect(result.index.segmentsByAddress).toHaveLength(1);
+    expect(resolveLocation(result.index, asmPath, 3)).toEqual([0x2000]);
+    expect(logs.some((line) => line.includes('Using native D8 map from "azm"'))).toBe(true);
   });
 
-  it('maps executable lines in the root source even when anchors only mention includes', () => {
+  it('does not derive a source map from listing content when native D8 is missing', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-map-'));
-    const listingPath = path.join(dir, 'build', 'tetro.lst');
-    const asmPath = path.join(dir, 'src', 'tetro.asm');
-    const constantsPath = path.join(dir, 'src', 'inc', 'constants.asm');
-    const modulePath = path.join(dir, 'src', 'modules', 'game_init.asm');
-    const mapPath = path.join(dir, 'build', 'tetro.d8.json');
-    const listing = [
-      '4000                          .ORG   0x4000',
-      '4000                             ; constants',
-      '4000                K_DROP:   EQU   0x00',
-      '4000                START:',
-      '4000   CD 14 45               CALL   INIT_STATE',
-      '4003                MAIN_LOOP:',
-      '4003   18 FE                  JR   MAIN_LOOP',
-      '4514                INIT_STATE:',
-      '4514   C9                     RET',
-      '',
-      'K_DROP:             0000 DEFINED AT LINE 24 IN inc/constants.asm',
-      'INIT_STATE:         4514 DEFINED AT LINE 1 IN modules/game_init.asm',
-    ].join('\n');
-
-    writeFile(listingPath, listing);
-    writeFile(
-      asmPath,
-      [
-        '        ORG     0x4000',
-        '        .include "inc/constants.asm"',
-        '',
-        'START:',
-        '        CALL    INIT_STATE',
-        '',
-        'MAIN_LOOP:',
-        '        JR      MAIN_LOOP',
-        '',
-        '        .include "modules/game_init.asm"',
-      ].join('\n')
-    );
-    writeFile(constantsPath, 'K_DROP: EQU 0x00\n');
-    writeFile(modulePath, 'INIT_STATE:\n        RET\n');
-
-    const staleMap = buildD8DebugMap(parseMapping(listing), {
-      arch: 'z80',
-      addressWidth: 16,
-      endianness: 'little',
-      generator: { name: 'debug80' },
-    });
-    writeFile(mapPath, JSON.stringify(staleMap, null, 2));
-    const future = new Date(Date.now() + 1000);
-    fs.utimesSync(mapPath, future, future);
-
+    const listingPath = path.join(dir, 'simple.lst');
+    const asmPath = path.join(dir, 'simple.asm');
+    const mapPath = path.join(dir, 'simple.d8.json');
     const logs: string[] = [];
+
+    writeFile(listingPath, '2000 00 NOP\n');
+    writeFile(asmPath, 'START:\n  NOP\n');
+
     const result = buildMappingFromListing({
-      listingContent: listing,
+      listingContent: '2000 00 NOP\n',
       listingPath,
       asmPath,
       sourceFile: asmPath,
       extraListingPaths: [],
       mapArgs: {},
-      service: {
-        platform: 'tec1g',
-        baseDir: dir,
-        resolveMappedPath: (file) => {
-          const candidate = path.isAbsolute(file) ? file : path.resolve(dir, 'src', file);
-          return fs.existsSync(candidate) ? candidate : undefined;
-        },
-        relativeIfPossible: (filePath, baseDir) => path.relative(baseDir, filePath) || filePath,
-        resolveExtraDebugMapPath: (p) => path.join(dir, `${path.basename(p)}.extra.json`),
-        resolveDebugMapPath: () => mapPath,
-        logger: createLogger(logs),
-      },
+      service: makeService(dir, mapPath, logs),
     });
 
-    expect(resolveLocation(result.index, asmPath, 5)).toContain(0x4000);
-    expect(
-      result.mapping.segments.some(
-        (seg) => seg.loc.file !== null && pathsEqual(seg.loc.file, asmPath)
-      )
-    ).toBe(true);
-    expect(logs.some((line) => line.includes('did not include target source'))).toBe(true);
+    expect(result.mapping.segments).toHaveLength(0);
+    expect(result.index.segmentsByAddress).toHaveLength(0);
+    expect(logs.some((line) => line.includes('Source map missing'))).toBe(true);
+    expect(logs.some((line) => line.includes('Build the selected target with AZM'))).toBe(true);
   });
 
-  it('loads a fresh debug map when available', () => {
+  it('ignores legacy Debug80-generated D8 maps instead of using listing fallback', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-map-'));
     const listingPath = path.join(dir, 'simple.lst');
     const asmPath = path.join(dir, 'simple.asm');
     const mapPath = path.join(dir, 'simple.d8.json');
-
-    writeFile(listingPath, listingContent);
-    writeFile(asmPath, asmContent);
-
-    const mapping = parseMapping(listingContent);
-    const map = buildD8DebugMap(mapping, {
-      arch: 'z80',
-      addressWidth: 16,
-      endianness: 'little',
-      generator: { name: 'debug80' },
-    });
-    writeFile(mapPath, JSON.stringify(map));
-
-    // Ensure map is newer than listing.
-    const now = new Date();
-    fs.utimesSync(mapPath, now, now);
-    const past = new Date(now.getTime() - 1000);
-    fs.utimesSync(listingPath, past, past);
-
     const logs: string[] = [];
-    const result = buildMappingFromListing({
-      listingContent,
-      listingPath,
-      asmPath,
-      sourceFile: asmPath,
-      extraListingPaths: [],
-      mapArgs: {},
-      service: {
-        platform: 'simple',
-        baseDir: dir,
-        resolveMappedPath: (file) => {
-          const candidate = path.resolve(dir, file);
-          return fs.existsSync(candidate) ? candidate : undefined;
-        },
-        relativeIfPossible: (filePath, baseDir) => path.relative(baseDir, filePath) || filePath,
-        resolveExtraDebugMapPath: (p) => path.join(dir, `${path.basename(p)}.extra.json`),
-        resolveDebugMapPath: () => mapPath,
-        logger: createLogger(logs),
-      },
-    });
-
-    expect(result.mapping.segments.length).toBeGreaterThan(0);
-    expect(logs.find((line) => line.includes('Regenerating'))).toBeUndefined();
-  });
-
-  it('prefers a stale native debug map without regenerating it', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-map-'));
-    const listingPath = path.join(dir, 'simple.lst');
-    const asmPath = path.join(dir, 'simple.asm');
-    const mapPath = path.join(dir, 'simple.d8.json');
-
-    writeFile(listingPath, listingContent);
-    writeFile(asmPath, asmContent);
-
-    const nativeMap = buildD8DebugMap(
+    const legacyMap = buildD8DebugMap(
       {
         segments: [
           {
             start: 0x2000,
             end: 0x2001,
-            loc: { file: asmPath, line: 42 },
-            lst: { line: 12, text: 'NOP' },
+            loc: { file: asmPath, line: 3 },
+            lst: { line: 1, text: 'NOP' },
             confidence: 'HIGH',
           },
         ],
@@ -252,10 +167,40 @@ describe('mapping-service', () => {
         arch: 'z80',
         addressWidth: 16,
         endianness: 'little',
-        generator: { tool: 'azm' },
+        generator: { name: 'debug80' },
       }
     );
-    const originalContent = JSON.stringify(nativeMap, null, 2);
+
+    writeFile(listingPath, '2000 00 NOP\n');
+    writeFile(asmPath, 'START:\n  NOP\n');
+    writeFile(mapPath, JSON.stringify(legacyMap, null, 2));
+
+    const result = buildMappingFromListing({
+      listingContent: '2000 00 NOP\n',
+      listingPath,
+      asmPath,
+      sourceFile: asmPath,
+      extraListingPaths: [],
+      mapArgs: {},
+      service: makeService(dir, mapPath, logs),
+    });
+
+    expect(result.mapping.segments).toHaveLength(0);
+    expect(logs.some((line) => line.includes('Ignoring legacy Debug80-generated source map'))).toBe(
+      true
+    );
+  });
+
+  it('prefers a stale native debug map without regenerating it', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-map-'));
+    const listingPath = path.join(dir, 'simple.lst');
+    const asmPath = path.join(dir, 'simple.asm');
+    const mapPath = path.join(dir, 'simple.d8.json');
+    const logs: string[] = [];
+    const originalContent = JSON.stringify(nativeMapFor(asmPath, 42), null, 2);
+
+    writeFile(listingPath, '2000 00 NOP\n');
+    writeFile(asmPath, 'START:\n  NOP\n');
     writeFile(mapPath, originalContent);
 
     const past = new Date(Date.now() - 2000);
@@ -263,31 +208,18 @@ describe('mapping-service', () => {
     const now = new Date();
     fs.utimesSync(listingPath, now, now);
 
-    const logs: string[] = [];
     const result = buildMappingFromListing({
-      listingContent,
+      listingContent: '2000 00 NOP\n',
       listingPath,
       asmPath,
       sourceFile: asmPath,
       extraListingPaths: [],
       mapArgs: {},
-      service: {
-        platform: 'simple',
-        baseDir: dir,
-        resolveMappedPath: (file) => {
-          const candidate = path.resolve(dir, file);
-          return fs.existsSync(candidate) ? candidate : undefined;
-        },
-        relativeIfPossible: (filePath, baseDir) => path.relative(baseDir, filePath) || filePath,
-        resolveExtraDebugMapPath: (p) => path.join(dir, `${path.basename(p)}.extra.json`),
-        resolveDebugMapPath: () => mapPath,
-        logger: createLogger(logs),
-      },
+      service: makeService(dir, mapPath, logs),
     });
 
     expect(result.mapping.segments).toHaveLength(1);
     expect(result.mapping.segments[0]?.loc.line).toBe(42);
-    expect(logs.some((line) => line.includes('Using native D8 map from "azm"'))).toBe(true);
     expect(logs.some((line) => line.includes('Regenerating'))).toBe(false);
     expect(fs.readFileSync(mapPath, 'utf-8')).toBe(originalContent);
   });
@@ -297,10 +229,6 @@ describe('mapping-service', () => {
     const listingPath = path.join(dir, 'simple.lst');
     const asmPath = path.join(dir, 'simple.asm');
     const mapPath = path.join(dir, 'simple.d8.json');
-
-    writeFile(listingPath, listingContent);
-    writeFile(asmPath, asmContent);
-
     const nativeMap = {
       format: 'd8-debug-map',
       version: 1,
@@ -314,282 +242,59 @@ describe('mapping-service', () => {
         },
       },
     };
+
+    writeFile(listingPath, 'ignored listing content\n');
+    writeFile(asmPath, 'START:\n  NOP\n');
     writeFile(mapPath, JSON.stringify(nativeMap, null, 2));
 
     const result = buildMappingFromListing({
-      listingContent,
+      listingContent: 'ignored listing content\n',
       listingPath,
       asmPath,
       sourceFile: asmPath,
       extraListingPaths: [],
       mapArgs: {},
-      service: {
-        platform: 'simple',
-        baseDir: dir,
-        resolveMappedPath: (file) => {
-          const candidate = path.resolve(dir, file);
-          return fs.existsSync(candidate) ? candidate : undefined;
-        },
-        relativeIfPossible: (filePath, baseDir) => path.relative(baseDir, filePath) || filePath,
-        resolveExtraDebugMapPath: (p) => path.join(dir, `${path.basename(p)}.extra.json`),
-        resolveDebugMapPath: () => mapPath,
-        logger: createLogger([]),
-      },
+      service: makeService(dir, mapPath),
     });
 
     expect(result.mapping.segments[0]?.loc.line).toBe(42);
     expect(result.mapping.segments[0]?.lst.line).toBe(42);
   });
 
-  it('regenerates when the debug map is stale and merges extra listings', () => {
+  it('loads extra ROM mappings only from native D8 maps', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-map-'));
     const listingPath = path.join(dir, 'simple.lst');
     const asmPath = path.join(dir, 'simple.asm');
     const mapPath = path.join(dir, 'simple.d8.json');
-    const extraListingPath = path.join(dir, 'extra.lst');
-
-    writeFile(listingPath, listingContent);
-    writeFile(asmPath, asmContent);
-    writeFile(extraListingPath, listingContent.replace('0000', '0100'));
-
-    writeFile(mapPath, JSON.stringify({}));
-    const past = new Date(Date.now() - 2000);
-    fs.utimesSync(mapPath, past, past);
-    const now = new Date();
-    fs.utimesSync(listingPath, now, now);
-
+    const extraListingPath = path.join(dir, 'rom', 'mon3.lst');
+    const extraSourcePath = path.join(dir, 'rom', 'mon3.z80');
+    const extraMapPath = path.join(dir, 'rom', 'mon3.d8.json');
     const logs: string[] = [];
+
+    writeFile(listingPath, 'ignored listing content\n');
+    writeFile(asmPath, 'START:\n  NOP\n');
+    writeFile(mapPath, JSON.stringify(nativeMapFor(asmPath), null, 2));
+    writeFile(extraListingPath, 'C100 00 NOP\n');
+    writeFile(extraSourcePath, 'BOOT:\n  NOP\n');
+    writeFile(extraMapPath, JSON.stringify(nativeMapFor(extraSourcePath, 1), null, 2));
+
     const result = buildMappingFromListing({
-      listingContent,
+      listingContent: 'ignored listing content\n',
       listingPath,
       asmPath,
       sourceFile: asmPath,
       extraListingPaths: [extraListingPath],
       mapArgs: {},
-      service: {
-        platform: 'simple',
-        baseDir: dir,
-        resolveMappedPath: (file) => {
-          const candidate = path.resolve(dir, file);
-          return fs.existsSync(candidate) ? candidate : undefined;
-        },
-        relativeIfPossible: (filePath, baseDir) => path.relative(baseDir, filePath) || filePath,
-        resolveExtraDebugMapPath: (p) => path.join(dir, `${path.basename(p)}.extra.json`),
-        resolveDebugMapPath: () => mapPath,
-        logger: createLogger(logs),
-      },
-    });
-
-    expect(result.mapping.segments.length).toBeGreaterThan(0);
-    expect(logs.some((line) => line.includes('Regenerating'))).toBe(true);
-  });
-
-  it('uses a source-resolved backend for extra listings when available', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-map-'));
-    const listingPath = path.join(dir, 'simple.lst');
-    const asmPath = path.join(dir, 'simple.asm');
-    const extraListingPath = path.join(dir, 'extra.lst');
-    const extraSourcePath = path.join(dir, 'extra.asm');
-    const mapPath = path.join(dir, 'simple.d8.json');
-
-    writeFile(listingPath, listingContent);
-    writeFile(asmPath, asmContent);
-    writeFile(extraListingPath, listingContent.replace('0000', '0100'));
-    writeFile(extraSourcePath, asmContent);
-    resolveListingSourcePathMock.mockReturnValue(extraSourcePath);
-
-    const compileMappingInProcess = vi.fn(() => ({
-      segments: [
-        {
-          start: 0x100,
-          end: 0x101,
-          loc: { file: extraSourcePath, line: 1 },
-          lst: { line: 1, text: 'NOP' },
-          confidence: 'HIGH' as const,
-        },
-      ],
-      anchors: [],
-    }));
-    const backend: AssemblerBackend = {
-      id: 'mock-asm',
-      assemble: () => Promise.resolve({ success: true }),
-      compileMappingInProcess,
-    };
-    const resolveAssemblerBackend = vi
-      .spyOn(assemblerBackendModule, 'resolveAssemblerBackend')
-      .mockReturnValue(backend);
-
-    const result = buildMappingFromListing({
-      listingContent,
-      listingPath,
-      asmPath,
-      sourceFile: asmPath,
-      extraListingPaths: [extraListingPath],
-      mapArgs: {},
-      service: {
-        platform: 'simple',
-        baseDir: dir,
-        resolveMappedPath: (file) => {
-          const candidate = path.resolve(dir, file);
-          return fs.existsSync(candidate) ? candidate : undefined;
-        },
-        relativeIfPossible: (filePath, baseDir) => path.relative(baseDir, filePath) || filePath,
-        resolveExtraDebugMapPath: (p) => path.join(dir, `${path.basename(p)}.extra.json`),
-        resolveDebugMapPath: () => mapPath,
-        logger: createLogger([]),
-      },
-    });
-
-    expect(resolveAssemblerBackend).toHaveBeenCalledWith(undefined, extraSourcePath);
-    expect(compileMappingInProcess).toHaveBeenCalledWith(
-      extraSourcePath,
-      path.dirname(extraSourcePath)
-    );
-    expect(result.mapping.segments.some((segment) => segment.loc.file === extraSourcePath)).toBe(
-      true
-    );
-    resolveAssemblerBackend.mockRestore();
-  });
-
-  it('falls back to listing parsing when the source-resolved backend lacks in-process mapping', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-map-'));
-    const listingPath = path.join(dir, 'simple.lst');
-    const asmPath = path.join(dir, 'simple.asm');
-    const extraListingPath = path.join(dir, 'extra.lst');
-    const extraSourcePath = path.join(dir, 'extra.asm');
-    const mapPath = path.join(dir, 'simple.d8.json');
-    const extraListingContent = '0100 00 NOP\n';
-
-    writeFile(listingPath, listingContent);
-    writeFile(asmPath, asmContent);
-    writeFile(extraListingPath, extraListingContent);
-    writeFile(extraSourcePath, asmContent);
-    resolveListingSourcePathMock.mockReturnValue(extraSourcePath);
-    const backend: AssemblerBackend = {
-      id: 'mock-asm',
-      assemble: () => Promise.resolve({ success: true }),
-    };
-    const resolveAssemblerBackend = vi
-      .spyOn(assemblerBackendModule, 'resolveAssemblerBackend')
-      .mockReturnValue(backend);
-
-    const result = buildMappingFromListing({
-      listingContent,
-      listingPath,
-      asmPath,
-      sourceFile: asmPath,
-      extraListingPaths: [extraListingPath],
-      mapArgs: {},
-      service: {
-        platform: 'simple',
-        baseDir: dir,
-        resolveMappedPath: (file) => {
-          const candidate = path.resolve(dir, file);
-          return fs.existsSync(candidate) ? candidate : undefined;
-        },
-        relativeIfPossible: (filePath, baseDir) => path.relative(baseDir, filePath) || filePath,
-        resolveExtraDebugMapPath: (p) => path.join(dir, `${path.basename(p)}.extra.json`),
-        resolveDebugMapPath: () => mapPath,
-        logger: createLogger([]),
-      },
+      service: makeService(dir, mapPath, logs),
     });
 
     expect(
       result.mapping.segments.some(
         (segment) =>
-          segment.start === 0x100 &&
-          segment.end === 0x101 &&
           segment.loc.file !== null &&
           pathsEqual(segment.loc.file, extraSourcePath) &&
           segment.loc.line === 1
       )
     ).toBe(true);
-    expect(resolveAssemblerBackend).toHaveBeenCalledWith(undefined, extraSourcePath);
-    resolveAssemblerBackend.mockRestore();
-  });
-
-  it('prefers a stale native debug map for extra listings without invoking backend regeneration', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-map-'));
-    const listingPath = path.join(dir, 'simple.lst');
-    const asmPath = path.join(dir, 'simple.asm');
-    const mapPath = path.join(dir, 'simple.d8.json');
-    const extraListingPath = path.join(dir, 'extra.lst');
-    const extraSourcePath = path.join(dir, 'extra.asm');
-    const extraMapPath = path.join(dir, 'extra.lst.extra.json');
-
-    writeFile(listingPath, listingContent);
-    writeFile(asmPath, asmContent);
-    writeFile(extraListingPath, '0100 00 NOP\n');
-    writeFile(extraSourcePath, asmContent);
-
-    const extraNativeMap = buildD8DebugMap(
-      {
-        segments: [
-          {
-            start: 0x100,
-            end: 0x101,
-            loc: { file: extraSourcePath, line: 7 },
-            lst: { line: 1, text: 'NOP' },
-            confidence: 'HIGH',
-          },
-        ],
-        anchors: [],
-      },
-      {
-        arch: 'z80',
-        addressWidth: 16,
-        endianness: 'little',
-        generator: { tool: 'azm' },
-      }
-    );
-    const originalExtraMap = JSON.stringify(extraNativeMap, null, 2);
-    writeFile(extraMapPath, originalExtraMap);
-
-    const past = new Date(Date.now() - 2000);
-    fs.utimesSync(extraMapPath, past, past);
-    const now = new Date();
-    fs.utimesSync(extraListingPath, now, now);
-
-    resolveListingSourcePathMock.mockReturnValue(extraSourcePath);
-    const resolveAssemblerBackend = vi.spyOn(assemblerBackendModule, 'resolveAssemblerBackend');
-    const logs: string[] = [];
-
-    const result = buildMappingFromListing({
-      listingContent,
-      listingPath,
-      asmPath,
-      sourceFile: asmPath,
-      extraListingPaths: [extraListingPath],
-      mapArgs: {},
-      service: {
-        platform: 'simple',
-        baseDir: dir,
-        resolveMappedPath: (file) => {
-          const candidate = path.resolve(dir, file);
-          return fs.existsSync(candidate) ? candidate : undefined;
-        },
-        relativeIfPossible: (filePath, baseDir) => path.relative(baseDir, filePath) || filePath,
-        resolveExtraDebugMapPath: () => extraMapPath,
-        resolveDebugMapPath: () => mapPath,
-        logger: createLogger(logs),
-      },
-    });
-
-    expect(
-      result.mapping.segments.some(
-        (segment) =>
-          segment.start === 0x100 &&
-          segment.end === 0x101 &&
-          segment.loc.file !== null &&
-          pathsEqual(segment.loc.file, extraSourcePath) &&
-          segment.loc.line === 7
-      )
-    ).toBe(true);
-    expect(logs.some((line) => line.includes('Using native D8 map from "azm"'))).toBe(true);
-    expect(resolveAssemblerBackend).not.toHaveBeenCalled();
-    expect(fs.readFileSync(extraMapPath, 'utf-8')).toBe(originalExtraMap);
-
-    resolveAssemblerBackend.mockRestore();
-    resolveListingSourcePathMock.mockReturnValue(undefined);
   });
 });

--- a/tests/debug/source-manager.test.ts
+++ b/tests/debug/source-manager.test.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import type { Logger } from '../../src/util/logger';
+import { buildD8DebugMap } from '../../src/mapping/d8-map';
 
 vi.mock('../../src/debug/mapping/path-resolver', () => ({
   resolveListingSourcePath: () => undefined,
@@ -39,8 +40,54 @@ describe('source-manager', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug80-source-'));
     const listingPath = path.join(dir, 'simple.lst');
     const extraListingPath = path.join(dir, 'extra.lst');
+    const sourcePath = path.join(dir, 'simple.asm');
+    const extraSourcePath = path.join(dir, 'extra.asm');
+    const mapPath = path.join(dir, `${path.basename(listingPath)}.d8.json`);
+    const extraMapPath = path.join(dir, `${path.basename(extraListingPath)}.extra.json`);
     writeFile(listingPath, listingContent);
     writeFile(extraListingPath, listingContent.replace('0000', '0200'));
+    writeFile(sourcePath, 'START:\n  NOP\n');
+    writeFile(extraSourcePath, 'ROM_START:\n  NOP\n');
+    writeFile(
+      mapPath,
+      JSON.stringify(
+        buildD8DebugMap(
+          {
+            segments: [
+              {
+                start: 0x1000,
+                end: 0x1001,
+                loc: { file: sourcePath, line: 2 },
+                lst: { line: 1, text: 'NOP' },
+                confidence: 'HIGH',
+              },
+            ],
+            anchors: [],
+          },
+          { arch: 'z80', addressWidth: 16, endianness: 'little', generator: { tool: 'azm' } }
+        )
+      )
+    );
+    writeFile(
+      extraMapPath,
+      JSON.stringify(
+        buildD8DebugMap(
+          {
+            segments: [
+              {
+                start: 0x2000,
+                end: 0x2001,
+                loc: { file: extraSourcePath, line: 2 },
+                lst: { line: 1, text: 'NOP' },
+                confidence: 'HIGH',
+              },
+            ],
+            anchors: [],
+          },
+          { arch: 'z80', addressWidth: 16, endianness: 'little', generator: { tool: 'azm' } }
+        )
+      )
+    );
 
     const logs: string[] = [];
     const manager = new SourceManager({


### PR DESCRIPTION
## Summary
- rewrite the AZM-only source map plan as a hard removal plan
- stop runtime mapping from deriving source maps from .lst listing content
- require native D8 maps for primary and extra ROM/platform mappings, with clear build-required warnings when missing or legacy
- replace fallback-oriented tests with D8-only mapping tests

## Verification
- npm run package:check
